### PR TITLE
Feature - make customized message pump still available with indroduction of message handlers

### DIFF
--- a/src/Arcus.Messaging.Pumps.Abstractions/MessageHandling/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/MessageHandling/IServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Arcus.Messaging.Abstractions;
+﻿using System;
+using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Pumps.Abstractions;
 using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
 using GuardNet;
@@ -31,6 +32,28 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
+        /// Adds a <see cref="IMessageHandler{TMessage}" /> implementation to process the messages from an <see cref="MessagePump"/> implementation.
+        /// resources.
+        /// </summary>
+        /// <typeparam name="TMessageHandler">The type of the implementation.</typeparam>
+        /// <typeparam name="TMessage">The type of the message that the message handler will process.</typeparam>
+        /// <param name="services">The collection of services to use in the application.</param>
+        /// <param name="implementationFactory">The function that creates the service.</param>
+        public static IServiceCollection WithMessageHandler<TMessageHandler, TMessage>(
+            this IServiceCollection services,
+            Func<IServiceProvider, TMessageHandler> implementationFactory)
+            where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
+            where TMessage : class
+        {
+            Guard.NotNull(services, nameof(services));
+            Guard.NotNull(implementationFactory, nameof(implementationFactory));
+
+            services.AddSingleton<IMessageHandler<TMessage, MessageContext>, TMessageHandler>(implementationFactory);
+
+            return services;
+        }
+
+        /// <summary>
         /// Adds a <see cref="IMessageHandler{TMessage, TMessageContext}" /> implementation to process the messages from an <see cref="MessagePump"/> implementation.
         /// resources.
         /// </summary>
@@ -46,6 +69,30 @@ namespace Microsoft.Extensions.DependencyInjection
             Guard.NotNull(services, nameof(services));
 
             services.AddSingleton<IMessageHandler<TMessage, TMessageContext>, TMessageHandler>();
+
+            return services;
+        }
+
+        /// <summary>
+        /// Adds a <see cref="IMessageHandler{TMessage, TMessageContext}" /> implementation to process the messages from an <see cref="MessagePump"/> implementation.
+        /// resources.
+        /// </summary>
+        /// <typeparam name="TMessageHandler">The type of the implementation.</typeparam>
+        /// <typeparam name="TMessage">The type of the message that the message handler will process.</typeparam>
+        /// <typeparam name="TMessageContext">The type of the context in which the message handler will process the message.</typeparam>
+        /// <param name="services">The collection of services to use in the application.</param>
+        /// <param name="implementationFactory">The function that creates the message handler.</param>
+        public static IServiceCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
+            this IServiceCollection services,
+            Func<IServiceProvider, TMessageHandler> implementationFactory)
+            where TMessageHandler : class, IMessageHandler<TMessage, TMessageContext> 
+            where TMessage : class
+            where TMessageContext : MessageContext
+        {
+            Guard.NotNull(services, nameof(services));
+            Guard.NotNull(implementationFactory, nameof(implementationFactory));
+
+            services.AddSingleton<IMessageHandler<TMessage, TMessageContext>, TMessageHandler>(implementationFactory);
 
             return services;
         }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpConfiguration.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpConfiguration.cs
@@ -6,12 +6,12 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
     /// <summary>
     ///     Options to configure how the Azure Service Bus message pump works
     /// </summary>
-    internal class AzureServiceBusMessagePumpConfiguration
+    public class AzureServiceBusMessagePumpConfiguration
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureServiceBusMessagePumpConfiguration"/> class.
         /// </summary>
