### PR TITLE
Feature - provide specific Azure Service Bus message operations during message handling

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -135,7 +135,7 @@ stages:
 
   - stage: SelfContainingIntegrationTests
     displayName: Self-Containing Integration Tests
-    dependsOn: Build
+    dependsOn: DockerIntegrationTests
     condition: succeeded()
     variables:
       - name: 'Arcus.Health.Port.Queue'

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -120,7 +120,7 @@ stages:
 
   - stage: SelfContainingIntegrationTests
     displayName: Self-Containing Integration Tests
-    dependsOn: Build
+    dependsOn: DockerIntegrationTests
     condition: succeeded()
     variables:
       - name: 'Arcus.Health.Port.Queue'

--- a/docs/preview/features/message-pumps/customization.md
+++ b/docs/preview/features/message-pumps/customization.md
@@ -8,6 +8,10 @@ layout: default
 While the message processing is handled by the `IMessageHandler<>` implementations, the message pump controls in what format the message is received.
 We allow several customizations while implementing your own message pump.
 
+- [Control custom deserialization](#control-custom-deserialization)
+- [Filter messages based on message context](#filter-messages-based-on-message-context)
+- [Fallback message handling](#fallback-message-handling)
+
 ## Control custom deserialization
 
 When inheriting from an `...MessagePump` type, there's a way to control how the incoming raw message is being deserialized.

--- a/docs/preview/features/message-pumps/service-bus.md
+++ b/docs/preview/features/message-pumps/service-bus.md
@@ -249,7 +249,7 @@ public void ConfigureServices(IServiceCollection services)
 
 ### During fallback message handling
 
-To have access to the Azure Service Bus operations, you have to implement the `abstract` AzureServiceBusFallbackMessageHandler` class.
+To have access to the Azure Service Bus operations, you have to implement the abstract `AzureServiceBusFallbackMessageHandler` class.
 Behind the scenes it implements the `IServiceBusFallbackMessageHandler`, so you can register this the same way as any other fallback message handler.
 
 This base class provides several protected methods to call the Azure Service Bus operations:

--- a/docs/preview/features/message-pumps/service-bus.md
+++ b/docs/preview/features/message-pumps/service-bus.md
@@ -5,7 +5,6 @@ layout: default
 
 # Azure Service Bus Message Pump
 
-
 Azure Service Bus Message Pump will perform all the plumbing that is required for processing queues & topics:
 
 - Manage message pump lifecycle

--- a/src/Arcus.Messaging.Pumps.Abstractions/MessageHandling/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/MessageHandling/IServiceCollectionExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             Guard.NotNull(services, nameof(services));
 
-            services.AddSingleton<IMessageHandler<TMessage, MessageContext>, TMessageHandler>();
+            services.AddTransient<IMessageHandler<TMessage, MessageContext>, TMessageHandler>();
 
             return services;
         }
@@ -48,7 +48,7 @@ namespace Microsoft.Extensions.DependencyInjection
             Guard.NotNull(services, nameof(services));
             Guard.NotNull(implementationFactory, nameof(implementationFactory));
 
-            services.AddSingleton<IMessageHandler<TMessage, MessageContext>, TMessageHandler>(implementationFactory);
+            services.AddTransient<IMessageHandler<TMessage, MessageContext>, TMessageHandler>(implementationFactory);
 
             return services;
         }
@@ -68,7 +68,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             Guard.NotNull(services, nameof(services));
 
-            services.AddSingleton<IMessageHandler<TMessage, TMessageContext>, TMessageHandler>();
+            services.AddTransient<IMessageHandler<TMessage, TMessageContext>, TMessageHandler>();
 
             return services;
         }
@@ -92,7 +92,7 @@ namespace Microsoft.Extensions.DependencyInjection
             Guard.NotNull(services, nameof(services));
             Guard.NotNull(implementationFactory, nameof(implementationFactory));
 
-            services.AddSingleton<IMessageHandler<TMessage, TMessageContext>, TMessageHandler>(implementationFactory);
+            services.AddTransient<IMessageHandler<TMessage, TMessageContext>, TMessageHandler>(implementationFactory);
 
             return services;
         }
@@ -186,7 +186,7 @@ namespace Microsoft.Extensions.DependencyInjection
             Guard.NotNull(messageContextFilter,  nameof(messageContextFilter));
             Guard.NotNull(implementationFactory, nameof(implementationFactory));
 
-            return services.AddSingleton<IMessageHandler<TMessage, TMessageContext>, MessageHandlerRegistration<TMessage, TMessageContext>>(
+            return services.AddTransient<IMessageHandler<TMessage, TMessageContext>, MessageHandlerRegistration<TMessage, TMessageContext>>(
                 serviceProvider => new MessageHandlerRegistration<TMessage, TMessageContext>(
                     messageContextFilter, implementationFactory(serviceProvider)));
         }

--- a/src/Arcus.Messaging.Pumps.Abstractions/MessageHandling/MessageHandler.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/MessageHandling/MessageHandler.cs
@@ -38,7 +38,7 @@ namespace Arcus.Messaging.Pumps.Abstractions.MessageHandling
         }
 
         /// <summary>
-        /// 
+        /// Gets the instance of the message handler that this abstracted message handler represents.
         /// </summary>
         public object Service { get; }
 

--- a/src/Arcus.Messaging.Pumps.Abstractions/MessageHandling/MessageHandler.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/MessageHandling/MessageHandler.cs
@@ -18,7 +18,6 @@ namespace Arcus.Messaging.Pumps.Abstractions.MessageHandling
     /// </summary>
     public class MessageHandler
     {
-        private readonly object _service;
         private readonly ILogger _logger;
 
         private MessageHandler(Type serviceType, object service, ILogger logger)
@@ -29,14 +28,19 @@ namespace Arcus.Messaging.Pumps.Abstractions.MessageHandling
             Guard.For<ArgumentException>(
                 () => serviceType.GenericTypeArguments.Length != 2, 
                 $"Message handler type '{serviceType.Name}' has not the expected 2 generic type arguments");
-            
-            _service = service;
+
             _logger = logger;
 
+            Service = service;
             ServiceType = serviceType;
             MessageType = ServiceType.GenericTypeArguments[0];
             MessageContextType = ServiceType.GenericTypeArguments[1];
         }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public object Service { get; }
 
         /// <summary>
         /// Gets the type of the message handler that this abstracted message handler represents.
@@ -104,13 +108,13 @@ namespace Arcus.Messaging.Pumps.Abstractions.MessageHandling
                     "Message context type '{ActualMessageContextType}' matches registered message handler's {MessageHandlerType} context type {ExpectedMessageContextType}",
                     actualMessageContextType.Name, ServiceType.Name, expectedMessageContextType.Name);
 
-                if (_service.GetType().Name == typeof(MessageHandlerRegistration<,>).Name)
+                if (Service.GetType().Name == typeof(MessageHandlerRegistration<,>).Name)
                 {
                     _logger.LogTrace(
                         "Determining whether the message context predicate registered with the message handler {MessageHandlerType} holds...",
                          ServiceType.Name);
 
-                    var canProcessMessage = (bool) _service.InvokeMethod(
+                    var canProcessMessage = (bool) Service.InvokeMethod(
                         "CanProcessMessage",
                         BindingFlags.Instance | BindingFlags.NonPublic,
                         messageContext);
@@ -169,13 +173,13 @@ namespace Arcus.Messaging.Pumps.Abstractions.MessageHandling
             try
             {
                 var processMessageAsync =
-                        (Task)_service.InvokeMethod(
+                        (Task)Service.InvokeMethod(
                             methodName, BindingFlags.Instance | BindingFlags.Public, message, messageContext, correlationInfo, cancellationToken);
 
                 if (processMessageAsync is null)
                 {
                     throw new InvalidOperationException(
-                        $"The '{typeof(IMessageHandler<,>).Name}' implementation '{_service.GetType().Name}' returned 'null' while calling the '{methodName}' method");
+                        $"The '{typeof(IMessageHandler<,>).Name}' implementation '{Service.GetType().Name}' returned 'null' while calling the '{methodName}' method");
                 }
 
                 await processMessageAsync;
@@ -190,7 +194,7 @@ namespace Arcus.Messaging.Pumps.Abstractions.MessageHandling
                     methodName, ServiceType.Name, methodName, ServiceType.Name);
 
                 throw new AmbiguousMatchException(
-                    $"Ambiguous match found of '{methodName}' methods in the '{_service.GetType().Name}'. ", exception);
+                    $"Ambiguous match found of '{methodName}' methods in the '{Service.GetType().Name}'. ", exception);
             }
         }
     }

--- a/src/Arcus.Messaging.Pumps.Abstractions/MessageHandling/MessageHandler.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/MessageHandling/MessageHandler.cs
@@ -45,7 +45,7 @@ namespace Arcus.Messaging.Pumps.Abstractions.MessageHandling
         /// <summary>
         /// Gets the type of the message handler that this abstracted message handler represents.
         /// </summary>
-        internal Type ServiceType { get; }
+        public Type ServiceType { get; }
 
         /// <summary>
         /// Gets the type of the message that this abstracted message handler can process.

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -519,13 +519,19 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             Guard.NotNull(messageHandler, nameof(messageHandler), "Requires a message handler instance to pre-process the message");
             Guard.NotNull(messageContext, nameof(messageContext), "Requires a message context to pre-process the message");
 
+            Logger.LogTrace("Start pre-processing message handler {MessageHandlerType}...", messageHandler.ServiceType.Name);
+
             if (messageHandler.Service is AzureServiceBusMessageHandlerTemplate template 
                 && messageContext is AzureServiceBusMessageContext serviceBusMessageContext)
             {
                 template.SetLockToken(serviceBusMessageContext.SystemProperties.LockToken);
                 template.SetMessageReceiver(_messageReceiver);
             }
-
+            else
+            {
+                Logger.LogTrace("Nothing to pre-process for message handler type '{MessageHandlerType}'", messageHandler.ServiceType.Name);
+            }
+            
             return Task.CompletedTask;
         }
 

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -540,7 +540,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             CancellationToken cancellationToken,
             MessageCorrelationInfo correlationInfo)
         {
-            Logger.LogInformation("Received message '{MessageId}'", message.MessageId);
+            Logger.LogTrace("Received message '{MessageId}'", message.MessageId);
 
             var messageContext = new AzureServiceBusMessageContext(message.MessageId, message.SystemProperties, message.UserProperties);
             Encoding encoding = messageContext.GetMessageEncodingProperty(Logger);

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -569,7 +569,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
                 }
             }
 
-            Logger.LogInformation("Message '{MessageId}' processed", message.MessageId);
+            Logger.LogTrace("Message '{MessageId}' processed", message.MessageId);
         }
 
         private static async Task UntilCancelledAsync(CancellationToken cancellationToken)

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
@@ -7,7 +8,9 @@ using Arcus.Messaging.Pumps.ServiceBus.Configuration;
 using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
 using Arcus.Security.Core;
 using GuardNet;
+using Microsoft.Azure.ServiceBus.Core;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 // ReSharper disable once CheckNamespace
@@ -703,7 +706,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             Guard.NotNull(services, nameof(services));
 
-            services.AddSingleton<IMessageHandler<TMessage, AzureServiceBusMessageContext>, TMessageHandler>();
+            services.AddTransient<IMessageHandler<TMessage, AzureServiceBusMessageContext>, TMessageHandler>();
 
             return services;
         }
@@ -725,7 +728,7 @@ namespace Microsoft.Extensions.DependencyInjection
             Guard.NotNull(services, nameof(services));
             Guard.NotNull(implementationFactory, nameof(implementationFactory));
 
-            services.AddSingleton<IMessageHandler<TMessage, AzureServiceBusMessageContext>, TMessageHandler>(implementationFactory);
+            services.AddTransient<IMessageHandler<TMessage, AzureServiceBusMessageContext>, TMessageHandler>(implementationFactory);
 
             return services;
         }
@@ -786,7 +789,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             Guard.NotNull(services, nameof(services), "Requires a services collection to add the Azure Service Bus fallback message handler to");
 
-            return services.AddSingleton<IAzureServiceBusFallbackMessageHandler, TMessageHandler>();
+            return services.AddTransient<IAzureServiceBusFallbackMessageHandler, TMessageHandler>();
         }
 
         /// <summary>
@@ -804,7 +807,7 @@ namespace Microsoft.Extensions.DependencyInjection
             Guard.NotNull(services, nameof(services), "Requires a services collection to add the fallback message handler to");
             Guard.NotNull(createImplementation, nameof(createImplementation), "Requires a function to create the fallback message handler");
 
-            return services.AddSingleton<IAzureServiceBusFallbackMessageHandler, TMessageHandler>(createImplementation);
+            return services.AddTransient<IAzureServiceBusFallbackMessageHandler, TMessageHandler>(createImplementation);
         }
     }
 }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/IAzureServiceBusMessageHandler.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/IAzureServiceBusMessageHandler.cs
@@ -1,5 +1,4 @@
-﻿using Arcus.Messaging.Pumps.Abstractions;
-using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
+﻿using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
 using Microsoft.Azure.ServiceBus;
 
 namespace Arcus.Messaging.Pumps.ServiceBus

--- a/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/AzureServiceBusFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/AzureServiceBusFallbackMessageHandler.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
+using GuardNet;
+using Microsoft.Azure.ServiceBus;
+using Microsoft.Extensions.Logging;
+
+namespace Arcus.Messaging.Pumps.ServiceBus.MessageHandling
+{
+    /// <summary>
+    /// Represents a <see cref="IAzureServiceBusFallbackMessageHandler"/> template to control the Azure Service Bus message operations during the fallback handling of the message.
+    /// </summary>
+    public abstract class AzureServiceBusFallbackMessageHandler : AzureServiceBusMessageHandlerTemplate, IAzureServiceBusFallbackMessageHandler
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureServiceBusFallbackMessageHandler"/> class.
+        /// </summary>
+        /// <param name="logger">The logger instance to write diagnostic messages during the message handling.</param>
+        protected AzureServiceBusFallbackMessageHandler(ILogger logger) : base(logger)
+        {
+        }
+
+        /// <summary>
+        ///     Process a new message that was received
+        /// </summary>
+        /// <param name="message">The Azure Service Bus Message message that was received</param>
+        /// <param name="messageContext">The context providing more information concerning the processing</param>
+        /// <param name="correlationInfo">
+        ///     The information concerning correlation of telemetry and processes by using a variety of unique
+        ///     identifiers.
+        /// </param>
+        /// <param name="cancellationToken">The cancellation token to cancel the processing.</param>
+        public abstract Task ProcessMessageAsync(
+            Message message,
+            AzureServiceBusMessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Dead letters the Azure Service Bus <paramref name="message"/> on Azure while providing <paramref name="newMessageProperties"/> for properties that has to be modified in the process.
+        /// </summary>
+        /// <param name="message">The message that has to be dead lettered.</param>
+        /// <param name="newMessageProperties">The properties to modify on the message during the dead lettering of the message.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the message handler was not initialized yet.</exception>
+        protected async Task DeadLetterAsync(Message message, IDictionary<string, object> newMessageProperties = null)
+        {
+            Guard.NotNull(message, nameof(message), "Requires a message to be dead lettered");
+
+            if (MessageReceiver is null)
+            {
+                throw new InvalidOperationException($"Cannot DeadLetter the message '{message.MessageId}' because the message receiver was not yet initialized yet");
+            }
+
+            Logger.LogTrace("DeadLettering message '{MessageId}'...", message.MessageId);
+            await MessageReceiver.DeadLetterAsync(message.SystemProperties.LockToken, newMessageProperties);
+            Logger.LogInformation("Message '{MessageId}' was DeadLettered!", message.MessageId);
+        }
+
+        /// <summary>
+        /// Dead letters the Azure Service Bus <paramref name="message"/> on Azure with a reason why the message needs to be dead lettered.
+        /// </summary>
+        /// <param name="message">The message that has to be dead lettered.</param>
+        /// <param name="deadLetterReason">The reason why the <paramref name="message"/> should be dead lettered.</param>
+        /// <param name="deadLetterErrorDescription">The optional extra description of the dead letter error.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="deadLetterReason"/> is blank.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the message handler was not initialized yet.</exception>
+        protected async Task DeadLetterAsync(Message message, string deadLetterReason, string deadLetterErrorDescription = null)
+        {
+            Guard.NotNull(message, nameof(message), "Requires a message to be dead lettered");
+            Guard.NotNullOrWhitespace(deadLetterReason, nameof(deadLetterReason), "Requires a non-blank dead letter reason for the message");
+
+            if (MessageReceiver is null)
+            {
+                throw new InvalidOperationException($"Cannot DeadLetter the message '{message.MessageId}' because the message receiver was not yet initialized yet");
+            }
+
+            Logger.LogTrace("DeadLettering message '{MessageId}'...", message.MessageId);
+            await MessageReceiver.DeadLetterAsync(message.SystemProperties.LockToken, deadLetterReason, deadLetterErrorDescription);
+            Logger.LogInformation("Message '{MessageId}' was DeadLettered!", message.MessageId);
+        }
+
+        /// <summary>
+        /// Abandon the Azure Service Bus <paramref name="message"/> on Azure while providing <paramref name="newMessageProperties"/> for properties that has to be modified in the process.
+        /// </summary>
+        /// <param name="message">The message that has to be abandoned.</param>
+        /// <param name="newMessageProperties">The properties to modify on the message during the abandoning of the message.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the message handler was not initialized yet.</exception>
+        protected async Task AbandonAsync(Message message, IDictionary<string, object> newMessageProperties = null)
+        {
+            Guard.NotNull(message, nameof(message), "Requires a message to be abandoned");
+
+            if (MessageReceiver is null)
+            {
+                throw new InvalidOperationException($"Cannot Abandon the message '{message.MessageId}' because the message receiver was not yet initialized yet");
+            }
+
+            Logger.LogTrace("Abandoning message '{MessageId}'...", message.MessageId);
+            await MessageReceiver.AbandonAsync(message.SystemProperties.LockToken, newMessageProperties);
+            Logger.LogInformation("Message '{MessageId}' was Abandoned!", message.MessageId);
+        }
+    }
+}

--- a/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/AzureServiceBusFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/AzureServiceBusFallbackMessageHandler.cs
@@ -54,7 +54,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.MessageHandling
                 throw new InvalidOperationException($"Cannot DeadLetter the message '{message.MessageId}' because the message receiver was not yet initialized yet");
             }
 
-            Logger.LogTrace("DeadLettering message '{MessageId}'...", message.MessageId);
+            Logger.LogTrace("Dead-lettering message '{MessageId}'...", message.MessageId);
             await MessageReceiver.DeadLetterAsync(message.SystemProperties.LockToken, newMessageProperties);
             Logger.LogTrace("Message '{MessageId}' was dead-lettered", message.MessageId);
         }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/AzureServiceBusFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/AzureServiceBusFallbackMessageHandler.cs
@@ -80,7 +80,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.MessageHandling
 
             Logger.LogTrace("DeadLettering message '{MessageId}'...", message.MessageId);
             await MessageReceiver.DeadLetterAsync(message.SystemProperties.LockToken, deadLetterReason, deadLetterErrorDescription);
-            Logger.LogInformation("Message '{MessageId}' was DeadLettered!", message.MessageId);
+            Logger.LogTrace("Message '{MessageId}' was dead-lettered!", message.MessageId);
         }
 
         /// <summary>

--- a/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/AzureServiceBusFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/AzureServiceBusFallbackMessageHandler.cs
@@ -54,9 +54,9 @@ namespace Arcus.Messaging.Pumps.ServiceBus.MessageHandling
                 throw new InvalidOperationException($"Cannot DeadLetter the message '{message.MessageId}' because the message receiver was not yet initialized yet");
             }
 
-            Logger.LogTrace("Dead-lettering message '{MessageId}'...", message.MessageId);
+            Logger.LogTrace("Dead-lettering message '{MessageId}' using lock token '{LockToken}'...", message.MessageId, message.SystemProperties.LockToken);
             await MessageReceiver.DeadLetterAsync(message.SystemProperties.LockToken, newMessageProperties);
-            Logger.LogTrace("Message '{MessageId}' was dead-lettered", message.MessageId);
+            Logger.LogTrace("Message '{MessageId}' was dead-lettered using lock token '{LockToken}'!", message.MessageId, message.SystemProperties.LockToken);
         }
 
         /// <summary>
@@ -78,9 +78,9 @@ namespace Arcus.Messaging.Pumps.ServiceBus.MessageHandling
                 throw new InvalidOperationException($"Cannot DeadLetter the message '{message.MessageId}' because the message receiver was not yet initialized yet");
             }
 
-            Logger.LogTrace("Dead-lettering message '{MessageId}'...", message.MessageId);
+            Logger.LogTrace("Dead-lettering message '{MessageId}' using lock token '{LockToken}' because '{Reason}'...", message.MessageId, message.SystemProperties.LockToken, deadLetterReason);
             await MessageReceiver.DeadLetterAsync(message.SystemProperties.LockToken, deadLetterReason, deadLetterErrorDescription);
-            Logger.LogTrace("Message '{MessageId}' was dead-lettered!", message.MessageId);
+            Logger.LogTrace("Message '{MessageId}' was dead-lettered using lock token '{LockToken}' because '{Reason}'!", message.MessageId, message.SystemProperties.LockToken, deadLetterReason);
         }
 
         /// <summary>
@@ -99,9 +99,9 @@ namespace Arcus.Messaging.Pumps.ServiceBus.MessageHandling
                 throw new InvalidOperationException($"Cannot Abandon the message '{message.MessageId}' because the message receiver was not yet initialized yet");
             }
 
-            Logger.LogTrace("Abandoning message '{MessageId}'...", message.MessageId);
+            Logger.LogTrace("Abandoning message '{MessageId}' using lock token '{LockToken}'...", message.MessageId, message.SystemProperties.LockToken);
             await MessageReceiver.AbandonAsync(message.SystemProperties.LockToken, newMessageProperties);
-            Logger.LogTrace("Message '{MessageId}' was abandoned", message.MessageId);
+            Logger.LogTrace("Message '{MessageId}' was abandoned using '{LockToken}'!", message.MessageId, message.SystemProperties.LockToken);
         }
     }
 }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/AzureServiceBusFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/AzureServiceBusFallbackMessageHandler.cs
@@ -56,7 +56,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.MessageHandling
 
             Logger.LogTrace("DeadLettering message '{MessageId}'...", message.MessageId);
             await MessageReceiver.DeadLetterAsync(message.SystemProperties.LockToken, newMessageProperties);
-            Logger.LogInformation("Message '{MessageId}' was DeadLettered!", message.MessageId);
+            Logger.LogTrace("Message '{MessageId}' was dead-lettered", message.MessageId);
         }
 
         /// <summary>

--- a/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/AzureServiceBusFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/AzureServiceBusFallbackMessageHandler.cs
@@ -78,7 +78,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.MessageHandling
                 throw new InvalidOperationException($"Cannot DeadLetter the message '{message.MessageId}' because the message receiver was not yet initialized yet");
             }
 
-            Logger.LogTrace("DeadLettering message '{MessageId}'...", message.MessageId);
+            Logger.LogTrace("Dead-lettering message '{MessageId}'...", message.MessageId);
             await MessageReceiver.DeadLetterAsync(message.SystemProperties.LockToken, deadLetterReason, deadLetterErrorDescription);
             Logger.LogTrace("Message '{MessageId}' was dead-lettered!", message.MessageId);
         }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/AzureServiceBusFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/AzureServiceBusFallbackMessageHandler.cs
@@ -101,7 +101,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.MessageHandling
 
             Logger.LogTrace("Abandoning message '{MessageId}'...", message.MessageId);
             await MessageReceiver.AbandonAsync(message.SystemProperties.LockToken, newMessageProperties);
-            Logger.LogInformation("Message '{MessageId}' was Abandoned!", message.MessageId);
+            Logger.LogTrace("Message '{MessageId}' was abandoned", message.MessageId);
         }
     }
 }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/AzureServiceBusMessageHandler.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/AzureServiceBusMessageHandler.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
+using GuardNet;
+using Microsoft.Extensions.Logging;
+
+namespace Arcus.Messaging.Pumps.ServiceBus.MessageHandling
+{
+    /// <summary>
+    /// Represents a <see cref="IAzureServiceBusMessageHandler{TMessage}"/> template to control the Azure Service Bus message operations during the handling of the deserialized message.
+    /// </summary>
+    public abstract class AzureServiceBusMessageHandler<TMessage> : AzureServiceBusMessageHandlerTemplate, IAzureServiceBusMessageHandler<TMessage>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureServiceBusMessageHandlerTemplate"/> class.
+        /// </summary>
+        protected AzureServiceBusMessageHandler(ILogger logger) : base(logger) { }
+
+        /// <summary>
+        ///     Process a new message that was received
+        /// </summary>
+        /// <param name="message">Message that was received</param>
+        /// <param name="messageContext">Context providing more information concerning the processing</param>
+        /// <param name="correlationInfo">
+        ///     Information concerning correlation of telemetry and processes by using a variety of unique
+        ///     identifiers
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        public abstract Task ProcessMessageAsync(
+            TMessage message,
+            AzureServiceBusMessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Dead letters the Azure Service Bus message on Azure while providing <paramref name="newMessageProperties"/> for properties that has to be modified in the process.
+        /// </summary>
+        /// <param name="newMessageProperties">The properties to modify on the message during the dead lettering of the message.</param>
+        /// <exception cref="InvalidOperationException">Thrown when the message handler was not initialized yet.</exception>
+        protected async Task DeadLetterMessageAsync(IDictionary<string, object> newMessageProperties = null)
+        {
+            if (LockToken is null)
+            {
+                throw new InvalidOperationException("Cannot dead letter the message because the message was not yet initialized");
+            }
+
+            if (MessageReceiver is null)
+            {
+                throw new InvalidOperationException($"Cannot dead letter the message because the message receiver was not yet initialized");
+            }
+
+            Logger.LogTrace("DeadLettering message...");
+            await MessageReceiver.DeadLetterAsync(LockToken, newMessageProperties);
+            Logger.LogInformation("Message was DeadLettered!");
+        }
+
+        /// <summary>
+        /// Dead letters the Azure Service Bus message on Azure with a reason why the message needs to be dead lettered.
+        /// </summary>
+        /// <param name="deadLetterReason">The reason why the message should be dead lettered.</param>
+        /// <param name="deadLetterErrorDescription">The optional extra description of the dead letter error.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the message is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="deadLetterReason"/> is blank.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the message handler was not initialized yet.</exception>
+        protected async Task DeadLetterMessageAsync(string deadLetterReason, string deadLetterErrorDescription = null)
+        {
+            Guard.NotNullOrWhitespace(deadLetterReason, nameof(deadLetterReason), "Requires a non-blank dead letter reason for the message");
+
+            if (LockToken is null)
+            {
+                throw new InvalidOperationException("Cannot dead letter the message because the message was not yet initialized");
+            }
+
+            if (MessageReceiver is null)
+            {
+                throw new InvalidOperationException($"Cannot dead letter the message because the message receiver was not yet initialized");
+            }
+
+            Logger.LogTrace("DeadLettering message...");
+            await MessageReceiver.DeadLetterAsync(LockToken, deadLetterReason, deadLetterErrorDescription);
+            Logger.LogInformation("Message was DeadLettered!");
+        }
+
+        /// <summary>
+        /// Abandon the Azure Service Bus message on Azure while providing <paramref name="newMessageProperties"/> for properties that has to be modified in the process.
+        /// </summary>
+        /// <param name="newMessageProperties">The properties to modify on the message during the abandoning of the message.</param>
+        /// <exception cref="InvalidOperationException">Thrown when the message handler was not initialized yet.</exception>
+        protected async Task AbandonMessageAsync(IDictionary<string, object> newMessageProperties = null)
+        {
+            if (LockToken is null)
+            {
+                throw new InvalidOperationException("Cannot abandon the message because the message was not yet initialized");
+            }
+
+            if (MessageReceiver is null)
+            {
+                throw new InvalidOperationException($"Cannot Abandon the message because the message receiver was not yet initialized");
+            }
+
+            Logger.LogTrace("Abandoning message...");
+            await MessageReceiver.AbandonAsync(LockToken, newMessageProperties);
+            Logger.LogInformation("Message was Abandoned!");
+        }
+    }
+}

--- a/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/AzureServiceBusMessageHandler.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/AzureServiceBusMessageHandler.cs
@@ -51,9 +51,9 @@ namespace Arcus.Messaging.Pumps.ServiceBus.MessageHandling
                 throw new InvalidOperationException($"Cannot dead letter the message because the message receiver was not yet initialized");
             }
 
-            Logger.LogTrace("DeadLettering message...");
+            Logger.LogTrace("Dead-lettering message using lock token '{LockToken}'...", LockToken);
             await MessageReceiver.DeadLetterAsync(LockToken, newMessageProperties);
-            Logger.LogInformation("Message was DeadLettered!");
+            Logger.LogTrace("Message was dead-lettered using lock token '{LockToken}'!", LockToken);
         }
 
         /// <summary>
@@ -78,9 +78,9 @@ namespace Arcus.Messaging.Pumps.ServiceBus.MessageHandling
                 throw new InvalidOperationException($"Cannot dead letter the message because the message receiver was not yet initialized");
             }
 
-            Logger.LogTrace("DeadLettering message...");
+            Logger.LogTrace("Dead-lettering message using lock token '{LockToken}' because '{Reason}'...", LockToken, deadLetterReason);
             await MessageReceiver.DeadLetterAsync(LockToken, deadLetterReason, deadLetterErrorDescription);
-            Logger.LogInformation("Message was DeadLettered!");
+            Logger.LogTrace("Message was dead-lettered using lock token '{LockToken}' because '{Reason}'!", LockToken, deadLetterReason);
         }
 
         /// <summary>
@@ -100,9 +100,9 @@ namespace Arcus.Messaging.Pumps.ServiceBus.MessageHandling
                 throw new InvalidOperationException($"Cannot Abandon the message because the message receiver was not yet initialized");
             }
 
-            Logger.LogTrace("Abandoning message...");
+            Logger.LogTrace("Abandoning message using lock token '{LockToken}'...", LockToken);
             await MessageReceiver.AbandonAsync(LockToken, newMessageProperties);
-            Logger.LogInformation("Message was Abandoned!");
+            Logger.LogTrace("Message was abandoned using lock token '{LockToken}'!", LockToken);
         }
     }
 }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/AzureServiceBusMessageHandlerTemplate.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/AzureServiceBusMessageHandlerTemplate.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using GuardNet;
+using Microsoft.Azure.ServiceBus.Core;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Arcus.Messaging.Pumps.ServiceBus.MessageHandling
+{
+    /// <summary>
+    /// Represents the default template when handling Azure Service Bus messages and controlling how the message is being handled by Azure Service Bus.
+    /// </summary>
+    public abstract class AzureServiceBusMessageHandlerTemplate
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureServiceBusMessageHandlerTemplate"/> class.
+        /// </summary>
+        /// <param name="logger">The logger instance to write diagnostic messages during the message handling.</param>
+        protected AzureServiceBusMessageHandlerTemplate(ILogger logger)
+        {
+            Logger = logger ?? NullLogger.Instance;
+        }
+
+        /// <summary>
+        /// Gets the Azure Service Bus message lock token of the  message that is currently being handled.
+        /// </summary>
+        internal string LockToken { get; private set; }
+
+        /// <summary>
+        /// Gets the specific message receiver to control Azure Service Bus specific operations.
+        /// </summary>
+        internal MessageReceiver MessageReceiver { get; private set; }
+
+        /// <summary>
+        /// Gets the logger to write diagnostic messages during the handling of the message.
+        /// </summary>
+        protected ILogger Logger { get; }
+
+        /// <summary>
+        /// Sets the message receiver to the message handler template.
+        /// </summary>
+        /// <param name="messageReceiver">The message receiver to handle Azure Service Bus message-specific operations.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="messageReceiver"/> is <c>null</c>.</exception>
+        internal void SetMessageReceiver(MessageReceiver messageReceiver)
+        {
+            Guard.NotNull(messageReceiver, nameof(messageReceiver), "Requires a message receiver to run Azure Service Bus message-specific operations");
+            
+            Logger.LogTrace("Setting message receiver on message handler");
+            MessageReceiver = messageReceiver;
+        }
+
+        /// <summary>
+        /// Sets the message lock token on the message handler template.
+        /// </summary>
+        /// <param name="lockToken">The message lock token to handle Azure Service Bus message-specific operations.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="lockToken"/> is blank.</exception>
+        internal void SetLockToken(string lockToken)
+        {
+            Guard.NotNullOrWhitespace(lockToken, nameof(lockToken), "Requires a non-blank lock token to run Azure Service Bus message-specific operations");
+
+            Logger.LogTrace("Setting message on the message lock token");
+            LockToken = lockToken;
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueWithServiceBusDeadLetterFallbackProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueWithServiceBusDeadLetterFallbackProgram.cs
@@ -1,0 +1,39 @@
+using Arcus.EventGrid.Publishing;
+using Arcus.Messaging.Pumps.Abstractions.Extensions;
+using Arcus.Messaging.Tests.Core.Messages.v1;
+using Arcus.Messaging.Tests.Workers.MessageHandlers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+// ReSharper disable once CheckNamespace
+namespace Arcus.Messaging.Tests.Workers.ServiceBus
+{
+    public class ServiceBusQueueWithServiceBusDeadLetterFallbackProgram
+    {
+        public static void main(string[] args)
+        {
+            CreateHostBuilder(args)
+                .Build()
+                .Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration(configuration =>
+                {
+                    configuration.AddCommandLine(args);
+                    configuration.AddEnvironmentVariables();
+                })
+                .ConfigureLogging(loggingBuilder => loggingBuilder.AddConsole(options => options.IncludeScopes = true))
+                .ConfigureServices((hostContext, services) =>
+                {
+                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
+                            .WithServiceBusFallbackMessageHandler<OrdersAzureServiceBusDeadLetterFallbackMessageHandler>();
+
+                    services.AddTcpHealthProbes("ARCUS_HEALTH_PORT", builder => builder.AddCheck("sample", () => HealthCheckResult.Healthy()));
+                });
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueWithServiceBusDeadLetterFallbackProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueWithServiceBusDeadLetterFallbackProgram.cs
@@ -30,7 +30,7 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus
                 .ConfigureLogging(loggingBuilder => loggingBuilder.AddConsole(options => options.IncludeScopes = true))
                 .ConfigureServices((hostContext, services) =>
                 {
-                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
+                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"], options => options.AutoComplete = false)
                             .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>()
                             .WithServiceBusFallbackMessageHandler<OrdersAzureServiceBusDeadLetterFallbackMessageHandler>();
 

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueWithServiceBusDeadLetterFallbackProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueWithServiceBusDeadLetterFallbackProgram.cs
@@ -31,6 +31,7 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus
                 .ConfigureServices((hostContext, services) =>
                 {
                     services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
+                            .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>()
                             .WithServiceBusFallbackMessageHandler<OrdersAzureServiceBusDeadLetterFallbackMessageHandler>();
 
                     services.AddTcpHealthProbes("ARCUS_HEALTH_PORT", builder => builder.AddCheck("sample", () => HealthCheckResult.Healthy()));

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueWithServiceBusDeadLetterProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueWithServiceBusDeadLetterProgram.cs
@@ -1,0 +1,39 @@
+using Arcus.EventGrid.Publishing;
+using Arcus.Messaging.Pumps.Abstractions.Extensions;
+using Arcus.Messaging.Tests.Core.Messages.v1;
+using Arcus.Messaging.Tests.Workers.MessageHandlers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+// ReSharper disable once CheckNamespace
+namespace Arcus.Messaging.Tests.Workers.ServiceBus
+{
+    public class ServiceBusQueueWithServiceBusDeadLetterProgram
+    {
+        public static void main(string[] args)
+        {
+            CreateHostBuilder(args)
+                .Build()
+                .Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration(configuration =>
+                {
+                    configuration.AddCommandLine(args);
+                    configuration.AddEnvironmentVariables();
+                })
+                .ConfigureLogging(loggingBuilder => loggingBuilder.AddConsole(options => options.IncludeScopes = true))
+                .ConfigureServices((hostContext, services) =>
+                {
+                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"], options => options.AutoComplete = false)
+                            .WithServiceBusMessageHandler<OrdersAzureServiceBusDeadLetterMessageHandler, Order>();
+
+                    services.AddTcpHealthProbes("ARCUS_HEALTH_PORT", builder => builder.AddCheck("sample", () => HealthCheckResult.Healthy()));
+                });
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusTopicWithServiceBusAbandonFallbackProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusTopicWithServiceBusAbandonFallbackProgram.cs
@@ -1,0 +1,49 @@
+using Arcus.EventGrid.Publishing;
+using Arcus.Messaging.Tests.Core.Messages.v1;
+using Arcus.Messaging.Tests.Workers.MessageHandlers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+// ReSharper disable once CheckNamespace
+namespace Arcus.Messaging.Tests.Workers.ServiceBus
+{
+    public class ServiceBusTopicWithServiceBusAbandonFallbackProgram
+    {
+        public static void main(string[] args)
+        {
+            CreateHostBuilder(args)
+                .Build()
+                .Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration(configuration =>
+                {
+                    configuration.AddCommandLine(args);
+                    configuration.AddEnvironmentVariables();
+                })
+                .ConfigureLogging(loggingBuilder => loggingBuilder.AddConsole(options => options.IncludeScopes = true))
+                .ConfigureServices((hostContext, services) =>
+                {
+                    services.AddTransient(svc =>
+                    {
+                        var configuration = svc.GetRequiredService<IConfiguration>();
+                        var eventGridTopic = configuration.GetValue<string>("EVENTGRID_TOPIC_URI");
+                        var eventGridKey = configuration.GetValue<string>("EVENTGRID_AUTH_KEY");
+
+                        return EventGridPublisherBuilder
+                            .ForTopic(eventGridTopic)
+                            .UsingAuthenticationKey(eventGridKey)
+                            .Build();
+                    });
+                    services.AddServiceBusTopicMessagePump("Test-Receive-All-Topic-Only", configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
+                            .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>()
+                            .WithServiceBusFallbackMessageHandler<OrdersAzureServiceBusAbandonFallbackMessageHandler>();
+
+                    services.AddTcpHealthProbes("ARCUS_HEALTH_PORT");
+                });
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusTopicWithServiceBusAbandonFallbackProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusTopicWithServiceBusAbandonFallbackProgram.cs
@@ -39,7 +39,10 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus
                             .UsingAuthenticationKey(eventGridKey)
                             .Build();
                     });
-                    services.AddServiceBusTopicMessagePump("Test-Receive-All-Topic-Only", configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
+                    services.AddServiceBusTopicMessagePump(
+                                "Test-Receive-All-Topic-Only", 
+                                configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"], 
+                                options => options.AutoComplete = false)
                             .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>()
                             .WithServiceBusFallbackMessageHandler<OrdersAzureServiceBusAbandonFallbackMessageHandler>();
 

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusTopicWithServiceBusAbandonProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusTopicWithServiceBusAbandonProgram.cs
@@ -1,0 +1,48 @@
+using Arcus.EventGrid.Publishing;
+using Arcus.Messaging.Tests.Core.Messages.v1;
+using Arcus.Messaging.Tests.Workers.MessageHandlers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+// ReSharper disable once CheckNamespace
+namespace Arcus.Messaging.Tests.Workers.ServiceBus
+{
+    public class ServiceBusTopicWithServiceBusAbandonProgram
+    {
+        public static void main(string[] args)
+        {
+            CreateHostBuilder(args)
+                .Build()
+                .Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration(configuration =>
+                {
+                    configuration.AddCommandLine(args);
+                    configuration.AddEnvironmentVariables();
+                })
+                .ConfigureLogging(loggingBuilder => loggingBuilder.AddConsole(options => options.IncludeScopes = true))
+                .ConfigureServices((hostContext, services) =>
+                {
+                    services.AddTransient(svc =>
+                    {
+                        var configuration = svc.GetRequiredService<IConfiguration>();
+                        var eventGridTopic = configuration.GetValue<string>("EVENTGRID_TOPIC_URI");
+                        var eventGridKey = configuration.GetValue<string>("EVENTGRID_AUTH_KEY");
+
+                        return EventGridPublisherBuilder
+                            .ForTopic(eventGridTopic)
+                            .UsingAuthenticationKey(eventGridKey)
+                            .Build();
+                    });
+                    services.AddServiceBusTopicMessagePump("Test-Receive-All-Topic-Only", configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
+                            .WithServiceBusMessageHandler<OrdersAzureServiceBusAbandonMessageHandler, Order>();
+
+                    services.AddTcpHealthProbes("ARCUS_HEALTH_PORT");
+                });
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusTopicWithServiceBusAbandonProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusTopicWithServiceBusAbandonProgram.cs
@@ -39,7 +39,10 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus
                             .UsingAuthenticationKey(eventGridKey)
                             .Build();
                     });
-                    services.AddServiceBusTopicMessagePump("Test-Receive-All-Topic-Only", configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
+                    services.AddServiceBusTopicMessagePump(
+                                "Test-Receive-All-Topic-Only", 
+                                configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"], 
+                                options => options.AutoComplete = false)
                             .WithServiceBusMessageHandler<OrdersAzureServiceBusAbandonMessageHandler, Order>();
 
                     services.AddTcpHealthProbes("ARCUS_HEALTH_PORT");

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -149,7 +149,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                 {
                     // Act
                     await service.SendMessageToServiceBusAsync(connectionString, order.AsServiceBusMessage());
-                    
+
                     // Assert
                     await service.AssertDeadLetterMessageAsync(connectionString);
                 }

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -127,6 +127,26 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             }
         }
 
+        [Fact]
+        public async Task ServiceBusMessagePumpWithServiceBusDeadLetterFallback_PublishServiceBusMessage_MessageSuccessfullyProcessed()
+        {
+            // Arrange
+            var config = TestConfig.Create();
+            string connectionString = config.GetServiceBusConnectionString(ServiceBusEntity.Queue);
+            var commandArguments = new[]
+            {
+                CommandArgument.CreateSecret("ARCUS_SERVICEBUS_CONNECTIONSTRING", connectionString),
+            };
+
+            using (var project = await ServiceBusWorkerProject.StartNewWithAsync<ServiceBusQueueWithServiceBusDeadLetterFallbackProgram>(config, _logger, commandArguments))
+            {
+                await using (var service = await TestMessagePumpService.StartNewAsync(config, _logger))
+                {
+                    // Act / Assert
+                    await service.AssertDeadLetterMessageAsync(connectionString);
+                }
+            }
+        }
 
         [Fact]
         public async Task ServiceBusMessagePump_RotateServiceBusConnectionKeys_MessagePumpRestartsThenMessageSuccessfullyProcessed()

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -158,8 +158,10 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             }
         }
 
-        [Fact]
-        public async Task ServiceBusMessagePumpWithServiceBusAbandon_PublishServiceBusMessage_MessageSuccessfullyProcessed()
+        [Theory]
+        [InlineData(typeof(ServiceBusTopicWithServiceBusAbandonProgram))]
+        [InlineData(typeof(ServiceBusTopicWithServiceBusAbandonFallbackProgram))]
+        public async Task ServiceBusMessagePumpWithServiceBusAbandon_PublishServiceBusMessage_MessageSuccessfullyProcessed(Type programType)
         {
             // Arrange
             var config = TestConfig.Create();
@@ -171,7 +173,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                 CommandArgument.CreateSecret("ARCUS_SERVICEBUS_CONNECTIONSTRING", connectionString)
             };
 
-            using (var project = await ServiceBusWorkerProject.StartNewWithAsync<ServiceBusTopicWithServiceBusAbandonFallbackProgram>(config, _logger, commandArguments))
+            using (var project = await ServiceBusWorkerProject.StartNewWithAsync(programType, config, _logger, commandArguments))
             {
                 await using (var service = await TestMessagePumpService.StartNewAsync(config, _logger))
                 {

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/TestMessagePumpService.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/TestMessagePumpService.cs
@@ -140,10 +140,9 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
         }
 
         /// <summary>
-        /// 
+        /// Tries receiving a single dead lettered message on the Azure Service Bus dead letter queue.
         /// </summary>
-        /// <param name="connectionString"></param>
-        /// <returns></returns>
+        /// <param name="connectionString">The connection string to connect to the Azure Service Bus.</param>
         public async Task AssertDeadLetterMessageAsync(string connectionString)
         {
             var connectionStringBuilder = new ServiceBusConnectionStringBuilder(connectionString);

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/TestMessagePumpService.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/TestMessagePumpService.cs
@@ -147,8 +147,8 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
         public async Task AssertDeadLetterMessageAsync(string connectionString)
         {
             var connectionStringBuilder = new ServiceBusConnectionStringBuilder(connectionString);
-            connectionStringBuilder.EntityPath = EntityNameHelper.FormatTransferDeadLetterPath(connectionStringBuilder.EntityPath);
-            var messageReceiver = new MessageReceiver(connectionStringBuilder);
+            connectionStringBuilder.EntityPath = EntityNameHelper.FormatDeadLetterPath(connectionStringBuilder.EntityPath);
+            var messageReceiver = new MessageReceiver(connectionStringBuilder, ReceiveMode.ReceiveAndDelete);
 
             try
             {

--- a/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersAzureServiceBusAbandonFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersAzureServiceBusAbandonFallbackMessageHandler.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Net.Mime;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.EventGrid.Publishing.Interfaces;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
+using Arcus.Messaging.Tests.Core.Events.v1;
+using Arcus.Messaging.Tests.Core.Messages.v1;
+using CloudNative.CloudEvents;
+using GuardNet;
+using Microsoft.Azure.ServiceBus;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Arcus.Messaging.Tests.Workers.MessageHandlers
+{
+    public class OrdersAzureServiceBusAbandonFallbackMessageHandler : AzureServiceBusFallbackMessageHandler
+    {
+        private readonly IEventGridPublisher _eventGridPublisher;
+
+        public OrdersAzureServiceBusAbandonFallbackMessageHandler(IEventGridPublisher eventGridPublisher, ILogger<OrdersAzureServiceBusMessageHandler> logger)
+            : base(logger)
+        {
+            Guard.NotNull(eventGridPublisher, nameof(eventGridPublisher));
+
+            _eventGridPublisher = eventGridPublisher;
+        }
+
+        /// <summary>
+        ///     Process a new message that was received
+        /// </summary>
+        /// <param name="message">Message that was received</param>
+        /// <param name="azureMessageContext">Context providing more information concerning the processing</param>
+        /// <param name="correlationInfo">
+        ///     Information concerning correlation of telemetry and processes by using a variety of unique
+        ///     identifiers
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        public override async Task ProcessMessageAsync(
+            Message message,
+            AzureServiceBusMessageContext azureMessageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            if (message.SystemProperties.DeliveryCount <= 1)
+            {
+                Logger.LogTrace("Abandoning message '{MessageId}'...", message.MessageId);
+                await AbandonAsync(message);
+                Logger.LogTrace("Abandoned message '{MessageId}'", message.MessageId);
+            }
+            else
+            {
+                string json = Encoding.UTF8.GetString(message.Body);
+                var order = JsonConvert.DeserializeObject<Order>(json);
+
+                Logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", 
+                                      order.Id, order.Amount, order.ArticleNumber, order.Customer.FirstName, order.Customer.LastName);
+
+                await PublishEventToEventGridAsync(order, correlationInfo.OperationId, correlationInfo);
+
+                Logger.LogInformation("Order {OrderId} processed", order.Id);
+            }
+        }
+
+        private async Task PublishEventToEventGridAsync(Order orderMessage, string operationId, MessageCorrelationInfo correlationInfo)
+        {
+            var eventData = new OrderCreatedEventData(
+                orderMessage.Id,
+                orderMessage.Amount,
+                orderMessage.ArticleNumber,
+                $"{orderMessage.Customer.FirstName} {orderMessage.Customer.LastName}",
+                correlationInfo);
+
+            var orderCreatedEvent = new CloudEvent(
+                CloudEventsSpecVersion.V1_0,
+                "OrderCreatedEvent",
+                new Uri("http://test-host"),
+                operationId,
+                DateTime.UtcNow)
+            {
+                Data = eventData,
+                DataContentType = new ContentType("application/json")
+            };
+
+            await _eventGridPublisher.PublishAsync(orderCreatedEvent);
+
+            _logger.LogInformation("Event {EventId} was published with subject {EventSubject}", orderCreatedEvent.Id, orderCreatedEvent.Subject);
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersAzureServiceBusAbandonFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersAzureServiceBusAbandonFallbackMessageHandler.cs
@@ -87,7 +87,7 @@ namespace Arcus.Messaging.Tests.Workers.MessageHandlers
 
             await _eventGridPublisher.PublishAsync(orderCreatedEvent);
 
-            _logger.LogInformation("Event {EventId} was published with subject {EventSubject}", orderCreatedEvent.Id, orderCreatedEvent.Subject);
+            Logger.LogInformation("Event {EventId} was published with subject {EventSubject}", orderCreatedEvent.Id, orderCreatedEvent.Subject);
         }
     }
 }

--- a/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersAzureServiceBusAbandonMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersAzureServiceBusAbandonMessageHandler.cs
@@ -21,7 +21,7 @@ namespace Arcus.Messaging.Tests.Workers.MessageHandlers
     {
         private readonly IEventGridPublisher _eventGridPublisher;
 
-        private int _deliveryCount;
+        private static int _deliveryCount;
 
         public OrdersAzureServiceBusAbandonMessageHandler(IEventGridPublisher eventGridPublisher, ILogger<OrdersAzureServiceBusAbandonMessageHandler> logger)
             : base(logger)

--- a/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersAzureServiceBusAbandonMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersAzureServiceBusAbandonMessageHandler.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Net.Mime;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.EventGrid.Publishing.Interfaces;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
+using Arcus.Messaging.Tests.Core.Events.v1;
+using Arcus.Messaging.Tests.Core.Messages.v1;
+using CloudNative.CloudEvents;
+using GuardNet;
+using Microsoft.Azure.ServiceBus;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Arcus.Messaging.Tests.Workers.MessageHandlers
+{
+    public class OrdersAzureServiceBusAbandonMessageHandler : AzureServiceBusMessageHandler<Order>
+    {
+        private readonly IEventGridPublisher _eventGridPublisher;
+
+        private int _deliveryCount;
+
+        public OrdersAzureServiceBusAbandonMessageHandler(IEventGridPublisher eventGridPublisher, ILogger<OrdersAzureServiceBusAbandonMessageHandler> logger)
+            : base(logger)
+        {
+            Guard.NotNull(eventGridPublisher, nameof(eventGridPublisher));
+
+            _eventGridPublisher = eventGridPublisher;
+        }
+
+        /// <summary>
+        ///     Process a new message that was received
+        /// </summary>
+        /// <param name="order">Message that was received</param>
+        /// <param name="azureMessageContext">Context providing more information concerning the processing</param>
+        /// <param name="correlationInfo">
+        ///     Information concerning correlation of telemetry and processes by using a variety of unique
+        ///     identifiers
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        public override async Task ProcessMessageAsync(
+            Order order,
+            AzureServiceBusMessageContext azureMessageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            if (++_deliveryCount <= 1)
+            {
+                Logger.LogTrace("Abandoning message '{OrderId}'...", order.Id);
+                await AbandonMessageAsync();
+                Logger.LogTrace("Abandoned message '{OrderId}'", order.Id);
+            }
+            else
+            {
+                Logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", 
+                                      order.Id, order.Amount, order.ArticleNumber, order.Customer.FirstName, order.Customer.LastName);
+
+                await PublishEventToEventGridAsync(order, correlationInfo.OperationId, correlationInfo);
+
+                Logger.LogInformation("Order {OrderId} processed", order.Id);
+            }
+        }
+
+        private async Task PublishEventToEventGridAsync(Order orderMessage, string operationId, MessageCorrelationInfo correlationInfo)
+        {
+            var eventData = new OrderCreatedEventData(
+                orderMessage.Id,
+                orderMessage.Amount,
+                orderMessage.ArticleNumber,
+                $"{orderMessage.Customer.FirstName} {orderMessage.Customer.LastName}",
+                correlationInfo);
+
+            var orderCreatedEvent = new CloudEvent(
+                CloudEventsSpecVersion.V1_0,
+                "OrderCreatedEvent",
+                new Uri("http://test-host"),
+                operationId,
+                DateTime.UtcNow)
+            {
+                Data = eventData,
+                DataContentType = new ContentType("application/json")
+            };
+
+            await _eventGridPublisher.PublishAsync(orderCreatedEvent);
+
+            Logger.LogInformation("Event {EventId} was published with subject {EventSubject}", orderCreatedEvent.Id, orderCreatedEvent.Subject);
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersAzureServiceBusDeadLetterFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersAzureServiceBusDeadLetterFallbackMessageHandler.cs
@@ -1,0 +1,42 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
+using Microsoft.Azure.ServiceBus;
+using Microsoft.Extensions.Logging;
+
+namespace Arcus.Messaging.Tests.Workers.MessageHandlers
+{
+    public class OrdersAzureServiceBusDeadLetterFallbackMessageHandler : AzureServiceBusFallbackMessageHandler
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureServiceBusFallbackMessageHandler"/> class.
+        /// </summary>
+        /// <param name="logger">The logger instance to write diagnostic messages during the message handling.</param>
+        public OrdersAzureServiceBusDeadLetterFallbackMessageHandler(
+            ILogger<OrdersAzureServiceBusDeadLetterFallbackMessageHandler> logger)
+            : base(logger)
+        {
+        }
+
+        /// <summary>
+        ///     Process a new message that was received
+        /// </summary>
+        /// <param name="message">The Azure Service Bus Message message that was received</param>
+        /// <param name="messageContext">The context providing more information concerning the processing</param>
+        /// <param name="correlationInfo">
+        ///     The information concerning correlation of telemetry and processes by using a variety of unique
+        ///     identifiers.
+        /// </param>
+        /// <param name="cancellationToken">The cancellation token to cancel the processing.</param>
+        public override async Task ProcessMessageAsync(
+            Message message,
+            AzureServiceBusMessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            await DeadLetterAsync(message);
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersAzureServiceBusDeadLetterFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersAzureServiceBusDeadLetterFallbackMessageHandler.cs
@@ -36,7 +36,9 @@ namespace Arcus.Messaging.Tests.Workers.MessageHandlers
             MessageCorrelationInfo correlationInfo,
             CancellationToken cancellationToken)
         {
+            Logger.LogTrace("Dead letter message '{MessageId}'...", message.MessageId);
             await DeadLetterAsync(message);
+            Logger.LogInformation("Message '{MessageId}' is dead lettered", message.MessageId);
         }
     }
 }

--- a/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersAzureServiceBusDeadLetterMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersAzureServiceBusDeadLetterMessageHandler.cs
@@ -1,0 +1,41 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
+using Arcus.Messaging.Tests.Core.Messages.v1;
+using Microsoft.Extensions.Logging;
+
+namespace Arcus.Messaging.Tests.Workers.MessageHandlers
+{
+    public class OrdersAzureServiceBusDeadLetterMessageHandler : AzureServiceBusMessageHandler<Order>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureServiceBusMessageHandlerTemplate"/> class.
+        /// </summary>
+        public OrdersAzureServiceBusDeadLetterMessageHandler(ILogger logger) : base(logger)
+        {
+        }
+
+        /// <summary>
+        ///     Process a new message that was received
+        /// </summary>
+        /// <param name="message">Message that was received</param>
+        /// <param name="messageContext">Context providing more information concerning the processing</param>
+        /// <param name="correlationInfo">
+        ///     Information concerning correlation of telemetry and processes by using a variety of unique
+        ///     identifiers
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        public override async Task ProcessMessageAsync(
+            Order message,
+            AzureServiceBusMessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            Logger.LogTrace("Dead letter message '{OrderId}'...", message.Id);
+            await DeadLetterMessageAsync();
+            Logger.LogInformation("Message '{OrderId}' is dead lettered", message.Id);
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersAzureServiceBusDeadLetterMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersAzureServiceBusDeadLetterMessageHandler.cs
@@ -13,7 +13,7 @@ namespace Arcus.Messaging.Tests.Workers.MessageHandlers
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureServiceBusMessageHandlerTemplate"/> class.
         /// </summary>
-        public OrdersAzureServiceBusDeadLetterMessageHandler(ILogger logger) : base(logger)
+        public OrdersAzureServiceBusDeadLetterMessageHandler(ILogger<OrdersAzureServiceBusDeadLetterMessageHandler> logger) : base(logger)
         {
         }
 


### PR DESCRIPTION
Provide the capability to influence the Azure Service Bus operations during the message handling.
- Adds `AzureServiceBusMessageHandler<>`: with `DeadLetterMessageAsync` and `AbandonMessageAsync` methods
- Adds `AzureServiceBusFallbackMessageHandler<>`: with `DeadLetterAsync` and `AbandonAsync` methods
- Adds 4 integration tests to test the four different ways of deadlettering/abanoning the message
- Updates the (preview) feature docs with examples

Closes #118