### PR TITLE
Feature - change Azure Service Bus connection string key rotation flow w/ Primary & Secondary keys

### DIFF
--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -299,25 +299,20 @@ namespace Arcus.Messaging.Pumps.ServiceBus
                 Logger.LogWarning("Unable to connect anymore to Azure Service Bus, trying to re-authenticate...");
                 Logger.LogTrace("Restarting Azure Service Bus...");
 
-                await CloseMessageReceiverAsync()
-                    .ContinueWith(async t =>
-                    {
-                        using (var stopCancellationTokenSource = new CancellationTokenSource(Settings.Options.KeyRotationTimeout))
-                        {
-                            await StopAsync(stopCancellationTokenSource.Token);
-                        }
+                await CloseMessageReceiverAsync();
+                using (var stopCancellationTokenSource = new CancellationTokenSource(Settings.Options.KeyRotationTimeout))
+                {
+                    await StopAsync(stopCancellationTokenSource.Token);
+                }
 
-                        Logger.LogInformation("Azure Service Bus stopped!");
-                    })
-                    .ContinueWith(async t =>
-                    {
-                        using (var startCancellationTokenSource = new CancellationTokenSource(Settings.Options.KeyRotationTimeout))
-                        {
-                            await StartAsync(startCancellationTokenSource.Token);
-                        }
+                Logger.LogInformation("Azure Service Bus stopped!");
 
-                        Logger.LogInformation("Azure Service Bus restarted!");
-                    });
+                using (var startCancellationTokenSource = new CancellationTokenSource(Settings.Options.KeyRotationTimeout))
+                {
+                    await StartAsync(startCancellationTokenSource.Token);
+                }
+
+                Logger.LogInformation("Azure Service Bus restarted!");
             }
         }
 

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -140,15 +140,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
         {
             try
             {
-                _messageReceiver = await CreateMessageReceiverAsync(Settings);
-
-                Logger.LogInformation(
-                    "Starting message pump {MessagePumpId} on entity path '{EntityPath}' in namespace '{Namespace}'",
-                    Id, EntityPath, Namespace);
-
-                _messageReceiver.RegisterMessageHandler(HandleMessageAsync, _messageHandlerOptions);
-                Logger.LogInformation("Message pump {MessagePumpId} started",  Id);
-
+                await OpenNewMessageReceiverAsync();
                 await UntilCancelledAsync(stoppingToken);
             }
             catch (Exception exception)
@@ -158,15 +150,31 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             }
             finally
             {
-                if (_messageReceiver != null)
-                {
-                    await CloseMessageReceiverAsync();
-                }
+                await CloseMessageReceiverAsync();
             }
