### PR TITLE
Feature - rotate service bus connection string connection

### DIFF
--- a/docs/preview/features/message-pumps/service-bus.md
+++ b/docs/preview/features/message-pumps/service-bus.md
@@ -130,6 +130,10 @@ public void ConfigureServices(IServiceCollection services)
             // Indicate whether or not a new Azure Service Bus Topic subscription should be created/deleted
             // when the message pump starts/stops (default: CreateOnStart & DeleteOnStop).
             options.TopicSubscription = TopicSubscription.CreateOnStart | TopicSubscription.DeleteOnStop;
+
+            // The timeout when the message pump tries to restart and re-authenticate during key rotation of the connection string.
+            // (default: 5 seconds)
+            options.KeyRotationTimeout = TimeSpan.FromSeconds(10);
         });
 
     services.AddServiceBusQueueMessagePump(
@@ -147,6 +151,10 @@ public void ConfigureServices(IServiceCollection services)
             // The unique identifier for this background job to distinguish 
             // this job instance in a multi-instance deployment (default: guid).
             options.JobId = Guid.NewGuid().ToString();
+
+            // The timeout when the message pump tries to restart and re-authenticate during key rotation of the connection string.
+            // (default: 5 seconds)
+            options.KeyRotationTimeout = TimeSpan.FromSeconds(10);
         });
 
     // Multiple message handlers can be added to the servies, based on the message type (ex. 'Order', 'Customer'...), 

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -300,14 +300,14 @@ namespace Arcus.Messaging.Pumps.ServiceBus
                 Logger.LogTrace("Restarting Azure Service Bus...");
                 
                 await CloseMessageReceiverAsync();
-                using (var stopCancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5)))
+                using (var stopCancellationTokenSource = new CancellationTokenSource(Settings.Options.KeyRotationTimeout))
                 {
                     await StopAsync(stopCancellationTokenSource.Token);
                 }
 
                 Logger.LogInformation("Azure Service Bus stopped!");
 
-                using (var startCancellationTokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5)))
+                using (var startCancellationTokenSource = new CancellationTokenSource(Settings.Options.KeyRotationTimeout))
                 {
                     await StartAsync(startCancellationTokenSource.Token);
                 }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpConfiguration.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpConfiguration.cs
@@ -64,6 +64,6 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// <summary>
         /// Gets or sets the timeout when the message pump tries to restart and re-authenticate during key rotation.
         /// </summary>
-        internal TimeSpan KeyRotationTimeout { get; set;}
+        internal TimeSpan KeyRotationTimeout { get; set; }
     }
 }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpConfiguration.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpConfiguration.cs
@@ -18,6 +18,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
             MaxConcurrentCalls = options.MaxConcurrentCalls;
             AutoComplete = options.AutoComplete;
             JobId = options.JobId;
+            KeyRotationTimeout = options.KeyRotationTimeout;
         }
 
         /// <summary>
@@ -31,6 +32,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
             TopicSubscription = options.TopicSubscription;
             AutoComplete = options.AutoComplete;
             JobId = options.JobId;
+            KeyRotationTimeout = options.KeyRotationTimeout;
         }
 
         /// <summary>
@@ -58,5 +60,10 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// Gets or sets the unique identifier for this background job to distinguish this job instance in a multi-instance deployment.
         /// </summary>
         internal string JobId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the timeout when the message pump tries to restart and re-authenticate during key rotation.
+        /// </summary>
+        internal TimeSpan KeyRotationTimeout { get; set;}
     }
 }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
