### PR TITLE
Provide overload that doesn't require queue name

### DIFF
--- a/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
@@ -53,6 +53,24 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <remarks>When using this approach; the connection string should be scoped to the queue that is being processed, not the namespace</remarks>
         /// <param name="services">Collection of services to use in the application</param>
+        /// <param name="secretName">Name of the secret to retrieve using your registered <see cref="ISecretProvider"/> implementation</param>
+        /// <param name="configureMessagePump">Capability to configure how the message pump should behave</param>
+        /// <returns>Collection of services to use in the application</returns>
+        public static IServiceCollection AddServiceBusQueueMessagePump<TMessagePump>(this IServiceCollection services, string secretName, Action<AzureServiceBusMessagePumpOptions> configureMessagePump = null)
+            where TMessagePump : class, IHostedService
+        {
+            Guard.NotNull(services, nameof(services));
+
+            AddServiceBusMessagePump<TMessagePump>(services, string.Empty, string.Empty, getConnectionStringFromSecretFunc: secretProvider => secretProvider.GetRawSecretAsync(secretName), configureMessagePump: configureMessagePump);
+
+            return services;
+        }
+
+        /// <summary>
+        ///     Adds a message handler to consume messages from Azure Service Bus Queue
+        /// </summary>
+        /// <remarks>When using this approach; the connection string should be scoped to the queue that is being processed, not the namespace</remarks>
+        /// <param name="services">Collection of services to use in the application</param>
         /// <param name="queueName">Name of the queue to process</param>
         /// <param name="secretName">Name of the secret to retrieve using your registered <see cref="ISecretProvider"/> implementation</param>
         /// <param name="configureMessagePump">Capability to configure how the message pump should behave</param>

--- a/src/Arcus.Messaging.Tests.Unit/ServiceBus/IServiceCollectionExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/ServiceBus/IServiceCollectionExtensionsTests.cs
@@ -23,10 +23,10 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             services.AddSingleton(serviceProvider => Mock.Of<ILogger>());
 
             // Act
-            IServiceCollection result = 
+            IServiceCollection result =
                 services.AddServiceBusTopicMessagePump<EmptyMessagePump>(
                     "subscription name", "secret name", configureMessagePump: options => options.AutoComplete = true);
-            
+
             // Assert
             Assert.NotNull(result);
             ServiceProvider provider = result.BuildServiceProvider();
@@ -50,10 +50,10 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             services.AddSingleton(serviceProvider => Mock.Of<ILogger>());
 
             // Act
-            IServiceCollection result = 
+            IServiceCollection result =
                 services.AddServiceBusTopicMessagePump<EmptyMessagePump>(
                     "topic name", "subscription name", "secret name", configureMessagePump: options => options.AutoComplete = true);
-            
+
             // Assert
             // Assert
             Assert.NotNull(result);
@@ -68,7 +68,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
         }
 
         [Fact]
-        public async Task AddServiceBusQueueMessagePump_IndirectSecretProvider_WiresUpCorrectly()
+        public async Task AddServiceBusQueueMessagePump_IndirectSecretProviderWithQueueName_WiresUpCorrectly()
         {
             // Arrange
             var services = new ServiceCollection();
@@ -78,10 +78,36 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             services.AddSingleton(serviceProvider => Mock.Of<ILogger>());
 
             // Act
-            IServiceCollection result = 
+            IServiceCollection result =
                 services.AddServiceBusQueueMessagePump<EmptyMessagePump>(
                     "queue name", "secret name", configureMessagePump: options => options.AutoComplete = true);
-            
+
+            // Assert
+            Assert.NotNull(result);
+            ServiceProvider provider = result.BuildServiceProvider();
+
+            var messagePump = provider.GetService<IHostedService>();
+            Assert.IsType<EmptyMessagePump>(messagePump);
+
+            var settings = provider.GetService<AzureServiceBusMessagePumpSettings>();
+            await settings.GetConnectionStringAsync();
+            spySecretProvider.Verify(spy => spy.GetRawSecretAsync("secret name"), Times.Once);
+        }
+
+        [Fact]
+        public async Task AddServiceBusQueueMessagePump_IndirectSecretProviderWithoutQueueName_WiresUpCorrectly()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var spySecretProvider = new Mock<ISecretProvider>();
+            services.AddSingleton(serviceProvider => spySecretProvider.Object);
+            services.AddSingleton(serviceProvider => Mock.Of<IConfiguration>());
+            services.AddSingleton(serviceProvider => Mock.Of<ILogger>());
+
+            // Act
+            IServiceCollection result =
+                services.AddServiceBusQueueMessagePump<EmptyMessagePump>("secret name", configureMessagePump: options => options.AutoComplete = true);
+
             // Assert
             Assert.NotNull(result);
             ServiceProvider provider = result.BuildServiceProvider();


### PR DESCRIPTION
Provide overload that doesn't require queue name, only secret name.

This is to support connection strings scoped to the queue itself.

Follow-up of #50