+        }
+
+        private async Task OpenNewMessageReceiverAsync()
+        {
+            _messageReceiver = await CreateMessageReceiverAsync(Settings);
+
+            Logger.LogInformation(
+                "Starting message pump {MessagePumpId} on entity path '{EntityPath}' in namespace '{Namespace}'",
+                Id,
+                EntityPath,
+                Namespace);
+
+            _messageReceiver.RegisterMessageHandler(HandleMessageAsync, _messageHandlerOptions);
+            Logger.LogInformation("Message pump {MessagePumpId} started", Id);
         }
 
         private async Task CloseMessageReceiverAsync()
         {
+            if (_messageReceiver is null)
+            {
+                return;
+            }
+
             try
             {
                 Logger.LogInformation("Closing message pump {MessagePumpId}",  Id);
@@ -297,21 +305,10 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             if (exception is UnauthorizedException)
             {
                 Logger.LogWarning("Unable to connect anymore to Azure Service Bus, trying to re-authenticate...");
+                
                 Logger.LogTrace("Restarting Azure Service Bus...");
-
                 await CloseMessageReceiverAsync();
-                using (var stopCancellationTokenSource = new CancellationTokenSource(Settings.Options.KeyRotationTimeout))
-                {
-                    await StopAsync(stopCancellationTokenSource.Token);
-                }
-
-                Logger.LogInformation("Azure Service Bus stopped!");
-
-                using (var startCancellationTokenSource = new CancellationTokenSource(Settings.Options.KeyRotationTimeout))
-                {
-                    await StartAsync(startCancellationTokenSource.Token);
-                }
-
+                await OpenNewMessageReceiverAsync();
                 Logger.LogInformation("Azure Service Bus restarted!");
             }
         }

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -33,19 +33,20 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
         {
             // Arrange
             var config = TestConfig.Create();
+            string connectionString = config.GetServiceBusConnectionString(entity);
             var commandArguments = new[]
             {
                 CommandArgument.CreateSecret("EVENTGRID_TOPIC_URI", config.GetTestInfraEventGridTopicUri()),
                 CommandArgument.CreateSecret("EVENTGRID_AUTH_KEY", config.GetTestInfraEventGridAuthKey()),
-                CommandArgument.CreateSecret("ARCUS_SERVICEBUS_CONNECTIONSTRING", config.GetServiceBusConnectionString(entity)),
+                CommandArgument.CreateSecret("ARCUS_SERVICEBUS_CONNECTIONSTRING", connectionString),
             };
 
             using (var project = await ServiceBusWorkerProject.StartNewWithAsync(programType, config, _outputWriter, commandArguments))
             {
-                await using (var service = await TestMessagePumpService.StartNewAsync(entity, config, _outputWriter))
+                await using (var service = await TestMessagePumpService.StartNewAsync(config, _outputWriter))
                 {
                     // Act / Assert
-                    await service.SimulateMessageProcessingAsync();
+                    await service.SimulateMessageProcessingAsync(connectionString);
                 }
             }
         }
@@ -55,22 +56,22 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
         {
             // Arrange
             var config = TestConfig.Create();
-            const ServiceBusEntity entity = ServiceBusEntity.Queue;
-
+            string connectionString = config.GetServiceBusConnectionString(ServiceBusEntity.Queue);
+            
             var commandArguments = new[]
             {
                 CommandArgument.CreateSecret("EVENTGRID_TOPIC_URI", config.GetTestInfraEventGridTopicUri()),
                 CommandArgument.CreateSecret("EVENTGRID_AUTH_KEY", config.GetTestInfraEventGridAuthKey()),
-                CommandArgument.CreateSecret("ARCUS_SERVICEBUS_CONNECTIONSTRING_WITH_QUEUE", config.GetServiceBusConnectionString(ServiceBusEntity.Queue)),
+                CommandArgument.CreateSecret("ARCUS_SERVICEBUS_CONNECTIONSTRING_WITH_QUEUE", connectionString),
                 CommandArgument.CreateSecret("ARCUS_SERVICEBUS_CONNECTIONSTRING_WITH_TOPIC", config.GetServiceBusConnectionString(ServiceBusEntity.Topic)),
             };
 
             using (var project = await ServiceBusWorkerProject.StartNewWithAsync<ServiceBusQueueAndTopicProgram>(config, _outputWriter, commandArguments))
             {
-                await using (var service = await TestMessagePumpService.StartNewAsync(entity, config, _outputWriter))
+                await using (var service = await TestMessagePumpService.StartNewAsync(config, _outputWriter))
                 {
                     // Act / Assert
-                    await service.SimulateMessageProcessingAsync();
+                    await service.SimulateMessageProcessingAsync(connectionString);
                 }
             }
         }

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -105,13 +105,13 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                 string newSecondaryConnectionString = await client.RotateConnectionStringKeysAsync(KeyType.SecondaryKey);
                 await SetConnectionStringInKeyVaultAsync(keyVaultClient, keyRotationConfig, newSecondaryConnectionString);
 
-                await using (var service = await TestMessagePumpService.StartNewAsync(ServiceBusEntity.Queue, config, _outputWriter))
+                await using (var service = await TestMessagePumpService.StartNewAsync(config, _outputWriter))
                 {
                     // Act
                     string newPrimaryConnectionString = await client.RotateConnectionStringKeysAsync(KeyType.PrimaryKey);
 
                     // Assert
-                    await service.SimulateMessageProcessingAsync();
+                    await service.SimulateMessageProcessingAsync(newPrimaryConnectionString);
                 }
             }
         }

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/TestMessagePumpService.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/TestMessagePumpService.cs
@@ -23,9 +23,8 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
     /// </summary>
     public class TestMessagePumpService : IAsyncDisposable
     {
-        private readonly ServiceBusEntity _entity;
-        private readonly ITestOutputHelper _outputWriter;
         private readonly TestConfig _configuration;
+        private readonly ITestOutputHelper _outputWriter;
 
         private ServiceBusEventConsumerHost _serviceBusEventConsumerHost;
 
@@ -41,10 +40,16 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
         /// <summary>
         /// Starts a new instance of the <see cref="TestMessagePumpService"/> type to simulate messages.
         /// </summary>
+        /// <param name="config">The configuration instance to retrieve the Azure Service Bus test infrastructure authentication information.</param>
+        /// <param name="outputWriter">The instance to log diagnostic messages during the interaction with teh Azure Service Bus test infrastructure.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="config"/> or the <paramref name="outputWriter"/> is <c>null</c>.</exception>
         public static async Task<TestMessagePumpService> StartNewAsync(
             TestConfig config,
             ITestOutputHelper outputWriter)
         {
+            Guard.NotNull(config, nameof(config));
+            Guard.NotNull(outputWriter, nameof(outputWriter));
+
             var service = new TestMessagePumpService(config, outputWriter);
             await service.StartAsync();
 
@@ -71,8 +76,11 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
         /// Simulate the message processing of the message pump using the Azure Service Bus.
         /// </summary>
         /// <param name="connectionString">The connection string used to send a Azure Service Bus message to the respectively running message pump.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionString"/> is blank.</exception>
         public async Task SimulateMessageProcessingAsync(string connectionString)
         {
+            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString));
+
             if (_serviceBusEventConsumerHost is null)
             {
                 throw new InvalidOperationException(

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/TestMessagePumpService.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/TestMessagePumpService.cs
@@ -38,30 +38,6 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             _outputWriter = outputWriter;
         }
 
-        private TestMessagePumpService(ServiceBusEntity entity, TestConfig configuration, ITestOutputHelper outputWriter)
-        {
-            Guard.NotNull(configuration, nameof(configuration));
-            Guard.NotNull(outputWriter, nameof(outputWriter));
-
-            _entity = entity;
-            _outputWriter = outputWriter;
-            _configuration = configuration;
-        }
-
-        /// <summary>
-        /// Starts a new instance of the <see cref="TestMessagePumpService"/> type to simulate messages.
-        /// </summary>
-        public static async Task<TestMessagePumpService> StartNewAsync(
-            ServiceBusEntity entity,
-            TestConfig config,
-            ITestOutputHelper outputWriter)
-        {
-            var service = new TestMessagePumpService(entity, config, outputWriter);
-            await service.StartAsync();
-
-            return service;
-        }
-
         /// <summary>
         /// Starts a new instance of the <see cref="TestMessagePumpService"/> type to simulate messages.
         /// </summary>
@@ -92,17 +68,9 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
         }
 
         /// <summary>
-        /// Simulate the message processing of the message pump using the Service Bus.
+        /// Simulate the message processing of the message pump using the Azure Service Bus.
         /// </summary>
-        public async Task SimulateMessageProcessingAsync()
-        {
-            string connectionString = _configuration.GetServiceBusConnectionString(_entity);
-            await SimulateMessageProcessingAsync(connectionString);
-        }
-
-        /// <summary>
-        /// Simulate the message processing of the message pump using the Service Bus.
-        /// </summary>
+        /// <param name="connectionString">The connection string used to send a Azure Service Bus message to the respectively running message pump.</param>
         public async Task SimulateMessageProcessingAsync(string connectionString)
         {
             if (_serviceBusEventConsumerHost is null)

--- a/src/Arcus.Messaging.Tests.Integration/ServiceBus/ServiceBusClient.cs
+++ b/src/Arcus.Messaging.Tests.Integration/ServiceBus/ServiceBusClient.cs
@@ -71,7 +71,14 @@ namespace Arcus.Messaging.Tests.Integration.ServiceBus
                     _logger.WriteLine(
                         "Rotated {0} connection string of Azure Service Bus Queue '{1}'",
                         keyType, queueName);
-                    return keys.SecondaryConnectionString;
+
+                    switch (keyType)
+                    {
+                        case KeyType.PrimaryKey: return keys.PrimaryConnectionString;
+                        case KeyType.SecondaryKey: return keys.SecondaryConnectionString;
+                        default:
+                            throw new ArgumentOutOfRangeException(nameof(keyType), keyType, "Unknown key type");
+                    }
                 }
             }
             catch (Exception exception)

--- a/src/Arcus.Messaging.Tests.Integration/ServiceBus/ServiceBusClient.cs
+++ b/src/Arcus.Messaging.Tests.Integration/ServiceBus/ServiceBusClient.cs
@@ -21,6 +21,9 @@ namespace Arcus.Messaging.Tests.Integration.ServiceBus
         /// <summary>
         /// Initializes a new instance of the <see cref="ServiceBusClient"/> class.
         /// </summary>
+        /// <param name="configuration">The configuration instance to provide the necessary information during authentication with the correct Azure Service Bus instance.</param>
+        /// <param name="logger">The instance to log diagnostic messages during the interaction with the Azure Service Bus instance.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="configuration"/> or the <paramref name="logger"/> is <c>null</c>.</exception>
         public ServiceBusClient(KeyRotationConfig configuration, ITestOutputHelper logger)
         {
             Guard.NotNull(configuration, nameof(configuration));


### PR DESCRIPTION
Change the key rotation by using the Azure Service Bus Primary connection string key first and moving on to the Secondary connection string key on rotation.

Closes #100 