### PR TITLE
FEAT: make HealthReport serialization & TCP health port configurable

### DIFF
--- a/docs/features/tcp-health-probe.md
+++ b/docs/features/tcp-health-probe.md
@@ -23,13 +23,15 @@ To include the TCP endpoint, add the following line of code in the `Startup.Conf
 public void ConfigureServices(IServiceCollection services)
 {
     // Add TCP health probe without extra health checks.
-    services.AddTcpHealthProbes();
+    services.AddTcpHealthProbes("MyConfigurationKeyToTcpHealthPort");
 
     // Or, add your extra health checks in a configuration delegate.
-    services.AddTcpHealthProbes(healthBuilder => 
-    {
-        healthBuilder.AddCheck("Example", () => HealthCheckResult.Healthy("Example is OK!"), tags: new[] { "example" })
-    });
+    services.AddTcpHealthProbes(
+        "MyConfigurationkeyToTcpHealthPort",
+        configureHealthChecks: healthBuilder => 
+        {
+            healthBuilder.AddCheck("Example", () => HealthCheckResult.Healthy("Example is OK!"), tags: new[] { "example" })
+        });
 }
 ```
 
@@ -42,6 +44,7 @@ public void ConfigureServices(IServiceCollection services)
 {
     // Add TCP health probe with or whitout extra health checks.
     services.AddTcpHealthProbes(
+        "MyConfigurationKeyToTcpHealthPort",
         configureTcpListenerOptions: options =>
         {
             // Configure the configuration key on which the health report is exposed.

--- a/docs/features/tcp-health-probe.md
+++ b/docs/features/tcp-health-probe.md
@@ -35,10 +35,30 @@ public void ConfigureServices(IServiceCollection services)
 
 ## Configuration
 
-To make the TCP health check fully functional, you'll  require some configuration values. 
+The TCP probe allows several additional configuration options.
 
-| Configuration key   | Usage        | Type  | Description                                                         |
-| ------------------- | ------------ | ----- | ------------------------------------------------------------------- |
-| `ARCUS_HEALTH_PORT` | **required** | `int` | The TCP port on which the health report is exposed.                 |
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    // Add TCP health probe with or whitout extra health checks.
+    services.AddTcpHealthProbes(
+        configureTcpListenerOptions: options =>
+        {
+            // Configure the configuration key on which the health report is exposed.
+            options.TcpPortConfigurationKey = "MyConfigurationKey";
+
+            // Configure how the health report should be serialized.
+            options.HealthReportSerializer = new MyHealthReportSerializer();
+        });
+}
+
+public class MyHealthReportSerializer : IHealthReportSerializer
+{
+    public byte[] Serialize(HealthReport healthReport)
+    {
+        return Array.Empty<byte>();
+	}
+}
+```
 
 [&larr; back](/)

--- a/src/Arcus.Messaging.Health/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Health/Extensions/IServiceCollectionExtensions.cs
@@ -17,14 +17,22 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </remarks>
         /// <param name="services">Collection of services to use in the application</param>
         /// <param name="configureHealthChecks">Capability to configure the required health checks to expose, if required</param>
+        /// <param name="configureTcpListenerOptions">Capability to configure additional options how the <see cref="TcpHealthListener"/> works, if required</param>
         /// <returns>Collection of services to use in the application</returns>
-        public static IServiceCollection AddTcpHealthProbes(this IServiceCollection services,
-            Action<IHealthChecksBuilder> configureHealthChecks = null)
+        public static IServiceCollection AddTcpHealthProbes(
+            this IServiceCollection services,
+            Action<IHealthChecksBuilder> configureHealthChecks = null,
+            Action<TcpHealthListenerOptions> configureTcpListenerOptions = null)
         {
             Guard.NotNull(services, nameof(services));
 
             var healthCheckBuilder = services.AddHealthChecks();
             configureHealthChecks?.Invoke(healthCheckBuilder);
+
+            if (configureTcpListenerOptions != null)
+            {
+                services.Configure(configureTcpListenerOptions);
+            }
 
             services.AddHostedService<TcpHealthListener>();
 

--- a/src/Arcus.Messaging.Health/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Health/Extensions/IServiceCollectionExtensions.cs
@@ -16,23 +16,27 @@ namespace Microsoft.Extensions.DependencyInjection
         ///     it here or do it yourself as well.
         /// </remarks>
         /// <param name="services">Collection of services to use in the application</param>
+        /// <param name="tcpConfigurationKey">The TCP health port on which the health report is exposed.</param>
         /// <param name="configureHealthChecks">Capability to configure the required health checks to expose, if required</param>
         /// <param name="configureTcpListenerOptions">Capability to configure additional options how the <see cref="TcpHealthListener"/> works, if required</param>
         /// <returns>Collection of services to use in the application</returns>
         public static IServiceCollection AddTcpHealthProbes(
             this IServiceCollection services,
+            string tcpConfigurationKey,
             Action<IHealthChecksBuilder> configureHealthChecks = null,
             Action<TcpHealthListenerOptions> configureTcpListenerOptions = null)
         {
-            Guard.NotNull(services, nameof(services));
+            Guard.NotNull(services, nameof(services), "Requires a set of services to add the TCP health probe to");
+            Guard.NotNullOrWhitespace(tcpConfigurationKey, nameof(tcpConfigurationKey), "Requires a non-blank configuration key to retrieve the TCP port");
 
             var healthCheckBuilder = services.AddHealthChecks();
             configureHealthChecks?.Invoke(healthCheckBuilder);
 
-            if (configureTcpListenerOptions != null)
+            services.Configure<TcpHealthListenerOptions>(options =>
             {
-                services.Configure(configureTcpListenerOptions);
-            }
+                options.TcpPortConfigurationKey = tcpConfigurationKey;
+                configureTcpListenerOptions?.Invoke(options);
+            });
 
             services.AddHostedService<TcpHealthListener>();
 

--- a/src/Arcus.Messaging.Health/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Health/Extensions/IServiceCollectionExtensions.cs
@@ -5,6 +5,9 @@ using GuardNet;
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
 {
+    /// <summary>
+    /// Extensions on the <see cref="IServiceCollection"/> to provide dev-friendly approach to add TCP health check service.
+    /// </summary>
     // ReSharper disable once InconsistentNaming
     public static class IServiceCollectionExtensions
     {
@@ -15,10 +18,10 @@ namespace Microsoft.Extensions.DependencyInjection
         ///     In order for the TCP health probes to work, ASP.NET Core Health Checks must be configured. You can configure
         ///     it here or do it yourself as well.
         /// </remarks>
-        /// <param name="services">Collection of services to use in the application</param>
-        /// <param name="tcpConfigurationKey">The TCP health port on which the health report is exposed.</param>
-        /// <param name="configureHealthChecks">Capability to configure the required health checks to expose, if required</param>
-        /// <param name="configureTcpListenerOptions">Capability to configure additional options how the <see cref="TcpHealthListener"/> works, if required</param>
+        /// <param name="services">The collection of services to use in the application</param>
+        /// <param name="tcpConfigurationKey">The configuration key that defines TCP health port on which the health report is exposed.</param>
+        /// <param name="configureHealthChecks">The capability to configure the required health checks to expose, if required</param>
+        /// <param name="configureTcpListenerOptions">The capability to configure additional options how the <see cref="TcpHealthListener"/> works, if required</param>
         /// <returns>Collection of services to use in the application</returns>
         public static IServiceCollection AddTcpHealthProbes(
             this IServiceCollection services,

--- a/src/Arcus.Messaging.Health/IHealthReportSerializer.cs
+++ b/src/Arcus.Messaging.Health/IHealthReportSerializer.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Arcus.Messaging.Health
+{
+    /// <summary>
+    /// Represents a custom serialization for the <see cref="HealthReport"/> model.
+    /// </summary>
+    public interface IHealthReportSerializer
+    {
+        /// <summary>
+        /// Serializes the given <paramref name="healthReport"/> to a series of bytes.
+        /// </summary>
+        /// <param name="healthReport">The report to serialize.</param>
+        byte[] Serialize(HealthReport healthReport);
+    }
+}

--- a/src/Arcus.Messaging.Health/Tcp/TcpHealthListener.cs
+++ b/src/Arcus.Messaging.Health/Tcp/TcpHealthListener.cs
@@ -25,12 +25,12 @@ namespace Arcus.Messaging.Health.Tcp
         /// <summary>
         /// Initializes a new instance of the <see cref="TcpHealthListener"/> class.
         /// </summary>
-        /// <param name="serviceProvider">The service object to retrieve built-in and custom object instances.</param>
+        /// <param name="configuration">The key-value application configuration properties.</param>
         /// <param name="tcpListenerOptions">The additional options to configure the TCP listener.</param>
         /// <param name="healthService">The service to retrieve the current health of the application.</param>
         /// <param name="logger">The logging implementation to write diagnostic messages during the running of the TCP listener.</param>
         public TcpHealthListener(
-            IServiceProvider serviceProvider,
+            IConfiguration configuration,
             IOptions<TcpHealthListenerOptions> tcpListenerOptions,
             HealthCheckService healthService, 
             ILogger<TcpHealthListener> logger)
@@ -44,8 +44,20 @@ namespace Arcus.Messaging.Health.Tcp
             _healthService = healthService;
             _logger = logger;
 
-            Port = _tcpListenerOptions.GetTcpHealthPort(serviceProvider);
+            Port = GetTcpHealthPort(configuration, _tcpListenerOptions.TcpHealthPort);
             _listener = new TcpListener(IPAddress.Any, Port);
+        }
+
+        private static int GetTcpHealthPort(IConfiguration configuration, string tcpHealthPortKey)
+        {
+            string tcpPortString = configuration[tcpHealthPortKey];
+            if (!Int32.TryParse(tcpPortString, out int tcpPort))
+            {
+                throw new ArithmeticException(
+                    $"Requires a configuration implementation with a '{tcpHealthPortKey}' key containing a TCP port number");
+            }
+
+            return tcpPort;
         }
 
         /// <summary>

--- a/src/Arcus.Messaging.Health/Tcp/TcpHealthListener.cs
+++ b/src/Arcus.Messaging.Health/Tcp/TcpHealthListener.cs
@@ -146,7 +146,7 @@ namespace Arcus.Messaging.Health.Tcp
 
         private byte[] SerializeHealthReport(HealthReport healthReport)
         {
-            IHealthReportSerializer reportSerializer = _tcpListenerOptions.HealthReportSerializer;
+            IHealthReportSerializer reportSerializer = _tcpListenerOptions.Serializer;
             if (reportSerializer is null)
             {
                 string json = JsonConvert.SerializeObject(healthReport, SerializationSettings);

--- a/src/Arcus.Messaging.Health/Tcp/TcpHealthListener.cs
+++ b/src/Arcus.Messaging.Health/Tcp/TcpHealthListener.cs
@@ -16,7 +16,7 @@ using Newtonsoft.Json.Converters;
 namespace Arcus.Messaging.Health.Tcp
 {
     /// <summary>
-    /// Representing a TCP server as a background process to expose an endpoint where the <see cref="HealthReport"/> is being broadcasted.
+    /// Representing a TCP listener as a background process to expose an endpoint where the <see cref="HealthReport"/> is being broadcasted.
     /// </summary>
     public class TcpHealthListener : BackgroundService
     {

--- a/src/Arcus.Messaging.Health/Tcp/TcpHealthListener.cs
+++ b/src/Arcus.Messaging.Health/Tcp/TcpHealthListener.cs
@@ -44,7 +44,7 @@ namespace Arcus.Messaging.Health.Tcp
             _healthService = healthService;
             _logger = logger;
 
-            Port = GetTcpHealthPort(configuration, _tcpListenerOptions.TcpHealthPort);
+            Port = GetTcpHealthPort(configuration, _tcpListenerOptions.TcpPortConfigurationKey);
             _listener = new TcpListener(IPAddress.Any, Port);
         }
 

--- a/src/Arcus.Messaging.Health/Tcp/TcpHealthListenerOptions.cs
+++ b/src/Arcus.Messaging.Health/Tcp/TcpHealthListenerOptions.cs
@@ -8,7 +8,7 @@ namespace Arcus.Messaging.Health.Tcp
     /// </summary>
     public class TcpHealthListenerOptions
     {
-        private string _tcpHealthPort = "ARCUS_HEALTH_PORT";
+        private string _tcpHealthPort;
 
         /// <summary>
         /// Gets or sets the function that serializes the <see cref="HealthReport"/> to a series of bytes.

--- a/src/Arcus.Messaging.Health/Tcp/TcpHealthListenerOptions.cs
+++ b/src/Arcus.Messaging.Health/Tcp/TcpHealthListenerOptions.cs
@@ -56,7 +56,7 @@ namespace Arcus.Messaging.Health.Tcp
         /// <summary>
         /// Gets or sets the TCP health port on which the health report is exposed.
         /// </summary>
-        public string TcpHealthPort
+        public string TcpPortConfigurationKey
         {
             get => _tcpHealthPort;
             set

--- a/src/Arcus.Messaging.Health/Tcp/TcpHealthListenerOptions.cs
+++ b/src/Arcus.Messaging.Health/Tcp/TcpHealthListenerOptions.cs
@@ -1,11 +1,5 @@
-﻿using System;
-using System.Text;
-using GuardNet;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
+﻿using GuardNet;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace Arcus.Messaging.Health.Tcp
 {
@@ -16,42 +10,10 @@ namespace Arcus.Messaging.Health.Tcp
     {
         private string _tcpHealthPort = "ARCUS_HEALTH_PORT";
 
-        private static readonly JsonSerializerSettings SerializationSettings = CreateDefaultSerializerSettings();
-
-        private Func<HealthReport, byte[]> _reportSerializer = report =>
-        {
-            string json = JsonConvert.SerializeObject(report, SerializationSettings);
-            byte[] response = Encoding.UTF8.GetBytes(json);
-
-            return response;
-        };
-
-        private static JsonSerializerSettings CreateDefaultSerializerSettings()
-        {
-            var serializingSettings = new JsonSerializerSettings
-            {
-                Formatting = Formatting.None, 
-                NullValueHandling = NullValueHandling.Ignore
-            };
-
-            var enumConverter = new StringEnumConverter { AllowIntegerValues = false };
-            serializingSettings.Converters.Add(enumConverter);
-
-            return serializingSettings;
-        }
-
         /// <summary>
         /// Gets or sets the function that serializes the <see cref="HealthReport"/> to a series of bytes.
         /// </summary>
-        public Func<HealthReport, byte[]> ReportSerializer
-        {
-            get => _reportSerializer;
-            set
-            {
-                Guard.NotNull(value, nameof(value), "Cannot set a 'null' health report serializer for the TCP listener");
-                _reportSerializer = value;
-            }
-        }
+        public IHealthReportSerializer HealthReportSerializer { get; set; }
 
         /// <summary>
         /// Gets or sets the TCP health port on which the health report is exposed.

--- a/src/Arcus.Messaging.Health/Tcp/TcpHealthListenerOptions.cs
+++ b/src/Arcus.Messaging.Health/Tcp/TcpHealthListenerOptions.cs
@@ -14,7 +14,7 @@ namespace Arcus.Messaging.Health.Tcp
     /// </summary>
     public class TcpHealthListenerOptions
     {
-        private const string TcpHealthPort = "ARCUS_HEALTH_PORT";
+        private string _tcpHealthPort = "ARCUS_HEALTH_PORT";
 
         private static readonly JsonSerializerSettings SerializationSettings = CreateDefaultSerializerSettings();
 
@@ -24,20 +24,6 @@ namespace Arcus.Messaging.Health.Tcp
             byte[] response = Encoding.UTF8.GetBytes(json);
 
             return response;
-        };
-
-        private Func<IServiceProvider, int> _getTcpHealthPort = serviceProvider =>
-        {
-            var configuration = serviceProvider.GetRequiredService<IConfiguration>();
-            string tcpPortString = configuration[TcpHealthPort];
-            
-            if (!Int32.TryParse(tcpPortString, out int tcpPort))
-            {
-                throw new ArithmeticException(
-                    $"Requires a configuration implementation with a '{TcpHealthPort}' key containing a TCP port number");
-            }
-
-            return tcpPort;
         };
 
         private static JsonSerializerSettings CreateDefaultSerializerSettings()
@@ -68,15 +54,15 @@ namespace Arcus.Messaging.Health.Tcp
         }
 
         /// <summary>
-        /// Gets or sets the function that gets the TCP health check port, using the service object with a registered collection of instances.
+        /// Gets or sets the TCP health port on which the health report is exposed.
         /// </summary>
-        public Func<IServiceProvider, int> GetTcpHealthPort
+        public string TcpHealthPort
         {
-            get => _getTcpHealthPort;
+            get => _tcpHealthPort;
             set
             {
-                Guard.NotNull(value, nameof(value), "Cannot set a 'null' function to get the TCP health check port");
-                _getTcpHealthPort = value;
+                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank configuration key for the TCP health port");
+                _tcpHealthPort = value;
             }
         }
     }

--- a/src/Arcus.Messaging.Health/Tcp/TcpHealthListenerOptions.cs
+++ b/src/Arcus.Messaging.Health/Tcp/TcpHealthListenerOptions.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Text;
+using GuardNet;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Arcus.Messaging.Health.Tcp
+{
+    /// <summary>
+    /// Options to control how the <see cref="TcpHealthListener"/> acts as a TCP endpoint for the <see cref="HealthReport"/>.
+    /// </summary>
+    public class TcpHealthListenerOptions
+    {
+        private static readonly JsonSerializerSettings SerializationSettings = CreateDefaultSerializerSettings();
+
+        private Func<HealthReport, byte[]> _reportSerializer = report =>
+        {
+            string json = JsonConvert.SerializeObject(report, SerializationSettings);
+            byte[] response = Encoding.UTF8.GetBytes(json);
+
+            return response;
+        };
+
+        private static JsonSerializerSettings CreateDefaultSerializerSettings()
+        {
+            var serializingSettings = new JsonSerializerSettings
+            {
+                Formatting = Formatting.None, 
+                NullValueHandling = NullValueHandling.Ignore
+            };
+
+            var enumConverter = new StringEnumConverter { AllowIntegerValues = false };
+            serializingSettings.Converters.Add(enumConverter);
+
+            return serializingSettings;
+        }
+
+        /// <summary>
+        /// Gets or sets the function that serializes the <see cref="HealthReport"/> to a series of bytes.
+        /// </summary>
+        public Func<HealthReport, byte[]> ReportSerializer
+        {
+            get => _reportSerializer;
+            set
+            {
+                Guard.NotNull(value, nameof(value), "Cannot set a 'null' health report serializer for the TCP listener");
+                _reportSerializer = value;
+            }
+        }
+    }
+}

--- a/src/Arcus.Messaging.Health/Tcp/TcpHealthListenerOptions.cs
+++ b/src/Arcus.Messaging.Health/Tcp/TcpHealthListenerOptions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Text;
 using GuardNet;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -12,6 +14,8 @@ namespace Arcus.Messaging.Health.Tcp
     /// </summary>
     public class TcpHealthListenerOptions
     {
+        private const string TcpHealthPort = "ARCUS_HEALTH_PORT";
+
         private static readonly JsonSerializerSettings SerializationSettings = CreateDefaultSerializerSettings();
 
         private Func<HealthReport, byte[]> _reportSerializer = report =>
@@ -20,6 +24,20 @@ namespace Arcus.Messaging.Health.Tcp
             byte[] response = Encoding.UTF8.GetBytes(json);
 
             return response;
+        };
+
+        private Func<IServiceProvider, int> _getTcpHealthPort = serviceProvider =>
+        {
+            var configuration = serviceProvider.GetRequiredService<IConfiguration>();
+            string tcpPortString = configuration[TcpHealthPort];
+            
+            if (!Int32.TryParse(tcpPortString, out int tcpPort))
+            {
+                throw new ArithmeticException(
+                    $"Requires a configuration implementation with a '{TcpHealthPort}' key containing a TCP port number");
+            }
+
+            return tcpPort;
         };
 
         private static JsonSerializerSettings CreateDefaultSerializerSettings()
@@ -46,6 +64,19 @@ namespace Arcus.Messaging.Health.Tcp
             {
                 Guard.NotNull(value, nameof(value), "Cannot set a 'null' health report serializer for the TCP listener");
                 _reportSerializer = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the function that gets the TCP health check port, using the service object with a registered collection of instances.
+        /// </summary>
+        public Func<IServiceProvider, int> GetTcpHealthPort
+        {
+            get => _getTcpHealthPort;
+            set
+            {
+                Guard.NotNull(value, nameof(value), "Cannot set a 'null' function to get the TCP health check port");
+                _getTcpHealthPort = value;
             }
         }
     }

--- a/src/Arcus.Messaging.Health/Tcp/TcpHealthListenerOptions.cs
+++ b/src/Arcus.Messaging.Health/Tcp/TcpHealthListenerOptions.cs
@@ -13,7 +13,7 @@ namespace Arcus.Messaging.Health.Tcp
         /// <summary>
         /// Gets or sets the function that serializes the <see cref="HealthReport"/> to a series of bytes.
         /// </summary>
-        public IHealthReportSerializer HealthReportSerializer { get; set; }
+        public IHealthReportSerializer Serializer { get; set; }
 
         /// <summary>
         /// Gets or sets the TCP health port on which the health report is exposed.

--- a/src/Arcus.Messaging.Tests.Worker/Program.cs
+++ b/src/Arcus.Messaging.Tests.Worker/Program.cs
@@ -23,7 +23,7 @@ namespace Arcus.Messaging.Tests.Worker
                 })
                 .ConfigureServices((hostContext, services) =>
                 {
-                    services.AddTcpHealthProbes(builder => builder.AddCheck("sample", () => HealthCheckResult.Healthy()));
+                    services.AddTcpHealthProbes("ARCUS_HEALTH_PORT", builder => builder.AddCheck("sample", () => HealthCheckResult.Healthy()));
                 });
     }
 }


### PR DESCRIPTION
Adds a `TcpHealthListenerOptions` to the services collection so we can control the serialization of the `HealthReport` and the TCP port of the health check endpoint.

Closes #18 
Closes #20 