### PR TITLE
Fix - rethrow when message handling failed

### DIFF
--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -494,6 +494,8 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             {
                 Logger.LogCritical(ex, "Unable to process message with ID '{MessageId}'",  message.MessageId);
                 await HandleReceiveExceptionAsync(ex);
+
+                throw;
             }
         }
 


### PR DESCRIPTION
When the Azure Service Bus message is being handled but fails during processing, the exception should not only be logged, but also be re-thrown so the message is marked abannoned.

Closes #115 