### PR TITLE
FIX: health report deserialization with individual check

### DIFF
--- a/src/Arcus.Messaging.Tests.Integration/Health/HealthReportEntryConverter.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Health/HealthReportEntryConverter.cs
@@ -9,6 +9,8 @@ namespace Arcus.Messaging.Tests.Integration.Health
 {
     /// <summary>
     /// JSON converter to deserialize <see cref="HealthReportEntry"/> <c>struct</c>.
+    /// The <see cref="HealthReportEntry"/> <c>struct</c>s is not correctly deserialized since it was not especially made to be deserialized;
+    /// also <c>struct</c>s are naturally not made for deserialization using Newtonsoft.Json.
     /// </summary>
     public class HealthReportEntryConverter : JsonConverter
     {

--- a/src/Arcus.Messaging.Tests.Integration/Health/HealthReportEntryConverter.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Health/HealthReportEntryConverter.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Arcus.Messaging.Tests.Integration.Health
+{
+    /// <summary>
+    /// JSON converter to deserialize <see cref="HealthReportEntry"/> <c>struct</c>.
+    /// </summary>
+    public class HealthReportEntryConverter : JsonConverter
+    {
+        /// <summary>Writes the JSON representation of the object.</summary>
+        /// <param name="writer">The <see cref="T:Newtonsoft.Json.JsonWriter" /> to write to.</param>
+        /// <param name="value">The value.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>Reads the JSON representation of the object.</summary>
+        /// <param name="reader">The <see cref="T:Newtonsoft.Json.JsonReader" /> to read from.</param>
+        /// <param name="objectType">Type of the object.</param>
+        /// <param name="existingValue">The existing value of object being read.</param>
+        /// <param name="serializer">The calling serializer.</param>
+        /// <returns>The object value.</returns>
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            JToken token = JToken.Load(reader);
+
+            var healthStatus = token["Status"].ToObject<HealthStatus>();
+            var description = token["Description"]?.ToObject<string>();
+            var duration = token["Duration"].ToObject<TimeSpan>();
+            var exception = token["Exception"]?.ToObject<Exception>();
+            var data = token["Data"]?.ToObject<Dictionary<string, object>>();
+            var readOnlyDictionary = new ReadOnlyDictionary<string, object>(data ?? new Dictionary<string, object>());
+            var tags = token["Tags"]?.ToObject<string[]>();
+            
+            return new HealthReportEntry(healthStatus, description, duration, exception, readOnlyDictionary, tags);
+        }
+
+        /// <summary>
+        /// Determines whether this instance can convert the specified object type.
+        /// </summary>
+        /// <param name="objectType">Type of the object.</param>
+        /// <returns>
+        /// 	<c>true</c> if this instance can convert the specified object type; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(HealthReportEntry) == objectType;
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/Health/HealthReportEntryConverterTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Health/HealthReportEntryConverterTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Arcus.Messaging.Tests.Integration.Health
+{
+    public class HealthReportEntryConverterTests
+    {
+        [Fact]
+        public void Deserialize_HealthReportWithoutException_Succeeds()
+        {
+            // Arrange
+            string json = 
+                @"{""Entries"":
+                    {""sample"":
+                        {""Data"":{""key"":""value""},
+                         ""Description"":""desc"",
+                         ""Duration"":""00:00:05"",
+                         ""Status"":2,
+                         ""Tags"":[""tag1""]}},""Status"":2,""TotalDuration"":""00:00:05""}";
+            
+
+            // Act
+            var report = JsonConvert.DeserializeObject<HealthReport>(json, new HealthReportEntryConverter());
+            
+            // Assert
+            Assert.NotNull(report);
+            Assert.Equal(HealthStatus.Healthy, report.Status);
+            
+            (string entryName, HealthReportEntry entry) = Assert.Single(report.Entries);
+            Assert.Equal("sample", entryName);
+            Assert.Equal(HealthStatus.Healthy, entry.Status);
+            Assert.Equal("desc", entry.Description);
+            
+            (string key, object data) = Assert.Single(entry.Data);
+            Assert.Equal("key", key);
+            Assert.Equal("value", data);
+            Assert.Equal(TimeSpan.FromSeconds(5), entry.Duration);
+            
+            string tag = Assert.Single(entry.Tags);
+            Assert.Equal("tag1", tag);
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthListenerTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthListenerTests.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -38,9 +37,12 @@ namespace Arcus.Messaging.Tests.Integration.Health
                     string healthReport = await reader.ReadToEndAsync();
 
                     // Assert
-                    var report = JsonConvert.DeserializeObject<HealthReport>(healthReport);
+                    var report = JsonConvert.DeserializeObject<HealthReport>(healthReport, new HealthReportEntryConverter());
                     Assert.NotNull(report);
                     Assert.Equal(HealthStatus.Healthy, report.Status);
+                    (string entryName, HealthReportEntry entry) = Assert.Single(report.Entries);
+                    Assert.Equal("sample", entryName);
+                    Assert.Equal(HealthStatus.Healthy, entry.Status);
                 }
             }
         }

--- a/src/Arcus.Messaging.Tests.Worker/Program.cs
+++ b/src/Arcus.Messaging.Tests.Worker/Program.cs
@@ -23,7 +23,7 @@ namespace Arcus.Messaging.Tests.Worker
                 })
                 .ConfigureServices((hostContext, services) =>
                 {
-                    services.AddTcpHealthProbes();
+                    services.AddTcpHealthProbes(builder => builder.AddCheck("sample", () => HealthCheckResult.Healthy()));
                 });
     }
 }


### PR DESCRIPTION
Fixes how we deserializat the `HealthReport`.
The problem exists in that the report is made for serialization but not _deserialization_. The entries are `struct`'s and don't get deserialized correctly.

This could be fixed with a dedicated `JsonConverter` that get passed with the deserialization call.

Relates to #21 