### PR TITLE
Feature - add fallback message handler as safety net during message handing

### DIFF
--- a/docs/preview/features/message-pumps/customization.md
+++ b/docs/preview/features/message-pumps/customization.md
@@ -75,6 +75,7 @@ public void ConfigureServices(IServiceCollection services)
 ## Fallback message handling
 
 When receiving a message on the message pump and none of the registered `IMessageHandler`'s can correctly process the message, the message pump normally throws and logs an exception.
+
 It could also happen in a scenario that's to be expected that some received messages will not be processed correctly (or you don't want them to).
 
 In such a scenario, you can choose to register a `IFallbackMessageHandler` in the dependency container. 

--- a/docs/preview/features/message-pumps/customization.md
+++ b/docs/preview/features/message-pumps/customization.md
@@ -78,7 +78,7 @@ When receiving a message on the message pump and none of the registered `IMessag
 It could also happen in a scenario that's to be expected that some received messages will not be processed correctly (or you don't want them to).
 
 In such a scenario, you can choose to register a `IFallbackMessageHandler` in the dependency container. 
-This extra message handler will then process the remaining messages that can't be processed byt the normal message handlers.
+This extra message handler will then process the remaining messages that can't be processed by the normal message handlers.
 
 Following example shows how such a message handler can be implemented:
 

--- a/docs/preview/features/message-pumps/customization.md
+++ b/docs/preview/features/message-pumps/customization.md
@@ -72,4 +72,40 @@ public void ConfigureServices(IServiceCollection services)
 > Note that the order in which the message handlers are registered is important in the message processing.
 > In the example, when a message handler above this one is registered that could also handle the message (same message type) than that handler may be chosen instead of the one with the specific filter.
 
+## Fallback message handling
+
+When receiving a message on the message pump and none of the registered `IMessageHandler`'s can correctly process the message, the message pump normally throws and logs an exception.
+It could also happen in a scenario that's to be expected that some received messages will not be processed correctly (or you don't want them to).
+
+In such a scenario, you can choose to register a `IFallbackMessageHandler` in the dependency container. 
+This extra message handler will then process the remaining messages that can't be processed byt the normal message handlers.
+
+Following example shows how such a message handler can be implemented:
+
+```csharp
+public class WarnsUserFallbackMessageHandler : IFallbackMessageHandller
+{
+    private readonly ILogger _logger;
+
+    public WarnsUserFallbackMessageHandler(ILogger<WarnsUserFallbackMessageHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task ProcessMessageAsync(string message, MessageContext context, ...)
+    {
+        _logger.LogWarning("These type of messages are expected not to be processed");
+    }
+}
+```
+
+And to register such an implementation:
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.WithFallbackMessageHandler<WarnsUserFallbackMessageHandler>();
+}
+```
+
 [&larr; back](/)

--- a/docs/preview/features/message-pumps/service-bus.md
+++ b/docs/preview/features/message-pumps/service-bus.md
@@ -164,6 +164,44 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
+## Fallback message handling
+
+When receiving a message on the message pump and none of the registered `IAzureServiceBusMessageHandler`'s can correctly process the message, the message pump normally throws and logs an exception.
+It could also happen in a scenario that's to be expected that some received messages will not be processed correctly (or you don't want them to).
+
+In such a scenario, you can choose to register a `IAzureServiceBusFallbackMessageHandler` in the dependency container. 
+This extra message handler will then process the remaining messages that can't be processed by the normal message handlers.
+
+Following example shows how such a message handler can be implemented:
+
+```csharp
+public class WarnsUserFallbackMessageHandler : IAzureServiceBusFallbackMessageHandller
+{
+    private readonly ILogger _logger;
+
+    public WarnsUserFallbackMessageHandler(ILogger<WarnsUserFallbackMessageHandler> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task ProcessMessageAsync(Message message, AzureServiceBusMessageContext context, ...)
+    {
+        _logger.LogWarning("These type of messages are expected not to be processed");
+    }
+}
+```
+
+> Note that you have access to the Azure Service Bus message and the specific message context. These can be used to eventually call `.Abandon()` on the message.
+
+And to register such an implementation:
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.WithServiceBusFallbackMessageHandler<WarnsUserFallbackMessageHandler>();
+}
+```
+
 ## Correlation
 
 To retrieve the correlation information of Azure Service Bus messages, we provide an extension that wraps all correlation information.

--- a/src/Arcus.Messaging.Pumps.Abstractions/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/Extensions/IServiceCollectionExtensions.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
+using GuardNet;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Arcus.Messaging.Pumps.Abstractions.Extensions
+{
+    /// <summary>
+    /// Extensions on the <see cref="IServiceCollection"/> related to message pumps.
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    public static class IServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds an <see cref="IFallbackMessageHandler"/> implementation which the message pump can use to fall back to when no message handler is found to process the message.
+        /// </summary>
+        /// <typeparam name="TMessageHandler">The type of the fallback message handler.</typeparam>
+        /// <param name="services">The services to add the fallback message handler to.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
+        public static IServiceCollection WithFallbackMessageHandler<TMessageHandler>(this IServiceCollection services)
+            where TMessageHandler : class, IFallbackMessageHandler
+        {
+            Guard.NotNull(services, nameof(services), "Requires a services collection to add the fallback message handler to");
+
+            return services.AddSingleton<IFallbackMessageHandler, TMessageHandler>();
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IFallbackMessageHandler"/> implementation which the message pump can use to fall back to when no message handler is found to process the message.
+        /// </summary>
+        /// <typeparam name="TMessageHandler">The type of the fallback message handler.</typeparam>
+        /// <param name="services">The services to add the fallback message handler to.</param>
+        /// <param name="createImplementation">The function to create the fallback message handler.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or the <paramref name="createImplementation"/> is <c>null</c>.</exception>
+        public static IServiceCollection WithFallbackMessageHandler<TMessageHandler>(
+            this IServiceCollection services,
+            Func<IServiceProvider, TMessageHandler> createImplementation)
+            where TMessageHandler : IFallbackMessageHandler
+        {
+            Guard.NotNull(services, nameof(services), "Requires a services collection to add the fallback message handler to");
+            Guard.NotNull(createImplementation, nameof(createImplementation), "Requires a function to create the fallback message handler");
+
+            return services.AddSingleton(createImplementation);
+        }
+    }
+}

--- a/src/Arcus.Messaging.Pumps.Abstractions/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/Extensions/IServiceCollectionExtensions.cs
@@ -35,12 +35,12 @@ namespace Arcus.Messaging.Pumps.Abstractions.Extensions
         public static IServiceCollection WithFallbackMessageHandler<TMessageHandler>(
             this IServiceCollection services,
             Func<IServiceProvider, TMessageHandler> createImplementation)
-            where TMessageHandler : IFallbackMessageHandler
+            where TMessageHandler : class, IFallbackMessageHandler
         {
             Guard.NotNull(services, nameof(services), "Requires a services collection to add the fallback message handler to");
             Guard.NotNull(createImplementation, nameof(createImplementation), "Requires a function to create the fallback message handler");
 
-            return services.AddSingleton(createImplementation);
+            return services.AddSingleton<IFallbackMessageHandler, TMessageHandler>(createImplementation);
         }
     }
 }

--- a/src/Arcus.Messaging.Pumps.Abstractions/MessageHandling/IFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/MessageHandling/IFallbackMessageHandler.cs
@@ -1,0 +1,28 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
+
+namespace Arcus.Messaging.Pumps.Abstractions.MessageHandling
+{
+    /// <summary>
+    /// Fallback version of the <see cref="IMessageHandler{TMessage,TMessageContext}"/> to have a safety net when no handlers are found could process the message.
+    /// </summary>
+    public interface IFallbackMessageHandler
+    {
+        /// <summary>
+        ///     Process a new message that was received
+        /// </summary>
+        /// <param name="message">Message that was received</param>
+        /// <param name="messageContext">Context providing more information concerning the processing</param>
+        /// <param name="correlationInfo">
+        ///     Information concerning correlation of telemetry and processes by using a variety of unique
+        ///     identifiers
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        Task ProcessMessageAsync(
+            string message,
+            MessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken);
+    }
+}

--- a/src/Arcus.Messaging.Pumps.Abstractions/MessageHandling/MessageHandler.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/MessageHandling/MessageHandler.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Arcus.Messaging.Abstractions;
 using GuardNet;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Arcus.Messaging.Pumps.Abstractions.MessageHandling
 {
@@ -18,21 +19,29 @@ namespace Arcus.Messaging.Pumps.Abstractions.MessageHandling
     public class MessageHandler
     {
         private readonly object _service;
-        private readonly Type _serviceType;
+        private readonly ILogger _logger;
 
-        private MessageHandler(Type serviceType, object service)
+        private MessageHandler(Type serviceType, object service, ILogger logger)
         {
-            Guard.NotNull(serviceType, nameof(serviceType));
-            Guard.NotNull(service, nameof(service));
+            Guard.NotNull(serviceType, nameof(serviceType), "Requires a message handler type");
+            Guard.NotNull(service, nameof(service), "Requires a message handler instance");
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance");
             Guard.For<ArgumentException>(
                 () => serviceType.GenericTypeArguments.Length != 2, 
                 $"Message handler type '{serviceType.Name}' has not the expected 2 generic type arguments");
-
-            _serviceType = serviceType;
+            
             _service = service;
+            _logger = logger;
 
-            MessageType = _serviceType.GenericTypeArguments[0];
+            ServiceType = serviceType;
+            MessageType = ServiceType.GenericTypeArguments[0];
+            MessageContextType = ServiceType.GenericTypeArguments[1];
         }
+
+        /// <summary>
+        /// Gets the type of the message handler that this abstracted message handler represents.
+        /// </summary>
+        internal Type ServiceType { get; }
 
         /// <summary>
         /// Gets the type of the message that this abstracted message handler can process.
@@ -40,12 +49,19 @@ namespace Arcus.Messaging.Pumps.Abstractions.MessageHandling
         internal Type MessageType { get; }
 
         /// <summary>
+        /// Gets the type of the message context that this abstracted message handler can process.
+        /// </summary>
+        internal Type MessageContextType { get; }
+
+        /// <summary>
         /// Subtract all the <see cref="IMessageHandler{TMessage,TMessageContext}"/> implementations from the given <paramref name="serviceProvider"/>.
         /// </summary>
         /// <param name="serviceProvider">The provided registered services collection.</param>
-        public static IEnumerable<MessageHandler> SubtractFrom(IServiceProvider serviceProvider)
+        /// <param name="logger">The logger instance to write diagnostic trace messages during the lifetime of the message handlers.</param>
+        public static IEnumerable<MessageHandler> SubtractFrom(IServiceProvider serviceProvider, ILogger logger)
         {
-            Guard.NotNull(serviceProvider, nameof(serviceProvider));
+            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires a collection of services to subtract the message handlers from");
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to write trace messages during the lifetime of the message handlers");
 
             object engine = 
                 serviceProvider.GetType().GetProperty("Engine")?.GetValue(serviceProvider) 
@@ -64,7 +80,7 @@ namespace Arcus.Messaging.Pumps.Abstractions.MessageHandling
                     IEnumerable<object> services = serviceProvider.GetServices(serviceType);
                     foreach (object service in services)
                     {
-                        var messageHandler = new MessageHandler(serviceType, service);
+                        var messageHandler = new MessageHandler(serviceType, service, logger);
                         messageHandlers.Add(messageHandler);
                     }
                 }
@@ -79,19 +95,40 @@ namespace Arcus.Messaging.Pumps.Abstractions.MessageHandling
         /// <typeparam name="TMessageContext">The type of the message context.</typeparam>
         public bool CanProcessMessage<TMessageContext>(TMessageContext messageContext) where TMessageContext : MessageContext
         {
-            if (typeof(TMessageContext) == _serviceType.GenericTypeArguments[1])
+            Type expectedMessageContextType = ServiceType.GenericTypeArguments[1];
+            Type actualMessageContextType = typeof(TMessageContext);
+
+            if (actualMessageContextType == expectedMessageContextType)
             {
+                _logger.LogInformation(
+                    "Message context type '{ActualMessageContextType}' matches registered message handler's {MessageHandlerType} context type {ExpectedMessageContextType}",
+                    actualMessageContextType.Name, ServiceType.Name, expectedMessageContextType.Name);
+
                 if (_service.GetType().Name == typeof(MessageHandlerRegistration<,>).Name)
                 {
-                    return (bool) _service.InvokeMethod(
+                    _logger.LogTrace(
+                        "Determining whether the message context predicate registered with the message handler {MessageHandlerType} holds...",
+                         ServiceType.Name);
+
+                    var canProcessMessage = (bool) _service.InvokeMethod(
                         "CanProcessMessage",
                         BindingFlags.Instance | BindingFlags.NonPublic,
                         messageContext);
+
+                    _logger.LogInformation(
+                        "Message context predicate registered with the message handler {MessageHandlerType} resulted in {Result}, so {Action} process this message",
+                        ServiceType.Name, canProcessMessage, canProcessMessage ? "can" : "can't");
+
+                    return canProcessMessage;
                 }
 
                 // Message context type matches registration message context type; registered without predicate.
                 return true;
             }
+
+            _logger.LogInformation(
+                "Message context type '{ActualMessageContextType}' doesn't matches registered message handler's {MessageHandlerType} context type {ExpectedMessageContextType}",
+                actualMessageContextType.Name, ServiceType.Name, expectedMessageContextType.Name);
 
             // Message context type doesn't match registration message context type.
             return false;
@@ -124,6 +161,10 @@ namespace Arcus.Messaging.Pumps.Abstractions.MessageHandling
             Guard.NotNull(messageContext, nameof(messageContext), "Requires a message context to send to the message handler");
             Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires correlation information to send to the message handler");
 
+            _logger.LogTrace(
+                "Start processing '{MessageType}' message in message handler '{MessageHandlerType}'...", 
+                message.GetType().Name, ServiceType.Name);
+
             const string methodName = "ProcessMessageAsync";
             try
             {
@@ -138,12 +179,18 @@ namespace Arcus.Messaging.Pumps.Abstractions.MessageHandling
                 }
 
                 await processMessageAsync;
+
+                _logger.LogInformation(
+                    "Message handler '{MessageHandlerType}' successfully processed '{MessageType}' message", ServiceType.Name, MessageType.Name);
             }
             catch (AmbiguousMatchException exception)
             {
+                _logger.LogError(
+                    "Ambiguous match found of '{MethodName}' methods in the '{MessageHandlerType}'. Make sure that only 1 matching '{MethodName}' was found on the '{MessageHandlerType}' message handler",
+                    methodName, ServiceType.Name, methodName, ServiceType.Name);
+
                 throw new AmbiguousMatchException(
-                    $"Ambiguous match found of '{methodName}' methods in the '{_service.GetType().Name}'. "
-                    + $"Make sure that only 1 matching '{methodName}' method was found on the message handler implementation", exception);
+                    $"Ambiguous match found of '{methodName}' methods in the '{_service.GetType().Name}'. ", exception);
             }
         }
     }

--- a/src/Arcus.Messaging.Pumps.Abstractions/MessageHandling/MessageHandlerResult.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/MessageHandling/MessageHandlerResult.cs
@@ -11,8 +11,8 @@ namespace Arcus.Messaging.Pumps.Abstractions.MessageHandling
         private MessageHandlerResult(bool isProcessed, Exception exception)
         {
             Guard.For<ArgumentException>(
-                () => !isProcessed && exception is null, 
-                "Requires an exception when the message handler result is a failure");
+                () => isProcessed && exception != null, 
+                "Requires an no exception when the message handler result is a success");
 
             IsProcessed = isProcessed;
             Exception = exception;

--- a/src/Arcus.Messaging.Pumps.Abstractions/MessageHandling/MessageHandlerResult.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/MessageHandling/MessageHandlerResult.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using GuardNet;
+
+namespace Arcus.Messaging.Pumps.Abstractions.MessageHandling
+{
+    /// <summary>
+    /// Result data type to represent the outcome of the message handling processing in the <see cref="MessagePump.ProcessMessageAndCaptureAsync{TMessageContext}"/>.
+    /// </summary>
+    public class MessageHandlerResult
+    {
+        private MessageHandlerResult(bool isProcessed, Exception exception)
+        {
+            Guard.For<ArgumentException>(
+                () => !isProcessed && exception is null, 
+                "Requires an exception when the message handler result is a failure");
+
+            IsProcessed = isProcessed;
+            Exception = exception;
+        }
+
+        /// <summary>
+        /// Gets the flag indicating whether the message pump was able to process the message or not.
+        /// </summary>
+        public bool IsProcessed { get; }
+
+        /// <summary>
+        /// Gets the (optional) exception that was thrown during the message processing.
+        /// Only available when their was an exception thrown.
+        /// </summary>
+        public Exception Exception { get; }
+
+        /// <summary>
+        /// Creates an <see cref="MessageHandlerResult"/> instance that means that an <see cref="IMessageHandler{TMessage,TMessageContext}"/> was able to process the message.
+        /// </summary>
+        public static MessageHandlerResult Success()
+        {
+            return new MessageHandlerResult(isProcessed: true, exception: null);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="MessageHandlerResult"/> instance that means that no <see cref="IMessageHandler{TMessage,TMessageContext}"/> was found to process the message.
+        /// A custom fallback mechanism could happen in this case.
+        /// </summary>
+        public static MessageHandlerResult Pending()
+        {
+            return new MessageHandlerResult(isProcessed: false, exception: null);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="MessageHandlerResult"/> instance that means that an exception was thrown during the message processing either in an specific <see cref="IMessageHandler{TMessage,TMessageContext}"/>
+        /// or in the message processing logic itself.
+        /// </summary>
+        /// <param name="exception">The exception that was thrown.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="exception"/> is <c>null</c>.</exception>
+        public static MessageHandlerResult Failure(Exception exception)
+        {
+            Guard.NotNull(exception, nameof(exception), "Requires an exception when the message handler result is a failure");
+            return new MessageHandlerResult(isProcessed: false, exception: exception);
+        }
+    }
+}

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -6,8 +6,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Pumps.Abstractions;
+using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
 using Arcus.Messaging.Pumps.Abstractions.Telemetry;
 using Arcus.Messaging.Pumps.ServiceBus.Configuration;
+using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
 using Arcus.Observability.Correlation;
 using GuardNet;
 using Microsoft.Azure.ServiceBus;
@@ -25,6 +27,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
     /// </summary>
     public class AzureServiceBusMessagePump : MessagePump
     {
+        private readonly IAzureServiceBusFallbackMessageHandler _fallbackMessageHandler;
         private readonly MessageHandlerOptions _messageHandlerOptions;
         private readonly IDisposable _loggingScope;
         
@@ -51,6 +54,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             JobId = Settings.Options.JobId;
             SubscriptionName = Settings.SubscriptionName;
 
+            _fallbackMessageHandler = ServiceProvider.GetService<IAzureServiceBusFallbackMessageHandler>();
             _messageHandlerOptions = DetermineMessageHandlerOptions(Settings);
             _loggingScope = logger.BeginScope("Job: {JobId}", JobId);
         }
@@ -451,7 +455,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
 
         private async Task HandleMessageAsync(Message message, CancellationToken cancellationToken)
         {
-            if (message == null)
+            if (message is null)
             {
                 Logger.LogWarning("Received message was null, skipping");
                 return;
@@ -465,14 +469,13 @@ namespace Arcus.Messaging.Pumps.ServiceBus
                 return;
             }
 
+            if (String.IsNullOrEmpty(message.CorrelationId))
+            {
+                Logger.LogInformation("No operation ID was found on the message");
+            }
+
             try
             {
-                if (String.IsNullOrEmpty(message.CorrelationId))
-                {
-                    Logger.LogInformation("No operation ID was found on the message");
-                }
-
-
                 MessageCorrelationInfo correlationInfo = message.GetCorrelationInfo();
                 using (IServiceScope serviceScope = ServiceProvider.CreateScope())
                 {
@@ -482,14 +485,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
                     using (LogContext.Push(new MessageCorrelationInfoEnricher(correlationInfoAccessor)))
                     {
                         Logger.LogInformation("Received message '{MessageId}'", message.MessageId);
-
-                        var messageContext = new AzureServiceBusMessageContext(message.MessageId, message.SystemProperties, message.UserProperties);
-
-                        Encoding encoding = messageContext.GetMessageEncodingProperty(Logger);
-                        string messageBody = encoding.GetString(message.Body);
-
-                        await ProcessMessageAsync(messageBody, messageContext, correlationInfo, cancellationToken);
-
+                        await ProcessMessageAsync(message, cancellationToken, correlationInfo);
                         Logger.LogInformation("Message {MessageId} processed", message.MessageId);
                     }
                 }
@@ -498,6 +494,34 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             {
                 Logger.LogCritical(ex, "Unable to process message with ID '{MessageId}'",  message.MessageId);
                 await HandleReceiveExceptionAsync(ex);
+            }
+        }
+
+        private async Task ProcessMessageAsync(
+            Message message,
+            CancellationToken cancellationToken,
+            MessageCorrelationInfo correlationInfo)
+        {
+            var messageContext = new AzureServiceBusMessageContext(message.MessageId, message.SystemProperties, message.UserProperties);
+            Encoding encoding = messageContext.GetMessageEncodingProperty(Logger);
+            string messageBody = encoding.GetString(message.Body);
+
+            if (_fallbackMessageHandler is null)
+            {
+                await ProcessMessageAsync(messageBody, messageContext, correlationInfo, cancellationToken);
+            }
+            else
+            {
+                MessageHandlerResult result = await ProcessMessageAndCaptureAsync(messageBody, messageContext, correlationInfo, cancellationToken);
+                if (result.Exception != null)
+                {
+                    throw result.Exception;
+                }
+
+                if (!result.IsProcessed)
+                {
+                    await _fallbackMessageHandler.ProcessMessageAsync(message, messageContext, correlationInfo, cancellationToken);
+                }
             }
         }
 

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
 using Arcus.Messaging.Pumps.ServiceBus;
 using Arcus.Messaging.Pumps.ServiceBus.Configuration;
+using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
 using Arcus.Security.Core;
 using GuardNet;
 using Microsoft.Extensions.Configuration;
@@ -771,6 +772,39 @@ namespace Microsoft.Extensions.DependencyInjection
             Guard.NotNull(implementationFactory, nameof(implementationFactory));
 
             return services.WithMessageHandler<TMessageHandler, TMessage, AzureServiceBusMessageContext>(messageContextFilter, implementationFactory);
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IAzureServiceBusFallbackMessageHandler"/> implementation which the message pump can use to fall back to when no message handler is found to process the message.
+        /// </summary>
+        /// <typeparam name="TMessageHandler">The type of the fallback message handler.</typeparam>
+        /// <param name="services">The services to add the fallback message handler to.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
+        public static IServiceCollection WithServiceBusFallbackMessageHandler<TMessageHandler>(
+            this IServiceCollection services)
+            where TMessageHandler : class, IAzureServiceBusFallbackMessageHandler
+        {
+            Guard.NotNull(services, nameof(services), "Requires a services collection to add the Azure Service Bus fallback message handler to");
+
+            return services.AddSingleton<IAzureServiceBusFallbackMessageHandler, TMessageHandler>();
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IAzureServiceBusFallbackMessageHandler"/> implementation which the message pump can use to fall back to when no message handler is found to process the message.
+        /// </summary>
+        /// <typeparam name="TMessageHandler">The type of the fallback message handler.</typeparam>
+        /// <param name="services">The services to add the fallback message handler to.</param>
+        /// <param name="createImplementation">The function to create the fallback message handler.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or the <paramref name="createImplementation"/> is <c>null</c>.</exception>
+        public static IServiceCollection WithServiceBusFallbackMessageHandler<TMessageHandler>(
+            this IServiceCollection services,
+            Func<IServiceProvider, TMessageHandler> createImplementation)
+            where TMessageHandler : class, IAzureServiceBusFallbackMessageHandler
+        {
+            Guard.NotNull(services, nameof(services), "Requires a services collection to add the fallback message handler to");
+            Guard.NotNull(createImplementation, nameof(createImplementation), "Requires a function to create the fallback message handler");
+
+            return services.AddSingleton<IAzureServiceBusFallbackMessageHandler, TMessageHandler>(createImplementation);
         }
     }
 }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/IAzureServiceBusFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/IAzureServiceBusFallbackMessageHandler.cs
@@ -1,27 +1,28 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using Arcus.Messaging.Abstractions;
+using Microsoft.Azure.ServiceBus;
 
-namespace Arcus.Messaging.Pumps.Abstractions.MessageHandling
+namespace Arcus.Messaging.Pumps.ServiceBus.MessageHandling
 {
     /// <summary>
-    /// Fallback version of the <see cref="IMessageHandler{TMessage,TMessageContext}"/> to have a safety net when no handlers are found could process the message.
+    /// Fallback version of the <see cref="IAzureServiceBusMessageHandler{TMessage}"/> to have a safety net when no handlers are found could process the message.
     /// </summary>
-    public interface IFallbackMessageHandler
+    public interface IAzureServiceBusFallbackMessageHandler
     {
         /// <summary>
         ///     Process a new message that was received
         /// </summary>
-        /// <param name="message">The message that was received.</param>
-        /// <param name="messageContext">The context providing more information concerning the processing.</param>
+        /// <param name="message">The Azure Service Bus Message message that was received</param>
+        /// <param name="messageContext">The context providing more information concerning the processing</param>
         /// <param name="correlationInfo">
         ///     The information concerning correlation of telemetry and processes by using a variety of unique
         ///     identifiers.
         /// </param>
         /// <param name="cancellationToken">The cancellation token to cancel the processing.</param>
         Task ProcessMessageAsync(
-            string message,
-            MessageContext messageContext,
+            Message message,
+            AzureServiceBusMessageContext messageContext,
             MessageCorrelationInfo correlationInfo,
             CancellationToken cancellationToken);
     }

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueWithFallbackProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueWithFallbackProgram.cs
@@ -1,0 +1,51 @@
+using Arcus.EventGrid.Publishing;
+using Arcus.Messaging.Pumps.Abstractions.Extensions;
+using Arcus.Messaging.Tests.Core.Messages.v1;
+using Arcus.Messaging.Tests.Workers.MessageHandlers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+// ReSharper disable once CheckNamespace
+namespace Arcus.Messaging.Tests.Workers.ServiceBus
+{
+    public class ServiceBusQueueWithFallbackProgram
+    {
+        public static void main(string[] args)
+        {
+            CreateHostBuilder(args)
+                .Build()
+                .Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration(configuration =>
+                {
+                    configuration.AddCommandLine(args);
+                    configuration.AddEnvironmentVariables();
+                })
+                .ConfigureLogging(loggingBuilder => loggingBuilder.AddConsole(options => options.IncludeScopes = true))
+                .ConfigureServices((hostContext, services) =>
+                {
+                    services.AddTransient(svc =>
+                    {
+                        var configuration = svc.GetRequiredService<IConfiguration>();
+                        var eventGridTopic = configuration.GetValue<string>("EVENTGRID_TOPIC_URI");
+                        var eventGridKey = configuration.GetValue<string>("EVENTGRID_AUTH_KEY");
+
+                        return EventGridPublisherBuilder
+                               .ForTopic(eventGridTopic)
+                               .UsingAuthenticationKey(eventGridKey)
+                               .Build();
+                    });
+                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
+                            .WithServiceBusMessageHandler<PassThruOrderMessageHandler, Order>(context => false)
+                            .WithFallbackMessageHandler<OrdersFallbackMessageHandler>();
+
+                    services.AddTcpHealthProbes("ARCUS_HEALTH_PORT", builder => builder.AddCheck("sample", () => HealthCheckResult.Healthy()));
+                });
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueWithServiceBusFallbackProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueWithServiceBusFallbackProgram.cs
@@ -1,0 +1,51 @@
+using Arcus.EventGrid.Publishing;
+using Arcus.Messaging.Pumps.Abstractions.Extensions;
+using Arcus.Messaging.Tests.Core.Messages.v1;
+using Arcus.Messaging.Tests.Workers.MessageHandlers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+// ReSharper disable once CheckNamespace
+namespace Arcus.Messaging.Tests.Workers.ServiceBus
+{
+    public class ServiceBusQueueWithServiceBusFallbackProgram
+    {
+        public static void main(string[] args)
+        {
+            CreateHostBuilder(args)
+                .Build()
+                .Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration(configuration =>
+                {
+                    configuration.AddCommandLine(args);
+                    configuration.AddEnvironmentVariables();
+                })
+                .ConfigureLogging(loggingBuilder => loggingBuilder.AddConsole(options => options.IncludeScopes = true))
+                .ConfigureServices((hostContext, services) =>
+                {
+                    services.AddTransient(svc =>
+                    {
+                        var configuration = svc.GetRequiredService<IConfiguration>();
+                        var eventGridTopic = configuration.GetValue<string>("EVENTGRID_TOPIC_URI");
+                        var eventGridKey = configuration.GetValue<string>("EVENTGRID_AUTH_KEY");
+
+                        return EventGridPublisherBuilder
+                               .ForTopic(eventGridTopic)
+                               .UsingAuthenticationKey(eventGridKey)
+                               .Build();
+                    });
+                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
+                            .WithServiceBusMessageHandler<PassThruOrderMessageHandler, Order>(context => false)
+                            .WithServiceBusFallbackMessageHandler<OrdersServiceBusFallbackMessageHandler>();
+
+                    services.AddTcpHealthProbes("ARCUS_HEALTH_PORT", builder => builder.AddCheck("sample", () => HealthCheckResult.Healthy()));
+                });
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -104,6 +104,31 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
         }
 
         [Fact]
+        public async Task ServiceBusMessagePumpWithServiceBusFallback_PublishServiceBusMessage_MessageSuccessfullyProcessed()
+        {
+            // Arrange
+            var config = TestConfig.Create();
+            string connectionString = config.GetServiceBusConnectionString(ServiceBusEntity.Queue);
+
+            var commandArguments = new[]
+            {
+                CommandArgument.CreateSecret("EVENTGRID_TOPIC_URI", config.GetTestInfraEventGridTopicUri()),
+                CommandArgument.CreateSecret("EVENTGRID_AUTH_KEY", config.GetTestInfraEventGridAuthKey()),
+                CommandArgument.CreateSecret("ARCUS_SERVICEBUS_CONNECTIONSTRING", connectionString),
+            };
+
+            using (var project = await ServiceBusWorkerProject.StartNewWithAsync<ServiceBusQueueWithServiceBusFallbackProgram>(config, _logger, commandArguments))
+            {
+                await using (var service = await TestMessagePumpService.StartNewAsync(config, _logger))
+                {
+                    // Act / Assert
+                    await service.SimulateMessageProcessingAsync(connectionString);
+                }
+            }
+        }
+
+
+        [Fact]
         public async Task ServiceBusMessagePump_RotateServiceBusConnectionKeys_MessagePumpRestartsThenMessageSuccessfullyProcessed()
         {
             // Arrange

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -80,6 +80,30 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
         }
 
         [Fact]
+        public async Task ServiceBusMessagePumpWithFallback_PublishServiceBusMessage_MessageSuccessfullyProcessed()
+        {
+            // Arrange
+            var config = TestConfig.Create();
+            string connectionString = config.GetServiceBusConnectionString(ServiceBusEntity.Queue);
+
+            var commandArguments = new[]
+            {
+                CommandArgument.CreateSecret("EVENTGRID_TOPIC_URI", config.GetTestInfraEventGridTopicUri()),
+                CommandArgument.CreateSecret("EVENTGRID_AUTH_KEY", config.GetTestInfraEventGridAuthKey()),
+                CommandArgument.CreateSecret("ARCUS_SERVICEBUS_CONNECTIONSTRING", connectionString),
+            };
+
+            using (var project = await ServiceBusWorkerProject.StartNewWithAsync<ServiceBusQueueWithFallbackProgram>(config, _logger, commandArguments))
+            {
+                await using (var service = await TestMessagePumpService.StartNewAsync(config, _logger))
+                {
+                    // Act / Assert
+                    await service.SimulateMessageProcessingAsync(connectionString);
+                }
+            }
+        }
+
+        [Fact]
         public async Task ServiceBusMessagePump_RotateServiceBusConnectionKeys_MessagePumpRestartsThenMessageSuccessfullyProcessed()
         {
             // Arrange

--- a/src/Arcus.Messaging.Tests.Unit/Fixture/PassThruFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Unit/Fixture/PassThruFallbackMessageHandler.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
+
+namespace Arcus.Messaging.Tests.Unit.Fixture
+{
+    /// <summary>
+    /// Test version of the <see cref="IFallbackMessageHandler"/> to have a solid implementation.
+    /// </summary>
+    public class PassThruFallbackMessageHandler : IFallbackMessageHandler
+    {
+        /// <summary>
+        ///     Process a new message that was received
+        /// </summary>
+        /// <param name="message">Message that was received</param>
+        /// <param name="messageContext">Context providing more information concerning the processing</param>
+        /// <param name="correlationInfo">
+        ///     Information concerning correlation of telemetry and processes by using a variety of unique
+        ///     identifiers
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        public Task ProcessMessageAsync(
+            string message,
+            MessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Unit/Fixture/PassThruServiceBusFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Unit/Fixture/PassThruServiceBusFallbackMessageHandler.cs
@@ -1,0 +1,35 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
+using Microsoft.Azure.ServiceBus;
+
+namespace Arcus.Messaging.Tests.Unit.Fixture
+{
+    /// <summary>
+    /// Test version of the <see cref="IFallbackMessageHandler"/> to have a solid implementation.
+    /// </summary>
+    public class PassThruServiceBusFallbackMessageHandler : IAzureServiceBusFallbackMessageHandler
+    {
+        /// <summary>
+        ///     Process a new message that was received
+        /// </summary>
+        /// <param name="message">Message that was received</param>
+        /// <param name="messageContext">Context providing more information concerning the processing</param>
+        /// <param name="correlationInfo">
+        ///     Information concerning correlation of telemetry and processes by using a variety of unique
+        ///     identifiers
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        public Task ProcessMessageAsync(
+            Message message,
+            AzureServiceBusMessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/IServiceCollectionTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/IServiceCollectionTests.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using Arcus.Messaging.Pumps.Abstractions.Extensions;
+using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
+using Arcus.Messaging.Tests.Unit.Fixture;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Arcus.Messaging.Tests.Unit.MessageHandling
+{
+    public class IServiceCollectionTests
+    {
+        [Fact]
+        public void WithFallbackMessageHandler_WithValidType_RegistersInterface()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.WithFallbackMessageHandler<PassThruFallbackMessageHandler>();
+
+            // Assert
+            IServiceProvider provider = services.BuildServiceProvider();
+            var messageHandler = provider.GetRequiredService<IFallbackMessageHandler>();
+
+            Assert.IsType<PassThruFallbackMessageHandler>(messageHandler);
+        }
+
+        [Fact]
+        public void WithFallbackMessageHandler_WithValidImplementationFunction_RegistersInterface()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var expected = new PassThruFallbackMessageHandler();
+
+            // Act
+            services.WithFallbackMessageHandler(serviceProvider => expected);
+
+            // Assert
+            IServiceProvider provider = services.BuildServiceProvider();
+            var actual = provider.GetRequiredService<IFallbackMessageHandler>();
+
+            Assert.Same(expected, actual);
+        }
+
+        [Fact]
+        public void WithFallbackMessageHandlerType_WithoutServices_Throws()
+        {
+            Assert.ThrowsAny<ArgumentException>(
+                () => ((IServiceCollection) null).WithFallbackMessageHandler<PassThruFallbackMessageHandler>());
+        }
+
+        [Fact]
+        public void WithFallbackMessageHandlerImplementationFunction_WithoutServices_Throws()
+        {
+            Assert.ThrowsAny<ArgumentException>(
+                () => ((IServiceCollection) null).WithFallbackMessageHandler(serviceProvider => new PassThruFallbackMessageHandler()));
+        }
+
+        [Fact]
+        public void WithFallbackMessageHandlerImplementationFunction_WithoutImplementationFunction_Throws()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => services.WithFallbackMessageHandler(createImplementation: (Func<IServiceProvider, PassThruFallbackMessageHandler>) null));
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/MessageHandlerTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/MessageHandlerTests.cs
@@ -7,13 +7,17 @@ using System.Threading.Tasks;
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
 using Arcus.Messaging.Tests.Unit.Fixture;
+using Arcus.Testing.Logging;
 using Bogus;
 using Microsoft.Azure.ServiceBus;
 using Microsoft.Extensions.Configuration.EnvironmentVariables;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Newtonsoft.Json;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Arcus.Messaging.Tests.Unit.MessageHandling
 {
@@ -21,6 +25,15 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling
     public class MessageHandlerTests
     {
         private readonly Faker _bogusGenerator = new Faker();
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessageHandlerTests"/> class.
+        /// </summary>
+        public MessageHandlerTests(ITestOutputHelper outputWriter)
+        {
+            _logger = new XunitTestLogger(outputWriter);
+        }
 
         [Fact]
         public async Task CustomMessageHandlerConstructor_WithDefaultContext_SubtractsRegistration()
@@ -31,7 +44,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling
             IServiceProvider serviceProvider = services.BuildServiceProvider();
 
             // Act
-            IEnumerable<MessageHandler> messageHandlers = MessageHandler.SubtractFrom(serviceProvider);
+            IEnumerable<MessageHandler> messageHandlers = MessageHandler.SubtractFrom(serviceProvider, _logger);
 
             // Assert
             MessageHandler messageHandler = Assert.Single(messageHandlers);
@@ -53,7 +66,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling
             IServiceProvider serviceProvider = services.BuildServiceProvider();
 
             // Act
-            IEnumerable<MessageHandler> messageHandlers = MessageHandler.SubtractFrom(serviceProvider);
+            IEnumerable<MessageHandler> messageHandlers = MessageHandler.SubtractFrom(serviceProvider, _logger);
 
             // Assert
             MessageHandler messageHandler = Assert.Single(messageHandlers);
@@ -75,7 +88,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling
             IServiceProvider serviceProvider = services.BuildServiceProvider();
 
             // Act
-            IEnumerable<MessageHandler> messageHandlers = MessageHandler.SubtractFrom(serviceProvider);
+            IEnumerable<MessageHandler> messageHandlers = MessageHandler.SubtractFrom(serviceProvider, _logger);
 
             // Assert
             MessageHandler messageHandler = Assert.Single(messageHandlers);
@@ -98,7 +111,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling
             ServiceProvider serviceProvider = services.BuildServiceProvider();
 
             // Act
-            IEnumerable<MessageHandler> messageHandlers = MessageHandler.SubtractFrom(serviceProvider);
+            IEnumerable<MessageHandler> messageHandlers = MessageHandler.SubtractFrom(serviceProvider, _logger);
 
             // Assert
             MessageHandler messageHandler = Assert.Single(messageHandlers);
@@ -119,7 +132,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling
             ServiceProvider serviceProvider = services.BuildServiceProvider();
 
             // Act
-            IEnumerable<MessageHandler> messageHandlers = MessageHandler.SubtractFrom(serviceProvider);
+            IEnumerable<MessageHandler> messageHandlers = MessageHandler.SubtractFrom(serviceProvider, _logger);
 
             // Assert
             MessageHandler messageHandler = Assert.Single(messageHandlers);
@@ -143,7 +156,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling
             ServiceProvider serviceProvider = services.BuildServiceProvider();
 
             // Act
-            IEnumerable<MessageHandler> messageHandlers = MessageHandler.SubtractFrom(serviceProvider);
+            IEnumerable<MessageHandler> messageHandlers = MessageHandler.SubtractFrom(serviceProvider, _logger);
 
             // Assert
             MessageHandler messageHandler = Assert.Single(messageHandlers);
@@ -164,7 +177,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling
             IServiceProvider serviceProvider = services.BuildServiceProvider();
 
             // Act
-            IEnumerable<MessageHandler> messageHandlers = MessageHandler.SubtractFrom(serviceProvider);
+            IEnumerable<MessageHandler> messageHandlers = MessageHandler.SubtractFrom(serviceProvider, _logger);
 
             // Assert
             MessageHandler messageHandler = Assert.Single(messageHandlers);
@@ -191,7 +204,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling
             ServiceProvider serviceProvider = services.BuildServiceProvider();
 
             // Act
-            IEnumerable<MessageHandler> messageHandlers = MessageHandler.SubtractFrom(serviceProvider);
+            IEnumerable<MessageHandler> messageHandlers = MessageHandler.SubtractFrom(serviceProvider, _logger);
 
             // Assert
             MessageHandler messageHandler = Assert.Single(messageHandlers);
@@ -220,7 +233,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling
             IServiceProvider serviceProvider = services.BuildServiceProvider();
             
             // Act
-            IEnumerable<MessageHandler> messageHandlers = MessageHandler.SubtractFrom(serviceProvider);
+            IEnumerable<MessageHandler> messageHandlers = MessageHandler.SubtractFrom(serviceProvider, _logger);
 
             // Assert
             Assert.Equal(descriptors.Count, messageHandlers.Count());

--- a/src/Arcus.Messaging.Tests.Unit/ServiceBus/IServiceCollectionExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/ServiceBus/IServiceCollectionExtensionsTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Arcus.Messaging.Pumps.Abstractions.Extensions;
 using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
 using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
 using Arcus.Messaging.Tests.Unit.Fixture;
 using Arcus.Security.Core;
 using Microsoft.Extensions.Configuration;
@@ -143,7 +144,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
 
             // Assert
             IServiceProvider provider = services.BuildServiceProvider();
-            var messageHandler = provider.GetRequiredService<IFallbackMessageHandler>();
+            var messageHandler = provider.GetRequiredService<IAzureServiceBusFallbackMessageHandler>();
 
             Assert.IsType<PassThruServiceBusFallbackMessageHandler>(messageHandler);
         }
@@ -160,7 +161,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
 
             // Assert
             IServiceProvider provider = services.BuildServiceProvider();
-            var actual = provider.GetRequiredService<IFallbackMessageHandler>();
+            var actual = provider.GetRequiredService<IAzureServiceBusFallbackMessageHandler>();
 
             Assert.Same(expected, actual);
         }

--- a/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersFallbackMessageHandler.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Mime;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.EventGrid.Publishing.Interfaces;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
+using Arcus.Messaging.Tests.Core.Events.v1;
+using Arcus.Messaging.Tests.Core.Messages.v1;
+using CloudNative.CloudEvents;
+using GuardNet;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Arcus.Messaging.Tests.Workers.MessageHandlers
+{
+    public class OrdersFallbackMessageHandler : IFallbackMessageHandler
+    {
+        private readonly IEventGridPublisher _eventGridPublisher;
+        private readonly ILogger<OrdersAzureServiceBusMessageHandler> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrdersAzureServiceBusMessageHandler"/> class.
+        /// </summary>
+        /// <param name="eventGridPublisher">The publisher instance to send event messages to Azure Event Grid.</param>
+        /// <param name="logger">The logger instance to write diagnostic trace messages during the interaction with Azure Event Grid.</param>
+        public OrdersFallbackMessageHandler(IEventGridPublisher eventGridPublisher, ILogger<OrdersAzureServiceBusMessageHandler> logger)
+        {
+            Guard.NotNull(eventGridPublisher, nameof(eventGridPublisher));
+            Guard.NotNull(logger, nameof(logger));
+
+            _eventGridPublisher = eventGridPublisher;
+            _logger = logger;
+        }
+
+        /// <summary>
+        ///     Process a new message that was received
+        /// </summary>
+        /// <param name="message">Message that was received</param>
+        /// <param name="azureMessageContext">Context providing more information concerning the processing</param>
+        /// <param name="correlationInfo">
+        ///     Information concerning correlation of telemetry and processes by using a variety of unique
+        ///     identifiers
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        public async Task ProcessMessageAsync(
+            string message,
+            MessageContext azureMessageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            var order = JsonConvert.DeserializeObject<Order>(message);
+
+            _logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}",
+                                   order.Id, order.Amount, order.ArticleNumber, order.Customer.FirstName, order.Customer.LastName);
+
+            await PublishEventToEventGridAsync(order, correlationInfo.OperationId, correlationInfo);
+
+            _logger.LogInformation("Order {OrderId} processed", order.Id);
+        }
+
+        private async Task PublishEventToEventGridAsync(Order orderMessage, string operationId, MessageCorrelationInfo correlationInfo)
+        {
+            var eventData = new OrderCreatedEventData(
+                orderMessage.Id,
+                orderMessage.Amount,
+                orderMessage.ArticleNumber,
+                $"{orderMessage.Customer.FirstName} {orderMessage.Customer.LastName}",
+                correlationInfo);
+
+            var orderCreatedEvent = new CloudEvent(
+                CloudEventsSpecVersion.V1_0,
+                "OrderCreatedEvent",
+                new Uri("http://test-host"),
+                operationId,
+                DateTime.UtcNow)
+            {
+                Data = eventData,
+                DataContentType = new ContentType("application/json")
+            };
+
+            await _eventGridPublisher.PublishAsync(orderCreatedEvent);
+
+            _logger.LogInformation("Event {EventId} was published with subject {EventSubject}", orderCreatedEvent.Id, orderCreatedEvent.Subject);
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersServiceBusFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersServiceBusFallbackMessageHandler.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Mime;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.EventGrid.Publishing.Interfaces;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
+using Arcus.Messaging.Tests.Core.Events.v1;
+using Arcus.Messaging.Tests.Core.Messages.v1;
+using CloudNative.CloudEvents;
+using GuardNet;
+using Microsoft.Azure.ServiceBus;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Arcus.Messaging.Tests.Workers.MessageHandlers
+{
+    public class OrdersServiceBusFallbackMessageHandler : IAzureServiceBusFallbackMessageHandler
+    {
+        private readonly IEventGridPublisher _eventGridPublisher;
+        private readonly ILogger<OrdersAzureServiceBusMessageHandler> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrdersAzureServiceBusMessageHandler"/> class.
+        /// </summary>
+        /// <param name="eventGridPublisher">The publisher instance to send event messages to Azure Event Grid.</param>
+        /// <param name="logger">The logger instance to write diagnostic trace messages during the interaction with Azure Event Grid.</param>
+        public OrdersServiceBusFallbackMessageHandler(IEventGridPublisher eventGridPublisher, ILogger<OrdersAzureServiceBusMessageHandler> logger)
+        {
+            Guard.NotNull(eventGridPublisher, nameof(eventGridPublisher));
+            Guard.NotNull(logger, nameof(logger));
+
+            _eventGridPublisher = eventGridPublisher;
+            _logger = logger;
+        }
+
+        /// <summary>
+        ///     Process a new message that was received
+        /// </summary>
+        /// <param name="message">Message that was received</param>
+        /// <param name="azureMessageContext">Context providing more information concerning the processing</param>
+        /// <param name="correlationInfo">
+        ///     Information concerning correlation of telemetry and processes by using a variety of unique
+        ///     identifiers
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        public async Task ProcessMessageAsync(
+            Message message,
+            AzureServiceBusMessageContext azureMessageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            string messageBody = Encoding.UTF8.GetString(message.Body);
+            var order = JsonConvert.DeserializeObject<Order>(messageBody);
+
+            _logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}",
+                                   order.Id, order.Amount, order.ArticleNumber, order.Customer.FirstName, order.Customer.LastName);
+
+            await PublishEventToEventGridAsync(order, correlationInfo.OperationId, correlationInfo);
+
+            _logger.LogInformation("Order {OrderId} processed", order.Id);
+        }
+
+        private async Task PublishEventToEventGridAsync(Order orderMessage, string operationId, MessageCorrelationInfo correlationInfo)
+        {
+            var eventData = new OrderCreatedEventData(
+                orderMessage.Id,
+                orderMessage.Amount,
+                orderMessage.ArticleNumber,
+                $"{orderMessage.Customer.FirstName} {orderMessage.Customer.LastName}",
+                correlationInfo);
+
+            var orderCreatedEvent = new CloudEvent(
+                CloudEventsSpecVersion.V1_0,
+                "OrderCreatedEvent",
+                new Uri("http://test-host"),
+                operationId,
+                DateTime.UtcNow)
+            {
+                Data = eventData,
+                DataContentType = new ContentType("application/json")
+            };
+
+            await _eventGridPublisher.PublishAsync(orderCreatedEvent);
+
+            _logger.LogInformation("Event {EventId} was published with subject {EventSubject}", orderCreatedEvent.Id, orderCreatedEvent.Subject);
+        }
+    }
+}


### PR DESCRIPTION
Adds an extra interface `IFallbackMessageHandler` that will handle remaining messages if none of the message handlers were able to handle the message.
- Added service collection extension to register this more easily
- Added section in customization docs to explain this feature
- Added integration test that will explicitly test the fallback of the message to the handler
- Added extensions unit tests

Closes #110  