### PR TITLE
Provide a convenient way to opt-in for TCP health probing

### DIFF
--- a/src/Arcus.Messaging.Health/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Health/Extensions/IServiceCollectionExtensions.cs
@@ -23,13 +23,10 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             Guard.NotNull(services, nameof(services));
 
-            services.AddHostedService<TcpHealthListener>();
+            var healthCheckBuilder = services.AddHealthChecks();
+            configureHealthChecks?.Invoke(healthCheckBuilder);
 
-            if (configureHealthChecks != null)
-            {
-                var healthCheckBuilder = services.AddHealthChecks();
-                configureHealthChecks(healthCheckBuilder);
-            }
+            services.AddHostedService<TcpHealthListener>();
 
             return services;
         }

--- a/src/Arcus.Messaging.Health/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Health/Extensions/IServiceCollectionExtensions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Arcus.Messaging.Health.Tcp;
+using GuardNet;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.DependencyInjection
+{
+    // ReSharper disable once InconsistentNaming
+    public static class IServiceCollectionExtensions
+    {
+        /// <summary>
+        ///     Adds TCP health probing
+        /// </summary>
+        /// <remarks>
+        ///     In order for the TCP health probes to work, ASP.NET Core Health Checks must be configured. You can configure
+        ///     it here or do it yourself as well.
+        /// </remarks>
+        /// <param name="services">Collection of services to use in the application</param>
+        /// <param name="configureHealthChecks">Capability to configure the required health checks to expose, if required</param>
+        /// <returns>Collection of services to use in the application</returns>
+        public static IServiceCollection AddTcpHealthProbes(this IServiceCollection services,
+            Action<IHealthChecksBuilder> configureHealthChecks = null)
+        {
+            Guard.NotNull(services, nameof(services));
+
+            services.AddHostedService<TcpHealthListener>();
+
+            if (configureHealthChecks != null)
+            {
+                var healthCheckBuilder = services.AddHealthChecks();
+                configureHealthChecks(healthCheckBuilder);
+            }
+
+            return services;
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tcp.Orchestrator.dcproj
+++ b/src/Arcus.Messaging.Tcp.Orchestrator.dcproj
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup />
-</Project>

--- a/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthListenerTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthListenerTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -34,7 +35,7 @@ namespace Arcus.Messaging.Tests.Integration.Health
                 using (var reader = new StreamReader(clientStream))
                 {
                     // Act
-                    string healthReport = await reader.ReadLineAsync();
+                    string healthReport = await reader.ReadToEndAsync();
 
                     // Assert
                     var report = JsonConvert.DeserializeObject<HealthReport>(healthReport);

--- a/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthListenerTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthListenerTests.cs
@@ -11,20 +11,20 @@ using Xunit.Abstractions;
 namespace Arcus.Messaging.Tests.Integration.Health
 {
     [Trait("Category", "Integration")]
-    public class TcpHealthCheckTests : IntegrationTest
+    public class TcpHealthListenerTests : IntegrationTest
     {
         private readonly int _healthTcpPort;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="TcpHealthCheckTests"/> class.
+        /// Initializes a new instance of the <see cref="TcpHealthListenerTests"/> class.
         /// </summary>
-        public TcpHealthCheckTests(ITestOutputHelper testOutput) : base(testOutput)
+        public TcpHealthListenerTests(ITestOutputHelper testOutput) : base(testOutput)
         {
             _healthTcpPort = Configuration.GetValue<int>("Arcus:Health:Port");
         }
 
         [Fact]
-        public async Task TcpHealthServer_ProbeForHealthReport_ResponseHealthy()
+        public async Task TcpHealthListener_ProbeForHealthReport_ResponseHealthy()
         {
             // Arrange
             using (var client = new TcpClient())

--- a/src/Arcus.Messaging.Tests.Worker/Program.cs
+++ b/src/Arcus.Messaging.Tests.Worker/Program.cs
@@ -23,10 +23,8 @@ namespace Arcus.Messaging.Tests.Worker
                 })
                 .ConfigureServices((hostContext, services) =>
                 {
-                    services.AddTcpHealthProbes(healthCheckBuilder =>
-                    {
-                        healthCheckBuilder.AddCheck("sample", () => HealthCheckResult.Healthy());
-                    });
+                    services.AddTcpHealthProbes();
+                    services.AddHealthChecks();
                 });
     }
 }

--- a/src/Arcus.Messaging.Tests.Worker/Program.cs
+++ b/src/Arcus.Messaging.Tests.Worker/Program.cs
@@ -1,6 +1,6 @@
-using Arcus.Messaging.Health.Tcp;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 
 namespace Arcus.Messaging.Tests.Worker
@@ -23,8 +23,10 @@ namespace Arcus.Messaging.Tests.Worker
                 })
                 .ConfigureServices((hostContext, services) =>
                 {
-                    services.AddHostedService<TcpHealthListener>();
-                    services.AddHealthChecks();
+                    services.AddTcpHealthProbes(healthCheckBuilder =>
+                    {
+                        healthCheckBuilder.AddCheck("sample", () => HealthCheckResult.Healthy());
+                    });
                 });
     }
 }

--- a/src/Arcus.Messaging.Tests.Worker/Program.cs
+++ b/src/Arcus.Messaging.Tests.Worker/Program.cs
@@ -24,7 +24,6 @@ namespace Arcus.Messaging.Tests.Worker
                 .ConfigureServices((hostContext, services) =>
                 {
                     services.AddTcpHealthProbes();
-                    services.AddHealthChecks();
                 });
     }
 }


### PR DESCRIPTION
Provide a convenient way to opt-in for TCP health probing.

- Introduce `AddTcpHealthProbes` to opt-in and allow you to register health checks, if you want

```csharp
.ConfigureServices((hostContext, services) =>
{
    services.AddTcpHealthProbes(healthCheckBuilder =>
    {
        healthCheckBuilder.AddCheck("sample", () => HealthCheckResult.Healthy());
    });
});
```

```csharp
.ConfigureServices((hostContext, services) =>
{
    services.AddTcpHealthProbes();
    services.AddHealthChecks()
        .AddCheck("sample", () => HealthCheckResult.Healthy());
});
```

Relates to #11