### PR TITLE
Feature - add completion message to specific Azure Service Bus influence message handler

### DIFF
--- a/docs/preview/features/message-pumps/service-bus.md
+++ b/docs/preview/features/message-pumps/service-bus.md
@@ -211,6 +211,7 @@ To have access to the Azure Service Bus operations, you have to implement the `a
 Behind the screens it implements the `IMessageHandler<>` interface, so you can register this the same way as your other regular message handlers.
 
 This base class provides several protected methods to call the Azure Service Bus operations:
+- `.CompleteMessageAsync`
 - `.DeadLetterMessageAsync`
 - `.AbandonMessageAsync`
 
@@ -253,6 +254,7 @@ To have access to the Azure Service Bus operations, you have to implement the ab
 Behind the scenes it implements the `IServiceBusFallbackMessageHandler`, so you can register this the same way as any other fallback message handler.
 
 This base class provides several protected methods to call the Azure Service Bus operations:
+- `.CompleteAsync`
 - `.DeadLetterAsync`
 - `.AbandonAsync`
 

--- a/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/AzureServiceBusFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/AzureServiceBusFallbackMessageHandler.cs
@@ -39,6 +39,17 @@ namespace Arcus.Messaging.Pumps.ServiceBus.MessageHandling
             CancellationToken cancellationToken);
 
         /// <summary>
+        /// Completes the Azure Service Bus message on Azure.
+        /// </summary>
+        /// <param name="message">The Azure Service Bus message to be completed.</param>
+        protected async Task CompleteAsync(Message message)
+        {
+            Guard.NotNull(message, nameof(message), "Requires a message to be completed");
+
+            await MessageReceiver.CompleteAsync(message.SystemProperties.LockToken);
+        }
+
+        /// <summary>
         /// Dead letters the Azure Service Bus <paramref name="message"/> on Azure while providing <paramref name="newMessageProperties"/> for properties that has to be modified in the process.
         /// </summary>
         /// <param name="message">The message that has to be dead lettered.</param>

--- a/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/AzureServiceBusMessageHandler.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/MessageHandling/AzureServiceBusMessageHandler.cs
@@ -35,6 +35,19 @@ namespace Arcus.Messaging.Pumps.ServiceBus.MessageHandling
             CancellationToken cancellationToken);
 
         /// <summary>
+        /// Completes the Azure Service Bus message on Azure.
+        /// </summary>
+        protected async Task CompleteMessageAsync()
+        {
+            if (LockToken is null)
+            {
+                throw new InvalidOperationException("Cannot complete the message because the message receiver was not yet initialized");
+            }
+
+            await MessageReceiver.CompleteAsync(LockToken);
+        }
+
+        /// <summary>
         /// Dead letters the Azure Service Bus message on Azure while providing <paramref name="newMessageProperties"/> for properties that has to be modified in the process.
         /// </summary>
         /// <param name="newMessageProperties">The properties to modify on the message during the dead lettering of the message.</param>
@@ -43,12 +56,12 @@ namespace Arcus.Messaging.Pumps.ServiceBus.MessageHandling
         {
             if (LockToken is null)
             {
-                throw new InvalidOperationException("Cannot dead letter the message because the message was not yet initialized");
+                throw new InvalidOperationException("Cannot dead letter the message because the lock token was not yet initialized");
             }
 
             if (MessageReceiver is null)
             {
-                throw new InvalidOperationException($"Cannot dead letter the message because the message receiver was not yet initialized");
+                throw new InvalidOperationException("Cannot dead letter the message because the message receiver was not yet initialized");
             }
 
             Logger.LogTrace("Dead-lettering message using lock token '{LockToken}'...", LockToken);
@@ -70,12 +83,12 @@ namespace Arcus.Messaging.Pumps.ServiceBus.MessageHandling
 
             if (LockToken is null)
             {
-                throw new InvalidOperationException("Cannot dead letter the message because the message was not yet initialized");
+                throw new InvalidOperationException("Cannot dead letter the message because the lock token was not yet initialized");
             }
 
             if (MessageReceiver is null)
             {
-                throw new InvalidOperationException($"Cannot dead letter the message because the message receiver was not yet initialized");
+                throw new InvalidOperationException("Cannot dead letter the message because the message receiver was not yet initialized");
             }
 
             Logger.LogTrace("Dead-lettering message using lock token '{LockToken}' because '{Reason}'...", LockToken, deadLetterReason);
@@ -92,12 +105,12 @@ namespace Arcus.Messaging.Pumps.ServiceBus.MessageHandling
         {
             if (LockToken is null)
             {
-                throw new InvalidOperationException("Cannot abandon the message because the message was not yet initialized");
+                throw new InvalidOperationException("Cannot abandon the message because the lock token was not yet initialized");
             }
 
             if (MessageReceiver is null)
             {
-                throw new InvalidOperationException($"Cannot Abandon the message because the message receiver was not yet initialized");
+                throw new InvalidOperationException("Cannot Abandon the message because the message receiver was not yet initialized");
             }
 
             Logger.LogTrace("Abandoning message using lock token '{LockToken}'...", LockToken);

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueCompleteProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueCompleteProgram.cs
@@ -1,0 +1,49 @@
+using Arcus.EventGrid.Publishing;
+using Arcus.Messaging.Tests.Core.Messages.v1;
+using Arcus.Messaging.Tests.Workers.MessageHandlers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+// ReSharper disable once CheckNamespace
+namespace Arcus.Messaging.Tests.Workers.ServiceBus
+{
+    public class ServiceBusQueueCompleteProgram
+    {
+        public static void main(string[] args)
+        {
+            CreateHostBuilder(args)
+                .Build()
+                .Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration(configuration =>
+                {
+                    configuration.AddCommandLine(args);
+                    configuration.AddEnvironmentVariables();
+                })
+                .ConfigureLogging(loggingBuilder => loggingBuilder.AddConsole(options => options.IncludeScopes = true))
+                .ConfigureServices((hostContext, services) =>
+                {
+                    services.AddTransient(svc =>
+                    {
+                        var configuration = svc.GetRequiredService<IConfiguration>();
+                        var eventGridTopic = configuration.GetValue<string>("EVENTGRID_TOPIC_URI");
+                        var eventGridKey = configuration.GetValue<string>("EVENTGRID_AUTH_KEY");
+
+                        return EventGridPublisherBuilder
+                               .ForTopic(eventGridTopic)
+                               .UsingAuthenticationKey(eventGridKey)
+                               .Build();
+                    });
+                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"], options => options.AutoComplete = false)
+                            .WithServiceBusMessageHandler<OrdersAzureServiceBusCompleteMessageHandler, Order>();
+
+                    services.AddTcpHealthProbes("ARCUS_HEALTH_PORT", builder => builder.AddCheck("sample", () => HealthCheckResult.Healthy()));
+                });
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusTopicFallbackCompleteProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusTopicFallbackCompleteProgram.cs
@@ -1,0 +1,51 @@
+using Arcus.EventGrid.Publishing;
+using Arcus.Messaging.Pumps.Abstractions.Extensions;
+using Arcus.Messaging.Tests.Core.Messages.v1;
+using Arcus.Messaging.Tests.Workers.MessageHandlers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+// ReSharper disable once CheckNamespace
+namespace Arcus.Messaging.Tests.Workers.ServiceBus
+{
+    public class ServiceBusTopicFallbackCompleteProgram
+    {
+        public static void main(string[] args)
+        {
+            CreateHostBuilder(args)
+                .Build()
+                .Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration(configuration =>
+                {
+                    configuration.AddCommandLine(args);
+                    configuration.AddEnvironmentVariables();
+                })
+                .ConfigureLogging(loggingBuilder => loggingBuilder.AddConsole(options => options.IncludeScopes = true))
+                .ConfigureServices((hostContext, services) =>
+                {
+                    services.AddTransient(svc =>
+                    {
+                        var configuration = svc.GetRequiredService<IConfiguration>();
+                        var eventGridTopic = configuration.GetValue<string>("EVENTGRID_TOPIC_URI");
+                        var eventGridKey = configuration.GetValue<string>("EVENTGRID_AUTH_KEY");
+
+                        return EventGridPublisherBuilder
+                               .ForTopic(eventGridTopic)
+                               .UsingAuthenticationKey(eventGridKey)
+                               .Build();
+                    });
+                    services.AddServiceBusTopicMessagePump("Test-Receive-All-Topic-Only", configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"], options => options.AutoComplete = false)
+                            .WithServiceBusMessageHandler<PassThruOrderMessageHandler, Order>(context => false)
+                            .WithServiceBusFallbackMessageHandler<OrdersFallbackCompleteMessageHandler>();
+
+                    services.AddTcpHealthProbes("ARCUS_HEALTH_PORT", builder => builder.AddCheck("sample", () => HealthCheckResult.Healthy()));
+                });
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -35,6 +35,8 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
         [InlineData(ServiceBusEntity.Queue, typeof(ServiceBusQueueContextTypeSelectionProgram))]
         [InlineData(ServiceBusEntity.Topic, typeof(ServiceBusTopicProgram))]
         [InlineData(ServiceBusEntity.Topic, typeof(ServiceBusTopicContextPredicateSelectionProgram))]
+        [InlineData(ServiceBusEntity.Queue, typeof(ServiceBusQueueCompleteProgram))]
+        [InlineData(ServiceBusEntity.Topic, typeof(ServiceBusTopicFallbackCompleteProgram))]
         public async Task ServiceBusMessagePump_PublishServiceBusMessage_MessageSuccessfullyProcessed(ServiceBusEntity entity, Type programType)
         {
             // Arrange

--- a/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersAzureServiceBusCompleteMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersAzureServiceBusCompleteMessageHandler.cs
@@ -1,0 +1,45 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Arcus.EventGrid.Publishing.Interfaces;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
+using Arcus.Messaging.Tests.Core.Messages.v1;
+using Microsoft.Extensions.Logging;
+
+namespace Arcus.Messaging.Tests.Workers.MessageHandlers
+{
+    public class OrdersAzureServiceBusCompleteMessageHandler : AzureServiceBusMessageHandler<Order>
+    {
+        private readonly IAzureServiceBusMessageHandler<Order> _orderMessageHandler;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrdersAzureServiceBusCompleteMessageHandler"/> class.
+        /// </summary>
+        public OrdersAzureServiceBusCompleteMessageHandler(IEventGridPublisher eventGridPublisher, ILogger<OrdersAzureServiceBusMessageHandler> logger) 
+            : base(logger)
+        {
+            _orderMessageHandler = new OrdersAzureServiceBusMessageHandler(eventGridPublisher, logger);
+        }
+
+        /// <summary>
+        ///     Process a new message that was received
+        /// </summary>
+        /// <param name="message">Message that was received</param>
+        /// <param name="messageContext">Context providing more information concerning the processing</param>
+        /// <param name="correlationInfo">
+        ///     Information concerning correlation of telemetry and processes by using a variety of unique
+        ///     identifiers
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        public override async Task ProcessMessageAsync(
+            Order message,
+            AzureServiceBusMessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            await _orderMessageHandler.ProcessMessageAsync(message, messageContext, correlationInfo, cancellationToken);
+            await CompleteMessageAsync();
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersFallbackCompleteMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersFallbackCompleteMessageHandler.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.EventGrid.Publishing.Interfaces;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
+using Microsoft.Azure.ServiceBus;
+using Microsoft.Extensions.Logging;
+
+namespace Arcus.Messaging.Tests.Workers.MessageHandlers
+{
+    public class OrdersFallbackCompleteMessageHandler : AzureServiceBusFallbackMessageHandler
+    {
+        private readonly IAzureServiceBusFallbackMessageHandler _fallbackMessageHandler;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureServiceBusFallbackMessageHandler"/> class.
+        /// </summary>
+        public OrdersFallbackCompleteMessageHandler(
+            IEventGridPublisher eventGridPublisher,
+            ILogger<OrdersAzureServiceBusMessageHandler> logger) : base(logger)
+        {
+            _fallbackMessageHandler = new OrdersServiceBusFallbackMessageHandler(eventGridPublisher, logger);
+        }
+
+        /// <summary>
+        ///     Process a new message that was received
+        /// </summary>
+        /// <param name="message">The Azure Service Bus Message message that was received</param>
+        /// <param name="messageContext">The context providing more information concerning the processing</param>
+        /// <param name="correlationInfo">
+        ///     The information concerning correlation of telemetry and processes by using a variety of unique
+        ///     identifiers.
+        /// </param>
+        /// <param name="cancellationToken">The cancellation token to cancel the processing.</param>
+        public override async Task ProcessMessageAsync(
+            Message message,
+            AzureServiceBusMessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            await _fallbackMessageHandler.ProcessMessageAsync(message, messageContext, correlationInfo, cancellationToken);
+            await CompleteMessageAsync(message);
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersFallbackCompleteMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersFallbackCompleteMessageHandler.cs
@@ -43,7 +43,7 @@ namespace Arcus.Messaging.Tests.Workers.MessageHandlers
             CancellationToken cancellationToken)
         {
             await _fallbackMessageHandler.ProcessMessageAsync(message, messageContext, correlationInfo, cancellationToken);
-            await CompleteMessageAsync(message);
+            await CompleteAsync(message);
         }
     }
 }


### PR DESCRIPTION
Add the `.CompleteMessageAsync` and the `.CompleteAsync` to the respectively (regular) and fallback specific Azure Service Bus message handler templates.

Closes #128 