-        internal AzureServiceBusMessagePumpConfiguration(AzureServiceBusQueueMessagePumpOptions options)
+        public AzureServiceBusMessagePumpConfiguration(AzureServiceBusQueueMessagePumpOptions options)
         {
             Guard.NotNull(options, nameof(options));
 
@@ -23,7 +23,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureServiceBusMessagePumpConfiguration"/> class.
         /// </summary>
-        internal AzureServiceBusMessagePumpConfiguration(AzureServiceBusTopicMessagePumpOptions options)
+        public AzureServiceBusMessagePumpConfiguration(AzureServiceBusTopicMessagePumpOptions options)
         {
             Guard.NotNull(options, nameof(options));
 

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpSettings.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpSettings.cs
@@ -28,7 +28,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// <param name="getConnectionStringFromSecretFunc">Function to look up the connection string from the secret store</param>
         /// <param name="options">Options that influence the behavior of the message pump</param>
         /// <param name="serviceProvider">Collection of services to use</param>
-        internal AzureServiceBusMessagePumpSettings(
+        public AzureServiceBusMessagePumpSettings(
             string entityName,
             string subscriptionName,
             ServiceBusEntity serviceBusEntity,

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusQueueMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusQueueMessagePumpOptions.cs
@@ -10,7 +10,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// <summary>
         ///     Gets the default settings.
         /// </summary>
-        internal static AzureServiceBusQueueMessagePumpOptions Default => new AzureServiceBusQueueMessagePumpOptions
+        public static AzureServiceBusQueueMessagePumpOptions Default => new AzureServiceBusQueueMessagePumpOptions
         {
             AutoComplete = true,
             JobId = Guid.NewGuid().ToString(),

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusTopicMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusTopicMessagePumpOptions.cs
@@ -19,7 +19,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// <summary>
         ///     Gets the default settings.
         /// </summary>
-        internal static AzureServiceBusTopicMessagePumpOptions Default => new AzureServiceBusTopicMessagePumpOptions
+        public static AzureServiceBusTopicMessagePumpOptions Default => new AzureServiceBusTopicMessagePumpOptions
         {
             AutoComplete = true,
             JobId = Guid.NewGuid().ToString(),

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
@@ -703,5 +703,27 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return services;
         }
+
+        /// <summary>
+        /// Adds a <see cref="IAzureServiceBusMessageHandler{TMessage}" /> implementation to process the messages from Azure Service Bus
+        /// resources.
+        /// </summary>
+        /// <typeparam name="TMessageHandler">The type of the implementation.</typeparam>
+        /// <typeparam name="TMessage">The type of the message that the message handler will process.</typeparam>
+        /// <param name="services">The collection of services to use in the application.</param>
+        /// <param name="implementationFactory">The function that creates the message handler.</param>
+        public static IServiceCollection WithServiceBusMessageHandler<TMessageHandler, TMessage>(
+            this IServiceCollection services,
+            Func<IServiceProvider, TMessageHandler> implementationFactory)
+            where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
+            where TMessage : class
+        {
+            Guard.NotNull(services, nameof(services));
+            Guard.NotNull(implementationFactory, nameof(implementationFactory));
+
+            services.AddSingleton<IMessageHandler<TMessage, AzureServiceBusMessageContext>, TMessageHandler>(implementationFactory);
+
+            return services;
+        }
     }
 }

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueAndTopicProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueAndTopicProgram.cs
@@ -44,8 +44,8 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus
                                .Build();
                     });
 
-                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING_WITH_TOPIC"])
-                            .AddServiceBusTopicMessagePump("Test-Receive-All-Topic-And-Queue", configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING_WITH_QUEUE"])
+                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING_WITH_QUEUE"])
+                            .AddServiceBusTopicMessagePump("Test-Receive-All-Topic-And-Queue", configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING_WITH_TOPIC"])
                             .WithMessageHandler<OrdersMessageHandler, Order>();
 
                     services.AddTcpHealthProbes("ARCUS_HEALTH_PORT", builder => builder.AddCheck("sample", () => HealthCheckResult.Healthy()));

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueAndTopicProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueAndTopicProgram.cs
@@ -45,7 +45,7 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus
                     });
 
                     services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING_WITH_TOPIC"])
-                            .AddServiceBusTopicMessagePump("Receive-All", configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING_WITH_QUEUE"])
+                            .AddServiceBusTopicMessagePump("Test-Receive-All-Topic-And-Queue", configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING_WITH_QUEUE"])
                             .WithMessageHandler<OrdersMessageHandler, Order>();
 
                     services.AddTcpHealthProbes("ARCUS_HEALTH_PORT", builder => builder.AddCheck("sample", () => HealthCheckResult.Healthy()));

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusTopicProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusTopicProgram.cs
@@ -39,7 +39,7 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus
                             .UsingAuthenticationKey(eventGridKey)
                             .Build();
                     });
-                    services.AddServiceBusTopicMessagePump("Receive-All", configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
+                    services.AddServiceBusTopicMessagePump("Test-Receive-All-Topic-Only", configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
                             .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 
                     services.AddTcpHealthProbes("ARCUS_HEALTH_PORT");


### PR DESCRIPTION
We could also provide some custom return type if that's necessary or more user-friendly.
I think this (or something simulair) is required if we want to control JSON deserialization since in previous versions (without message handlers) we already could do that so we should keep that functionality.

Relates to #43 