### PR TITLE
DOC: add feature docs for TCP health probe

### DIFF
--- a/docs/features/tcp-health-probe.md
+++ b/docs/features/tcp-health-probe.md
@@ -5,7 +5,7 @@ layout: default
 
 # TCP Health probe
 
-We provide a TCP health probe endpoint that allows a runtime to periodically check the liveness/readiness of the host based on the .NET Core health approach.
+We provide a TCP health probe endpoint that allows a runtime to periodically check the liveness/readiness of the host based on the [.NET Core health checks](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks).
 
 ## Installation
 

--- a/docs/features/tcp-health-probe.md
+++ b/docs/features/tcp-health-probe.md
@@ -5,7 +5,7 @@ layout: default
 
 # TCP Health probe
 
-A `BackgroundService` can be added to the <span>ASP.NET</span> hosted services to expose a TCP health endpoint that allows a runtime to periodically check the liveness/readiness of the host.
+We provide a TCP health probe endpoint that allows a runtime to periodically check the liveness/readiness of the host based on the .NET Core health approach.
 
 ## Installation
 
@@ -22,6 +22,10 @@ To include the TCP endpoint, add the following line of code in the `Startup.Conf
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
+    // Add TCP health probe without extra health checks.
+    services.AddTcpHealthProbes();
+
+    // Or, add your extra health checks in a configuration delegate.
     services.AddTcpHealthProbes(healthBuilder => 
     {
         healthBuilder.AddCheck("Example", () => HealthCheckResult.Healthy("Example is OK!"), tags: new[] { "example" })

--- a/docs/features/tcp-health-probe.md
+++ b/docs/features/tcp-health-probe.md
@@ -1,0 +1,40 @@
+---
+title: "TCP Health probe"
+layout: default
+---
+
+# TCP Health probe
+
+A `BackgroundService` can be added to the <span>ASP.NET</span> hosted services to expose a TCP health endpoint that allows a runtime to periodically check the liveness/readiness of the host.
+
+## Installation
+
+This features requires to install our NuGet package:
+
+```shell
+PM > Install-Package Arcus.Messaging.Health
+```
+
+## Usage
+
+To include the TCP endpoint, add the following line of code in the `Startup.ConfigureServices` method:
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddTcpHealthProbes(healthBuilder => 
+    {
+        healthBuilder.AddCheck("Example", () => HealthCheckResult.Healthy("Example is OK!"), tags: new[] { "example" })
+    });
+}
+```
+
+## Configuration
+
+To make the TCP health check fully functional, you'll  require some configuration values. 
+
+| Configuration key   | Usage        | Type  | Description                                                         |
+| ------------------- | ------------ | ----- | ------------------------------------------------------------------- |
+| `ARCUS_HEALTH_PORT` | **required** | `int` | The TCP port on which the health report is exposed.                 |
+
+[&larr; back](/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ Coming soon!
 
 # Features
 
-Coming soon!
+- [TCP health probe](features/tcp-health-probe) allow the runtime to periodically check liveness/readiness of the host.
 
 # License
 This is licensed under The MIT License (MIT). Which means that you can use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the web application. But you always need to state that Codit is the original author of this web application.


### PR DESCRIPTION
Adds feature docs for the TCP health probe.

Relates to #11

Ps.: the folder structure will probably change when more features are added; so I added this feature docs at the root of the `./features` folder.