@@ -10,6 +10,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
     {
         private int? _maxConcurrentCalls;
         private string _jobId;
+        private TimeSpan _keyRotationTimeout = TimeSpan.FromSeconds(5);
 
         /// <summary>
         ///     Maximum concurrent calls to process messages
@@ -45,6 +46,19 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
             {
                 Guard.NotNullOrEmpty(value, nameof(value), "Unique identifier for background job cannot be empty");
                 _jobId = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the timeout when the message pump tries to restart and re-authenticate during key rotation.
+        /// </summary>
+        public TimeSpan KeyRotationTimeout
+        {
+            get => _keyRotationTimeout;
+            set
+            {
+                Guard.NotLessThan(value, TimeSpan.Zero, nameof(value), "Key rotation timeout cannot be less than a zero time range");
+                _keyRotationTimeout = value;
             }
         }
     }

--- a/src/Arcus.Messaging.Tests.Integration/Arcus.Messaging.Tests.Integration.csproj
+++ b/src/Arcus.Messaging.Tests.Integration/Arcus.Messaging.Tests.Integration.csproj
@@ -18,7 +18,9 @@
   <ItemGroup>
     <PackageReference Include="Arcus.EventGrid.Publishing" Version="3.0.0" />
     <PackageReference Include="Arcus.EventGrid.Testing" Version="3.0.0" />
+    <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.2.0" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/KeyRotationConfig.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/KeyRotationConfig.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Arcus.Messaging.Tests.Integration.Fixture
+{
+    public class KeyRotationConfig
+    {
+        /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
+        public KeyRotationConfig(KeyVaultSecret keyVaultSecret, ServicePrincipal servicePrincipal, ServiceBusQueue serviceBusQueue)
+        {
+            KeyVaultSecret = keyVaultSecret;
+            ServicePrincipal = servicePrincipal;
+            ServiceBusQueue = serviceBusQueue;
+        }
+
+        public KeyVaultSecret KeyVaultSecret { get; }
+
+        public ServicePrincipal ServicePrincipal { get; }
+
+        public ServiceBusQueue ServiceBusQueue { get; }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/KeyRotationConfig.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/KeyRotationConfig.cs
@@ -1,23 +1,42 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using GuardNet;
 
 namespace Arcus.Messaging.Tests.Integration.Fixture
 {
+    /// <summary>
+    /// Represents all the configuration values related to testing key rotation.
+    /// </summary>
     public class KeyRotationConfig
     {
-        /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyRotationConfig" /> class.
+        /// </summary>
+        /// <param name="keyVaultSecret">The config to represent a Azure Key Vault secret.</param>
+        /// <param name="servicePrincipal">The config to authenticate to Azure resources.</param>
+        /// <param name="serviceBusQueue">The config to represent a Azure Service Bus Queue.</param>
         public KeyRotationConfig(KeyVaultSecret keyVaultSecret, ServicePrincipal servicePrincipal, ServiceBusQueue serviceBusQueue)
         {
+            Guard.NotNull(keyVaultSecret, nameof(keyVaultSecret));
+            Guard.NotNull(servicePrincipal, nameof(servicePrincipal));
+            Guard.NotNull(serviceBusQueue, nameof(serviceBusQueue));
+
             KeyVaultSecret = keyVaultSecret;
             ServicePrincipal = servicePrincipal;
             ServiceBusQueue = serviceBusQueue;
         }
 
+        /// <summary>
+        /// Gets the config representing a Azure Key Vault secret.
+        /// </summary>
         public KeyVaultSecret KeyVaultSecret { get; }
 
+        /// <summary>
+        /// Gets the config to authenticate to Azure resources.
+        /// </summary>
         public ServicePrincipal ServicePrincipal { get; }
 
+        /// <summary>
+        /// Gets the config to represent a Azure Service Bus Queue.
+        /// </summary>
         public ServiceBusQueue ServiceBusQueue { get; }
     }
 }

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/KeyVaultSecret.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/KeyVaultSecret.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using GuardNet;
+
+namespace Arcus.Messaging.Tests.Integration.Fixture
+{
+    public class KeyVaultSecret
+    {
+        /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
+        public KeyVaultSecret(string vaultUri, string secretName)
+        {
+            Guard.NotNullOrWhitespace(vaultUri, nameof(vaultUri));
+            Guard.NotNullOrWhitespace(secretName, nameof(secretName));
+
+            VaultUri = vaultUri;
+            SecretName = secretName;
+        }
+
+        public string VaultUri { get; }
+
+        public string SecretName { get; }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/KeyVaultSecret.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/KeyVaultSecret.cs
@@ -1,13 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using GuardNet;
+﻿using GuardNet;
 
 namespace Arcus.Messaging.Tests.Integration.Fixture
 {
+    /// <summary>
+    /// Represents a secret inside an Azure Key Vault instance.
+    /// </summary>
     public class KeyVaultSecret
     {
-        /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyVaultSecret" /> class.
+        /// </summary>
+        /// <param name="vaultUri">The URI referencing the Azure Key Vault instance.</param>
+        /// <param name="secretName">The name of the secret in the Azure Key Vault instance.</param>
         public KeyVaultSecret(string vaultUri, string secretName)
         {
             Guard.NotNullOrWhitespace(vaultUri, nameof(vaultUri));
@@ -17,8 +21,14 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
             SecretName = secretName;
         }
 
+        /// <summary>
+        /// Gets the URI referencing the Azure Key Vault instance.
+        /// </summary>
         public string VaultUri { get; }
 
+        /// <summary>
+        /// Gets the name of the secret in the Azure Key Vault instance.
+        /// </summary>
         public string SecretName { get; }
     }
 }

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueue.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueue.cs
@@ -1,23 +1,37 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using GuardNet;
+﻿using GuardNet;
 
 namespace Arcus.Messaging.Tests.Integration.Fixture
 {
+    /// <summary>
+    /// Represents the configuration values related to an Azure Service Bus instance.
+    /// </summary>
     public class ServiceBusQueue
     {
-        /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
-        public ServiceBusQueue(string subscriptionId, string tenantId, string resourceGroup, string @namespace, string queueName, string authorizationRuleName)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServiceBusQueue" /> class.
+        /// </summary>
+        /// <param name="tenantId">The ID of the tenant on which the Azure instance is run.</param>
+        /// <param name="azureSubscriptionId">The ID of the Azure subscription.</param>
+        /// <param name="resourceGroup">The name of the resource group where the Azure Service Bus is located.</param>
+        /// <param name="namespace">The namespace in which the Azure Service Bus is categorized.</param>
+        /// <param name="queueName">The name of the Queue in the Azure Service Bus instance.</param>
+        /// <param name="authorizationRuleName">The name of the authorization rule that describes the available permissions.</param>
+        public ServiceBusQueue(
+            string tenantId,
+            string azureSubscriptionId,
+            string resourceGroup,
+            string @namespace,
+            string queueName,
+            string authorizationRuleName)
         {
-            Guard.NotNullOrWhitespace(subscriptionId, nameof(subscriptionId));
-            Guard.NotNullOrWhitespace(tenantId, nameof(subscriptionId));
+            Guard.NotNullOrWhitespace(azureSubscriptionId, nameof(azureSubscriptionId));
+            Guard.NotNullOrWhitespace(tenantId, nameof(azureSubscriptionId));
             Guard.NotNullOrWhitespace(resourceGroup, nameof(resourceGroup));
             Guard.NotNullOrWhitespace(@namespace, nameof(@namespace));
             Guard.NotNullOrWhitespace(queueName, nameof(queueName));
             Guard.NotNullOrWhitespace(authorizationRuleName, nameof(authorizationRuleName));
 
-            SubscriptionId = subscriptionId;
+            SubscriptionId = azureSubscriptionId;
             TenantId = tenantId;
             ResourceGroup = resourceGroup;
             Namespace = @namespace;
@@ -25,16 +39,34 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
             AuthorizationRuleName = authorizationRuleName;
         }
 
-        public string SubscriptionId { get; }
-
+        /// <summary>
+        /// Gets the ID of the tenant on which the Azure instance is run.
+        /// </summary>
         public string TenantId { get; }
 
+        /// <summary>
+        /// Gets the ID of the Azure subscription.
+        /// </summary>
+        public string SubscriptionId { get; }
+
+        /// <summary>
+        /// Gets the name of the resource group where the Azure Service Bus is located.
+        /// </summary>
         public string ResourceGroup { get; }
 
+        /// <summary>
+        /// Gets the namespace in which the Azure Service Bus is categorized.
+        /// </summary>
         public string Namespace { get; }
 
+        /// <summary>
+        /// Gets the name of the Queue in the Azure Service Bus instance.
+        /// </summary>
         public string QueueName { get; }
 
+        /// <summary>
+        /// Gets the name of the authorization rule that describes the available permissions.
+        /// </summary>
         public string AuthorizationRuleName { get; }
     }
 }

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueue.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueue.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using GuardNet;
+
+namespace Arcus.Messaging.Tests.Integration.Fixture
+{
+    public class ServiceBusQueue
+    {
+        /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
+        public ServiceBusQueue(string subscriptionId, string tenantId, string resourceGroup, string @namespace, string queueName, string authorizationRuleName)
+        {
+            Guard.NotNullOrWhitespace(subscriptionId, nameof(subscriptionId));
+            Guard.NotNullOrWhitespace(tenantId, nameof(subscriptionId));
+            Guard.NotNullOrWhitespace(resourceGroup, nameof(resourceGroup));
+            Guard.NotNullOrWhitespace(@namespace, nameof(@namespace));
+            Guard.NotNullOrWhitespace(queueName, nameof(queueName));
+            Guard.NotNullOrWhitespace(authorizationRuleName, nameof(authorizationRuleName));
+
+            SubscriptionId = subscriptionId;
+            TenantId = tenantId;
+            ResourceGroup = resourceGroup;
+            Namespace = @namespace;
+            QueueName = queueName;
+            AuthorizationRuleName = authorizationRuleName;
+        }
+
+        public string SubscriptionId { get; }
+
+        public string TenantId { get; }
+
+        public string ResourceGroup { get; }
+
+        public string Namespace { get; }
+
+        public string QueueName { get; }
+
+        public string AuthorizationRuleName { get; }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueKeyVaultProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueKeyVaultProgram.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using Arcus.EventGrid.Publishing;
+using Arcus.Messaging.Tests.Core.Messages.v1;
+using Arcus.Messaging.Tests.Workers.MessageHandlers;
+using Arcus.Security.Core;
+using Arcus.Security.Providers.AzureKeyVault;
+using Arcus.Security.Providers.AzureKeyVault.Authentication;
+using Arcus.Security.Providers.AzureKeyVault.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+// ReSharper disable once CheckNamespace
+namespace Arcus.Messaging.Tests.Workers.ServiceBus
+{
+    public class ServiceBusQueueKeyVaultProgram
+    {
+        public static void main(string[] args)
+        {
+            CreateHostBuilder(args)
+                .Build()
+                .Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration(configuration =>
+                {
+                    configuration.AddCommandLine(args);
+                    configuration.AddEnvironmentVariables();
+                })
+                .ConfigureLogging(loggingBuilder => loggingBuilder.AddConsole(options => options.IncludeScopes = true))
+                .ConfigureServices((hostContext, services) =>
+                {
+                    services.AddSingleton<ISecretProvider>(serviceProvider =>
+                    {
+                        return new KeyVaultSecretProvider(
+                            new ServicePrincipalAuthentication(
+                                hostContext.Configuration["ARCUS_KEYVAULT_SERVICEPRINCIPAL_CLIENTID"],
+                                hostContext.Configuration["ARCUS_KEYVAULT_SERVICEPRINCIPAL_CLIENTSECRET"]),
+                            new KeyVaultConfiguration(
+                                hostContext.Configuration["ARCUS_KEYVAULT_VAULTURI"]));
+                    });
+                    services.AddTransient(svc =>
+                    {
+                        var configuration = svc.GetRequiredService<IConfiguration>();
+                        var eventGridTopic = configuration.GetValue<string>("EVENTGRID_TOPIC_URI");
+                        var eventGridKey = configuration.GetValue<string>("EVENTGRID_AUTH_KEY");
+
+                        return EventGridPublisherBuilder
+                            .ForTopic(eventGridTopic)
+                            .UsingAuthenticationKey(eventGridKey)
+                            .Build();
+                    });
+                    services.AddServiceBusQueueMessagePump(hostContext.Configuration["ARCUS_KEYVAULT_CONNECTIONSTRINGSECRETNAME"])
+                            .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
+
+                    services.AddTcpHealthProbes("ARCUS_HEALTH_PORT", builder => builder.AddCheck("sample", () => HealthCheckResult.Healthy()));
+                });
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServicePrincipal.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServicePrincipal.cs
@@ -1,17 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Arcus.Security.Providers.AzureKeyVault.Authentication;
+﻿using Arcus.Security.Providers.AzureKeyVault.Authentication;
 using GuardNet;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 
 namespace Arcus.Messaging.Tests.Integration.Fixture
 {
+    /// <summary>
+    /// Represents a registered service principal that can authenticate to Azure resources.
+    /// </summary>
     public class ServicePrincipal
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ServicePrincipal"/> class.
         /// </summary>
+        /// <param name="clientId">The ID of the client application.</param>
+        /// <param name="clientSecret">The secret of the client application.</param>
         public ServicePrincipal(string clientId, string clientSecret)
         {
             Guard.NotNullOrWhitespace(clientId, nameof(clientId));
@@ -21,14 +23,27 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
             ClientSecret = clientSecret;
         }
 
+        /// <summary>
+        /// Gets the ID of the client application.
+        /// </summary>
         public string ClientId { get; }
+
+        /// <summary>
+        /// Gets the secret of the client application.
+        /// </summary>
         public string ClientSecret { get; }
 
+        /// <summary>
+        /// Creates an instance to authenticate to Azure Key Vault.
+        /// </summary>
         public ServicePrincipalAuthentication CreateAuthentication()
         {
-            return new ServicePrincipalAuthentication(ClientId, ClientId);
+            return new ServicePrincipalAuthentication(ClientId, ClientSecret);
         }
 
+        /// <summary>
+        /// Creates an instance that combines the service principal information into an <see cref="ClientCredential"/> instance.
+        /// </summary>
         public ClientCredential CreateCredentials()
         {
             return new ClientCredential(ClientId, ClientSecret);

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServicePrincipal.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServicePrincipal.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Arcus.Security.Providers.AzureKeyVault.Authentication;
+using GuardNet;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+
+namespace Arcus.Messaging.Tests.Integration.Fixture
+{
+    public class ServicePrincipal
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServicePrincipal"/> class.
+        /// </summary>
+        public ServicePrincipal(string clientId, string clientSecret)
+        {
+            Guard.NotNullOrWhitespace(clientId, nameof(clientId));
+            Guard.NotNullOrWhitespace(clientSecret, nameof(clientSecret));
+
+            ClientId = clientId;
+            ClientSecret = clientSecret;
+        }
+
+        public string ClientId { get; }
+        public string ClientSecret { get; }
+
+        public ServicePrincipalAuthentication CreateAuthentication()
+        {
+            return new ServicePrincipalAuthentication(ClientId, ClientId);
+        }
+
+        public ClientCredential CreateCredentials()
+        {
+            return new ClientCredential(ClientId, ClientSecret);
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/TestConfig.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/TestConfig.cs
@@ -123,20 +123,20 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
         public KeyRotationConfig GetKeyRotationConfig()
         {
             var azureEnv = new ServiceBusQueue(
-                subscriptionId: _config.GetValue<string>("Arcus:Infra:KeyRotation:ServiceBus:SubscriptionId"),
-                tenantId: _config.GetValue<string>("Arcus:Infra:KeyRotation:ServiceBus:TenantId"),
-                resourceGroup: _config.GetValue<string>("Arcus:Infra:KeyRotation:ServiceBus:ResourceGroupName"),
-                @namespace: _config.GetValue<string>("Arcus:Infra:KeyRotation:ServiceBus:Namespace"),
-                queueName: _config.GetValue<string>("Arcus:Infra:KeyRotation:ServiceBus:QueueName"),
-                authorizationRuleName: _config.GetValue<string>("Arcus:Infra:KeyRotation:ServiceBus:AuthorizationRuleName"));
+                subscriptionId: _config.GetValue<string>("Arcus:KeyRotation:ServiceBus:SubscriptionId"),
+                tenantId: _config.GetValue<string>("Arcus:KeyRotation:ServiceBus:TenantId"),
+                resourceGroup: _config.GetValue<string>("Arcus:KeyRotation:ServiceBus:ResourceGroupName"),
+                @namespace: _config.GetValue<string>("Arcus:KeyRotation:ServiceBus:Namespace"),
+                queueName: _config.GetValue<string>("Arcus:KeyRotation:ServiceBus:QueueName"),
+                authorizationRuleName: _config.GetValue<string>("Arcus:KeyRotation:ServiceBus:AuthorizationRuleName"));
 
             var servicePrincipal = new ServicePrincipal(
-                clientId: _config.GetValue<string>("Arcus:Infra:KeyRotation:ServicePrincipal:ClientId"),
-                clientSecret: _config.GetValue<string>("Arcus:Infra:KeyRotation:ServicePrincipal:ClientSecret"));
+                clientId: _config.GetValue<string>("Arcus:KeyRotation:ServicePrincipal:ClientId"),
+                clientSecret: _config.GetValue<string>("Arcus:KeyRotation:ServicePrincipal:ClientSecret"));
 
             var secret = new KeyVaultSecret(
-                vaultUri: _config.GetValue<string>("Arcus:Infra:KeyRotation:KeyVault:VaultUri"),
-                secretName: _config.GetValue<string>("Arcus:Infra:KeyRotation:KeyVault:ConnectionStringSecretName"));
+                vaultUri: _config.GetValue<string>("Arcus:KeyRotation:KeyVault:VaultUri"),
+                secretName: _config.GetValue<string>("Arcus:KeyRotation:KeyVault:ConnectionStringSecretName"));
 
             return new KeyRotationConfig(secret, servicePrincipal, azureEnv);
         }

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/TestConfig.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/TestConfig.cs
@@ -120,6 +120,27 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
             return new DirectoryInfo(sourcesDirectory);
         }
 
+        public KeyRotationConfig GetKeyRotationConfig()
+        {
+            var azureEnv = new ServiceBusQueue(
+                subscriptionId: _config.GetValue<string>("Arcus:Infra:KeyRotation:ServiceBus:SubscriptionId"),
+                tenantId: _config.GetValue<string>("Arcus:Infra:KeyRotation:ServiceBus:TenantId"),
+                resourceGroup: _config.GetValue<string>("Arcus:Infra:KeyRotation:ServiceBus:ResourceGroupName"),
+                @namespace: _config.GetValue<string>("Arcus:Infra:KeyRotation:ServiceBus:Namespace"),
+                queueName: _config.GetValue<string>("Arcus:Infra:KeyRotation:ServiceBus:QueueName"),
+                authorizationRuleName: _config.GetValue<string>("Arcus:Infra:KeyRotation:ServiceBus:AuthorizationRuleName"));
+
+            var servicePrincipal = new ServicePrincipal(
+                clientId: _config.GetValue<string>("Arcus:Infra:KeyRotation:ServicePrincipal:ClientId"),
+                clientSecret: _config.GetValue<string>("Arcus:Infra:KeyRotation:ServicePrincipal:ClientSecret"));
+
+            var secret = new KeyVaultSecret(
+                vaultUri: _config.GetValue<string>("Arcus:Infra:KeyRotation:KeyVault:VaultUri"),
+                secretName: _config.GetValue<string>("Arcus:Infra:KeyRotation:KeyVault:ConnectionStringSecretName"));
+
+            return new KeyRotationConfig(secret, servicePrincipal, azureEnv);
+        }
+
         /// <summary>
         /// Gets a configuration sub-section with the specified key.
         /// </summary>

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/TestConfig.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/TestConfig.cs
@@ -120,11 +120,14 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
             return new DirectoryInfo(sourcesDirectory);
         }
 
+        /// <summary>
+        /// Gets all the configuration to run a complete key rotation integration test.
+        /// </summary>
         public KeyRotationConfig GetKeyRotationConfig()
         {
             var azureEnv = new ServiceBusQueue(
-                subscriptionId: _config.GetValue<string>("Arcus:KeyRotation:ServiceBus:SubscriptionId"),
                 tenantId: _config.GetValue<string>("Arcus:KeyRotation:ServiceBus:TenantId"),
+                azureSubscriptionId: _config.GetValue<string>("Arcus:KeyRotation:ServiceBus:SubscriptionId"),
                 resourceGroup: _config.GetValue<string>("Arcus:KeyRotation:ServiceBus:ResourceGroupName"),
                 @namespace: _config.GetValue<string>("Arcus:KeyRotation:ServiceBus:Namespace"),
                 queueName: _config.GetValue<string>("Arcus:KeyRotation:ServiceBus:QueueName"),

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -92,7 +92,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                 vaultBaseUrl: keyRotationConfig.KeyVaultSecret.VaultUri,
                 secretName: keyRotationConfig.KeyVaultSecret.SecretName,
                 value: freshConnectionString);
-            TestConfig.Out.WriteLine($"Temp: {keyRotationConfig.ServicePrincipal.ClientSecret}");
+            Console.WriteLine($"Temp: {keyRotationConfig.ServicePrincipal.ClientSecret}");
             var commandArguments = new[]
             {
                 CommandArgument.CreateSecret("EVENTGRID_TOPIC_URI", config.GetTestInfraEventGridTopicUri()),

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -5,6 +5,7 @@ using Arcus.Messaging.Tests.Integration.ServiceBus;
 using Arcus.Messaging.Tests.Workers.ServiceBus;
 using Arcus.Security.Providers.AzureKeyVault.Authentication;
 using Microsoft.Azure.KeyVault;
+using Microsoft.Azure.Management.ServiceBus.Models;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -84,7 +85,9 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
 
             const ServiceBusEntity entity = ServiceBusEntity.Queue;
             var client = new ServiceBusClient(keyRotationConfig, _outputWriter);
-            string freshConnectionString = await client.RotateConnectionStringKeysAsync();
+
+            const KeyType keyType = KeyType.SecondaryKey; 
+            string freshConnectionString = await client.RotateConnectionStringKeysAsync(keyType);
 
             ServicePrincipalAuthentication authentication = keyRotationConfig.ServicePrincipal.CreateAuthentication();
             IKeyVaultClient keyVaultClient = await authentication.AuthenticateAsync();
@@ -107,7 +110,8 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                 await using (var service = await TestMessagePumpService.StartNewAsync(entity, config, _outputWriter))
                 {
                     // Act
-                    string rotatedConnectionString = await client.RotateConnectionStringKeysAsync();
+                    string rotatedConnectionString = await client.RotateConnectionStringKeysAsync(keyType
+               );
                     await keyVaultClient.SetSecretAsync(
                         vaultBaseUrl: keyRotationConfig.KeyVaultSecret.VaultUri,
                         secretName: keyRotationConfig.KeyVaultSecret.SecretName,

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -92,7 +92,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                 vaultBaseUrl: keyRotationConfig.KeyVaultSecret.VaultUri,
                 secretName: keyRotationConfig.KeyVaultSecret.SecretName,
                 value: freshConnectionString);
-
+            TestConfig.Out.WriteLine($"Temp: {keyRotationConfig.ServicePrincipal.ClientSecret}");
             var commandArguments = new[]
             {
                 CommandArgument.CreateSecret("EVENTGRID_TOPIC_URI", config.GetTestInfraEventGridTopicUri()),

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -80,7 +80,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             // Arrange
             var config = TestConfig.Create();
             KeyRotationConfig keyRotationConfig = config.GetKeyRotationConfig();
-            _outputWriter.WriteLine("Using Service Principal [ClientID: '{0}', Secret: '{1}]", keyRotationConfig.ServicePrincipal.ClientId, keyRotationConfig.ServicePrincipal.ClientSecret);
+            _outputWriter.WriteLine("Using Service Principal [ClientID: '{0}']", keyRotationConfig.ServicePrincipal.ClientId);
 
             const ServiceBusEntity entity = ServiceBusEntity.Queue;
             var client = new ServiceBusClient(keyRotationConfig, _outputWriter);

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -80,7 +80,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             // Arrange
             var config = TestConfig.Create();
             KeyRotationConfig keyRotationConfig = config.GetKeyRotationConfig();
-            _outputWriter.WriteLine("Using Service Principal [ClientID: '{0}']", keyRotationConfig.ServicePrincipal.ClientId);
+            _outputWriter.WriteLine("Using Service Principal [ClientID: '{0}', Secret: '{1}]", keyRotationConfig.ServicePrincipal.ClientId, keyRotationConfig.ServicePrincipal.ClientSecret);
 
             const ServiceBusEntity entity = ServiceBusEntity.Queue;
             var client = new ServiceBusClient(keyRotationConfig, _outputWriter);

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -80,9 +80,10 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             // Arrange
             var config = TestConfig.Create();
             KeyRotationConfig keyRotationConfig = config.GetKeyRotationConfig();
+            _outputWriter.WriteLine("Using Service Principal [ClientID: '{0}']", keyRotationConfig.ServicePrincipal.ClientId);
 
             const ServiceBusEntity entity = ServiceBusEntity.Queue;
-            var client = new ServiceBusClient(keyRotationConfig);
+            var client = new ServiceBusClient(keyRotationConfig, _outputWriter);
             string freshConnectionString = await client.RotateConnectionStringKeysAsync();
 
             ServicePrincipalAuthentication authentication = keyRotationConfig.ServicePrincipal.CreateAuthentication();

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -92,7 +92,6 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                 vaultBaseUrl: keyRotationConfig.KeyVaultSecret.VaultUri,
                 secretName: keyRotationConfig.KeyVaultSecret.SecretName,
                 value: freshConnectionString);
-            Console.WriteLine($"Temp: {keyRotationConfig.ServicePrincipal.ClientSecret}");
             var commandArguments = new[]
             {
                 CommandArgument.CreateSecret("EVENTGRID_TOPIC_URI", config.GetTestInfraEventGridTopicUri()),

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/TestMessagePumpService.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/TestMessagePumpService.cs
@@ -95,7 +95,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
 
                 await messageSender.SendAsync(orderMessage);
 
-                string receivedEvent = _serviceBusEventConsumerHost.GetReceivedEvent(operationId);
+                string receivedEvent = _serviceBusEventConsumerHost.GetReceivedEvent(operationId, 10);
                 Assert.NotEmpty(receivedEvent);
 
                 EventBatch<Event> eventBatch = EventParser.Parse(receivedEvent);

--- a/src/Arcus.Messaging.Tests.Integration/ServiceBus/ServiceBusClient.cs
+++ b/src/Arcus.Messaging.Tests.Integration/ServiceBus/ServiceBusClient.cs
@@ -1,25 +1,17 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Net;
-using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 using Arcus.Messaging.Tests.Integration.Fixture;
 using GuardNet;
 using Microsoft.Azure.Management.ServiceBus;
 using Microsoft.Azure.Management.ServiceBus.Models;
-using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.Rest;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace Arcus.Messaging.Tests.Integration.ServiceBus
 {
     /// <summary>
-    /// 
+    /// Represents the test client to interact with a Azure Service Bus resource.
     /// </summary>
     public class ServiceBusClient
     {

--- a/src/Arcus.Messaging.Tests.Integration/ServiceBus/ServiceBusClient.cs
+++ b/src/Arcus.Messaging.Tests.Integration/ServiceBus/ServiceBusClient.cs
@@ -8,11 +8,13 @@ using Arcus.Messaging.Tests.Integration.Fixture;
 using GuardNet;
 using Microsoft.Azure.Management.ServiceBus;
 using Microsoft.Azure.Management.ServiceBus.Models;
+using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.Rest;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Arcus.Messaging.Tests.Integration.ServiceBus
 {
@@ -22,17 +24,18 @@ namespace Arcus.Messaging.Tests.Integration.ServiceBus
     public class ServiceBusClient
     {
         private readonly KeyRotationConfig _configuration;
-
-        private static readonly HttpClient HttpClient = new HttpClient();
+        private readonly ITestOutputHelper _logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ServiceBusClient"/> class.
         /// </summary>
-        public ServiceBusClient(KeyRotationConfig configuration)
+        public ServiceBusClient(KeyRotationConfig configuration, ITestOutputHelper logger)
         {
             Guard.NotNull(configuration, nameof(configuration));
+            Guard.NotNull(logger, nameof(logger));
 
             _configuration = configuration;
+            _logger = logger;
         }
 
         /// <summary>
@@ -41,28 +44,46 @@ namespace Arcus.Messaging.Tests.Integration.ServiceBus
         /// <returns></returns>
         public async Task<string> RotateConnectionStringKeysAsync()
         {
-            string tenantId = _configuration.ServiceBusQueue.TenantId;
-            var context = new AuthenticationContext($"https://login.microsoftonline.com/{tenantId}");
+            const KeyType keyType = KeyType.SecondaryKey;
+            string queueName = _configuration.ServiceBusQueue.QueueName;
 
-            ClientCredential credentials = _configuration.ServicePrincipal.CreateCredentials();
-            AuthenticationResult result =
-                await context.AcquireTokenAsync(
-                    "https://management.azure.com/",
-                    credentials);
-
-            var creds = new TokenCredentials(result.AccessToken);
-            string subscriptionId = _configuration.ServiceBusQueue.SubscriptionId;
-
-            using (var client = new ServiceBusManagementClient(creds) { SubscriptionId = subscriptionId })
+            try
             {
-                AccessKeys keys = await client.Queues.RegenerateKeysAsync(
-                    _configuration.ServiceBusQueue.ResourceGroup,
-                    _configuration.ServiceBusQueue.Namespace,
-                    _configuration.ServiceBusQueue.QueueName,
-                    _configuration.ServiceBusQueue.AuthorizationRuleName,
-                    new RegenerateAccessKeyParameters(KeyType.SecondaryKey));
+                string tenantId = _configuration.ServiceBusQueue.TenantId;
+                var context = new AuthenticationContext($"https://login.microsoftonline.com/{tenantId}");
 
-                return keys.SecondaryConnectionString;
+                ClientCredential credentials = _configuration.ServicePrincipal.CreateCredentials();
+                AuthenticationResult result =
+                    await context.AcquireTokenAsync(
+                        "https://management.azure.com/",
+                        credentials);
+
+                var creds = new TokenCredentials(result.AccessToken);
+                string subscriptionId = _configuration.ServiceBusQueue.SubscriptionId;
+
+                using (var client = new ServiceBusManagementClient(creds) { SubscriptionId = subscriptionId })
+                {
+                    _logger.WriteLine(
+                        "Start rotating {0} connection string of Azure Service Bus Queue '{1}'...",
+                        keyType, queueName);
+
+                    AccessKeys keys = await client.Queues.RegenerateKeysAsync(
+                        _configuration.ServiceBusQueue.ResourceGroup,
+                        _configuration.ServiceBusQueue.Namespace,
+                        queueName,
+                        _configuration.ServiceBusQueue.AuthorizationRuleName,
+                        new RegenerateAccessKeyParameters(keyType));
+
+                    _logger.WriteLine(
+                        "Rotated {0} connection string of Azure Service Bus Queue '{1}'",
+                        keyType, queueName);
+                    return keys.SecondaryConnectionString;
+                }
+            }
+            catch (Exception exception)
+            {
+                _logger.WriteLine("Failed to rotate the {0} connection string of the Azure Service Bus Queue '{1}': {2}, {3}", keyType, queueName, exception.Message);
+                throw;
             }
         }
     }

--- a/src/Arcus.Messaging.Tests.Integration/ServiceBus/ServiceBusClient.cs
+++ b/src/Arcus.Messaging.Tests.Integration/ServiceBus/ServiceBusClient.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Arcus.Messaging.Tests.Integration.Fixture;
+using GuardNet;
+using Microsoft.Azure.Management.ServiceBus;
+using Microsoft.Azure.Management.ServiceBus.Models;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using Microsoft.Rest;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Arcus.Messaging.Tests.Integration.ServiceBus
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class ServiceBusClient
+    {
+        private readonly KeyRotationConfig _configuration;
+
+        private static readonly HttpClient HttpClient = new HttpClient();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServiceBusClient"/> class.
+        /// </summary>
+        public ServiceBusClient(KeyRotationConfig configuration)
+        {
+            Guard.NotNull(configuration, nameof(configuration));
+
+            _configuration = configuration;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public async Task<string> RotateConnectionStringKeysAsync()
+        {
+            string tenantId = _configuration.ServiceBusQueue.TenantId;
+            var context = new AuthenticationContext($"https://login.microsoftonline.com/{tenantId}");
+
+            ClientCredential credentials = _configuration.ServicePrincipal.CreateCredentials();
+            AuthenticationResult result =
+                await context.AcquireTokenAsync(
+                    "https://management.azure.com/",
+                    credentials);
+
+            var creds = new TokenCredentials(result.AccessToken);
+            string subscriptionId = _configuration.ServiceBusQueue.SubscriptionId;
+
+            using (var client = new ServiceBusManagementClient(creds) { SubscriptionId = subscriptionId })
+            {
+                AccessKeys keys = await client.Queues.RegenerateKeysAsync(
+                    _configuration.ServiceBusQueue.ResourceGroup,
+                    _configuration.ServiceBusQueue.Namespace,
+                    _configuration.ServiceBusQueue.QueueName,
+                    _configuration.ServiceBusQueue.AuthorizationRuleName,
+                    new RegenerateAccessKeyParameters(KeyType.SecondaryKey));
+
+                return keys.SecondaryConnectionString;
+            }
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/appsettings.json
+++ b/src/Arcus.Messaging.Tests.Integration/appsettings.json
@@ -20,20 +20,20 @@
     },
     "KeyRotation": {
       "ServicePrincipal": {
-        "ClientId": "#{Arcus.TestInfra.KeyRotation.ServicePrincipalClientId}#",
-        "ClientSecret": "#{Arcus.TestInfra.KeyRotation.ServicePrincipal.ClientSecret}#"
+        "ClientId": "#{Arcus.KeyRotation.ServicePrincipalClientId}#",
+        "ClientSecret": "#{Arcus.KeyRotation.ServicePrincipal.ClientSecret}#"
       },
       "ServiceBus": {
-        "ResourceGroupName": "#{Arcus.TestInfra.KeyRotation.ServiceBus.ResourceGroupName}#",
-        "TenantId": "#{Arcus.TestInfra.KeyRotation.ServiceBus.TenantId}#",
-        "SubscriptionId": "#{Arcus.TestInfra.KeyRotation.ServiceBus.SubscriptionId}#",
-        "Namespace": "#{Arcus.TestInfra.KeyRotation.ServiceBus.Namespace}#",
-        "QueueName": "#{Arcus.TestInfra.KeyRotation.ServiceBus.QueueName}#",
-        "AuthorizationRuleName": "#{Arcus.TestInfra.KeyRotation.ServiceBus.AuthorizationRuleName}#"
+        "ResourceGroupName": "#{Arcus.KeyRotation.ServiceBus.ResourceGroupName}#",
+        "TenantId": "#{Arcus.KeyRotation.ServiceBus.TenantId}#",
+        "SubscriptionId": "#{Arcus.KeyRotation.ServiceBus.SubscriptionId}#",
+        "Namespace": "#{Arcus.KeyRotation.ServiceBus.Namespace}#",
+        "QueueName": "#{Arcus.KeyRotation.ServiceBus.QueueName}#",
+        "AuthorizationRuleName": "#{Arcus.KeyRotation.ServiceBus.AuthorizationRuleName}#"
       },
       "KeyVault": {
-        "VaultUri": "#{Arcus.TestInfra.KeyRotation.KeyVault.VaultUri}#",
-        "ConnectionStringSecretName": "#{Arcus.TestInfra.KeyRotation.KeyVault.ConnectionStringSecretName}#"
+        "VaultUri": "#{Arcus.KeyRotation.KeyVault.VaultUri}#",
+        "ConnectionStringSecretName": "#{Arcus.KeyRotation.KeyVault.ConnectionStringSecretName}#"
       }
     } 
   },

--- a/src/Arcus.Messaging.Tests.Integration/appsettings.json
+++ b/src/Arcus.Messaging.Tests.Integration/appsettings.json
@@ -17,7 +17,25 @@
     "ServiceBus": {
       "ConnectionStringWithQueue": "#{Arcus.ServiceBus.ConnectionStringWithQueue}#",
       "ConnectionStringWithTopic": "#{Arcus.ServiceBus.ConnectionStringWithTopic}#"
-    }
+    },
+    "KeyRotation": {
+      "ServicePrincipal": {
+        "ClientId": "#{Arcus.TestInfra.KeyRotation.ServicePrincipalClientId}#",
+        "ClientSecret": "#{Arcus.TestInfra.KeyRotation.ServicePrincipal.ClientSecret}#"
+      },
+      "ServiceBus": {
+        "ResourceGroupName": "#{Arcus.TestInfra.KeyRotation.ServiceBus.ResourceGroupName}#",
+        "TenantId": "#{Arcus.TestInfra.KeyRotation.ServiceBus.TenantId}#",
+        "SubscriptionId": "#{Arcus.TestInfra.KeyRotation.ServiceBus.SubscriptionId}#",
+        "Namespace": "#{Arcus.TestInfra.KeyRotation.ServiceBus.Namespace}#",
+        "QueueName": "#{Arcus.TestInfra.KeyRotation.ServiceBus.QueueName}#",
+        "AuthorizationRuleName": "#{Arcus.TestInfra.KeyRotation.ServiceBus.AuthorizationRuleName}#"
+      },
+      "KeyVault": {
+        "VaultUri": "#{Arcus.TestInfra.KeyRotation.KeyVault.VaultUri}#",
+        "ConnectionStringSecretName": "#{Arcus.TestInfra.KeyRotation.KeyVault.ConnectionStringSecretName}#"
+      }
+    } 
   },
   "Build.SourcesDirectory": "#{Build.SourcesDirectory}#" 
 }

--- a/src/Arcus.Messaging.Tests.Workers.ServiceBus/Arcus.Messaging.Tests.Workers.ServiceBus.csproj
+++ b/src/Arcus.Messaging.Tests.Workers.ServiceBus/Arcus.Messaging.Tests.Workers.ServiceBus.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Arcus.EventGrid.Publishing" Version="3.0.0" />
     <PackageReference Include="Arcus.EventGrid.Testing" Version="3.0.0" />
+    <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.2.0" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />

--- a/src/Arcus.Messaging.Tests.Workers.ServiceBus/Program.cs
+++ b/src/Arcus.Messaging.Tests.Workers.ServiceBus/Program.cs
@@ -1,10 +1,16 @@
+using System.Collections.Generic;
 using Arcus.EventGrid.Publishing;
 using Arcus.Messaging.Tests.Core.Messages.v1;
 using Arcus.Messaging.Tests.Workers.MessageHandlers;
+using Arcus.Security.Core;
+using Arcus.Security.Providers.AzureKeyVault;
+using Arcus.Security.Providers.AzureKeyVault.Authentication;
+using Arcus.Security.Providers.AzureKeyVault.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 // ReSharper disable once CheckNamespace
 namespace Arcus.Messaging.Tests.Workers.ServiceBus
@@ -24,22 +30,40 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus
                 {
                     configuration.AddCommandLine(args);
                     configuration.AddEnvironmentVariables();
+                    configuration.AddInMemoryCollection(new []{ new KeyValuePair<string, string>("ARCUS_HEALTH_PORT", "5000") });
                 })
+                .ConfigureLogging(loggingBuilder => loggingBuilder.AddConsole(options => options.IncludeScopes = true))
                 .ConfigureServices((hostContext, services) =>
                 {
+                    services.AddSingleton<ISecretProvider>(serviceProvider =>
+                    {
+                        var authentication = new ServicePrincipalAuthentication(
+                            "d1c9a6b8-e26e-4bd7-85a7-98140ce73cb1",
+                            "B7y/GrQV6T.74UZpNBxGose=fIBEqa=W");
+
+                        return new KeyVaultSecretProvider(
+                            //new ServicePrincipalAuthentication(
+                            //    "88e84e7b-7f06-45e3-933f-4945270e0f60",
+                            //    "23.HBxx@Oft9e3XjWRczJCBDXTazz/c/"),
+                            authentication,
+                            new KeyVaultConfiguration(
+                                /*"https://arcustesting.vault.azure.net/"*/
+                                "https://arcus-messaging-dev-we.vault.azure.net/"));
+                    });
                     services.AddTransient(svc =>
                     {
                         var configuration = svc.GetRequiredService<IConfiguration>();
-                        var eventGridTopic = configuration.GetValue<string>("EVENTGRID_TOPIC_URI");
-                        var eventGridKey = configuration.GetValue<string>("EVENTGRID_AUTH_KEY");
+                        var eventGridTopic =
+                            "https://arcus-event-grid-dev-we-integration-tests-cncf-ce.westeurope-1.eventgrid.azure.net/api/events";
+                        var eventGridKey = "M1C7nia9SXWroDFyzl0dOMRL+1G2cI9D1+PCXkMsrd8=";
 
                         return EventGridPublisherBuilder
                             .ForTopic(eventGridTopic)
                             .UsingAuthenticationKey(eventGridKey)
                             .Build();
                     });
-                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
-                            .WithMessageHandler<OrdersMessageHandler, Order>();
+                    services.AddServiceBusQueueMessagePump("arcus-messaging-keyrotate-servicebus-connectionstring")
+                            .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 
                     services.AddTcpHealthProbes("ARCUS_HEALTH_PORT", builder => builder.AddCheck("sample", () => HealthCheckResult.Healthy()));
                 });

--- a/src/Arcus.Messaging.Tests.Workers.ServiceBus/Program.cs
+++ b/src/Arcus.Messaging.Tests.Workers.ServiceBus/Program.cs
@@ -1,16 +1,10 @@
-using System.Collections.Generic;
 using Arcus.EventGrid.Publishing;
 using Arcus.Messaging.Tests.Core.Messages.v1;
 using Arcus.Messaging.Tests.Workers.MessageHandlers;
-using Arcus.Security.Core;
-using Arcus.Security.Providers.AzureKeyVault;
-using Arcus.Security.Providers.AzureKeyVault.Authentication;
-using Arcus.Security.Providers.AzureKeyVault.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 // ReSharper disable once CheckNamespace
 namespace Arcus.Messaging.Tests.Workers.ServiceBus
@@ -30,39 +24,21 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus
                 {
                     configuration.AddCommandLine(args);
                     configuration.AddEnvironmentVariables();
-                    configuration.AddInMemoryCollection(new []{ new KeyValuePair<string, string>("ARCUS_HEALTH_PORT", "5000") });
                 })
-                .ConfigureLogging(loggingBuilder => loggingBuilder.AddConsole(options => options.IncludeScopes = true))
                 .ConfigureServices((hostContext, services) =>
                 {
-                    services.AddSingleton<ISecretProvider>(serviceProvider =>
-                    {
-                        var authentication = new ServicePrincipalAuthentication(
-                            "d1c9a6b8-e26e-4bd7-85a7-98140ce73cb1",
-                            "B7y/GrQV6T.74UZpNBxGose=fIBEqa=W");
-
-                        return new KeyVaultSecretProvider(
-                            //new ServicePrincipalAuthentication(
-                            //    "88e84e7b-7f06-45e3-933f-4945270e0f60",
-                            //    "23.HBxx@Oft9e3XjWRczJCBDXTazz/c/"),
-                            authentication,
-                            new KeyVaultConfiguration(
-                                /*"https://arcustesting.vault.azure.net/"*/
-                                "https://arcus-messaging-dev-we.vault.azure.net/"));
-                    });
                     services.AddTransient(svc =>
                     {
                         var configuration = svc.GetRequiredService<IConfiguration>();
-                        var eventGridTopic =
-                            "https://arcus-event-grid-dev-we-integration-tests-cncf-ce.westeurope-1.eventgrid.azure.net/api/events";
-                        var eventGridKey = "M1C7nia9SXWroDFyzl0dOMRL+1G2cI9D1+PCXkMsrd8=";
+                        var eventGridTopic = configuration.GetValue<string>("EVENTGRID_TOPIC_URI");
+                        var eventGridKey = configuration.GetValue<string>("EVENTGRID_AUTH_KEY");
 
                         return EventGridPublisherBuilder
                             .ForTopic(eventGridTopic)
                             .UsingAuthenticationKey(eventGridKey)
                             .Build();
                     });
-                    services.AddServiceBusQueueMessagePump("arcus-messaging-keyrotate-servicebus-connectionstring")
+                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
                             .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 
                     services.AddTcpHealthProbes("ARCUS_HEALTH_PORT", builder => builder.AddCheck("sample", () => HealthCheckResult.Healthy()));


### PR DESCRIPTION
Provides the functionality so that the message pump automatically re-authenticate when the Azure Service Bus connecting string is rotated.

Closes #37