### PR TITLE
Chore - separate Docker integration tests Azure resources

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -112,7 +112,7 @@ stages:
               imageName: '$(Images.ServiceBus.Queue)'
               imageTag: $(Build.BuildId)
               healthPort: $(Arcus.Health.Port.Queue)
-              connectionString: '$(Arcus.ServiceBus.ConnectionStringWithQueue)'
+              connectionString: '$(Arcus.ServiceBus.Docker.ConnectionStringWithQueue)'
           - template: templates/build-and-run-worker-container.yml
             parameters:
               projectName: 'Arcus.Messaging.Tests.Workers.ServiceBus.Topic'
@@ -120,7 +120,7 @@ stages:
               imageName: '$(Images.ServiceBus.Topic)'
               imageTag: $(Build.BuildId)
               healthPort: $(Arcus.Health.Port.Topic)
-              connectionString: '$(Arcus.ServiceBus.ConnectionStringWithTopic)'
+              connectionString: '$(Arcus.ServiceBus.Docker.ConnectionStringWithTopic)'
           - template: test/run-integration-tests.yml@templates
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
@@ -135,7 +135,7 @@ stages:
 
   - stage: SelfContainingIntegrationTests
     displayName: Self-Containing Integration Tests
-    dependsOn: DockerIntegrationTests
+    dependsOn: Build
     condition: succeeded()
     variables:
       - name: 'Arcus.Health.Port.Queue'

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -97,7 +97,7 @@ stages:
               imageName: '$(Images.ServiceBus.Queue)'
               imageTag: $(Build.BuildId)
               healthPort: $(Arcus.Health.Port.Queue)
-              connectionString: '$(Arcus.ServiceBus.ConnectionStringWithQueue)'
+              connectionString: '$(Arcus.ServiceBus.Docker.ConnectionStringWithQueue)'
           - template: templates/build-and-run-worker-container.yml
             parameters:
               projectName: 'Arcus.Messaging.Tests.Workers.ServiceBus.Topic'
@@ -105,7 +105,7 @@ stages:
               imageName: '$(Images.ServiceBus.Topic)'
               imageTag: $(Build.BuildId)
               healthPort: $(Arcus.Health.Port.Topic)
-              connectionString: '$(Arcus.ServiceBus.ConnectionStringWithTopic)'
+              connectionString: '$(Arcus.ServiceBus.Docker.ConnectionStringWithTopic)'
           - template: test/run-integration-tests.yml@templates
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'
@@ -120,7 +120,7 @@ stages:
 
   - stage: SelfContainingIntegrationTests
     displayName: Self-Containing Integration Tests
-    dependsOn: DockerIntegrationTests
+    dependsOn: Build
     condition: succeeded()
     variables:
       - name: 'Arcus.Health.Port.Queue'

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/TestConfig.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/TestConfig.cs
@@ -71,8 +71,8 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
         {
             switch (entity)
             {
-                case ServiceBusEntity.Queue: return _config["Arcus:ServiceBus:ConnectionStringWithQueue"];
-                case ServiceBusEntity.Topic: return _config["Arcus:ServiceBus:ConnectionStringWithTopic"];
+                case ServiceBusEntity.Queue: return _config["Arcus:ServiceBus:SelfContained:ConnectionStringWithQueue"];
+                case ServiceBusEntity.Topic: return _config["Arcus:ServiceBus:SelfContained:ConnectionStringWithTopic"];
                 default:
                     throw new ArgumentOutOfRangeException(nameof(entity), entity, "Unknown Service Bus entity");
             }

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpDockerTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpDockerTests.cs
@@ -18,8 +18,8 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
     [Trait("Category", "Docker")]
     public class ServiceBusMessagePumpDockerTests : IntegrationTest, IAsyncLifetime
     {
-        private const string QueueConnectionStringKey = "Arcus:ServiceBus:ConnectionStringWithQueue";
-        private const string TopicConnectionStringKey = "Arcus:ServiceBus:ConnectionStringWithTopic";
+        private const string QueueConnectionStringKey = "Arcus:ServiceBus:Docker:ConnectionStringWithQueue";
+        private const string TopicConnectionStringKey = "Arcus:ServiceBus:Docker:ConnectionStringWithTopic";
 
         public static IEnumerable<object[]> Encodings
         {

--- a/src/Arcus.Messaging.Tests.Integration/appsettings.json
+++ b/src/Arcus.Messaging.Tests.Integration/appsettings.json
@@ -15,6 +15,10 @@
       }
     },
     "ServiceBus": {
+      "Docker": {
+        "ConnectionStringWithQueue": "#{Arcus.ServiceBus.Docker.ConnectionStringWithQueue}#",
+        "ConnectionStringWithTopic": "#{Arcus.ServiceBus.Docker.ConnectionStringWithTopic}#" 
+      },
       "ConnectionStringWithQueue": "#{Arcus.ServiceBus.ConnectionStringWithQueue}#",
       "ConnectionStringWithTopic": "#{Arcus.ServiceBus.ConnectionStringWithTopic}#"
     },

--- a/src/Arcus.Messaging.Tests.Integration/appsettings.json
+++ b/src/Arcus.Messaging.Tests.Integration/appsettings.json
@@ -17,10 +17,12 @@
     "ServiceBus": {
       "Docker": {
         "ConnectionStringWithQueue": "#{Arcus.ServiceBus.Docker.ConnectionStringWithQueue}#",
-        "ConnectionStringWithTopic": "#{Arcus.ServiceBus.Docker.ConnectionStringWithTopic}#" 
+        "ConnectionStringWithTopic": "#{Arcus.ServiceBus.Docker.ConnectionStringWithTopic}#"
       },
-      "ConnectionStringWithQueue": "#{Arcus.ServiceBus.ConnectionStringWithQueue}#",
-      "ConnectionStringWithTopic": "#{Arcus.ServiceBus.ConnectionStringWithTopic}#"
+      "SelfContained": {
+        "ConnectionStringWithQueue": "#{Arcus.ServiceBus.ConnectionStringWithQueue}#",
+        "ConnectionStringWithTopic": "#{Arcus.ServiceBus.ConnectionStringWithTopic}#"
+      } 
     },
     "KeyRotation": {
       "ServicePrincipal": {


### PR DESCRIPTION
Use speparate Azure resources for Docker integration tests so it can run more safely in parallel with the self-contained integration tests.

Closes #121 