### PR TITLE
Fix - include correlation information when tracking exceptions

### DIFF
--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -415,32 +415,21 @@ namespace Arcus.Messaging.Pumps.ServiceBus
 
             try
             {
-                bool subscriptionExists =
-                    await serviceBusClient.SubscriptionExistsAsync(serviceBusConnectionString.EntityPath, SubscriptionName, cancellationToken);
-                
+                bool subscriptionExists = await serviceBusClient.SubscriptionExistsAsync(serviceBusConnectionString.EntityPath, SubscriptionName, cancellationToken);
                 if (subscriptionExists)
                 {
-                    Logger.LogTrace(
-                        "Deleting subscription '{SubscriptionName}' on topic '{Path}'...",
-                         SubscriptionName, serviceBusConnectionString.EntityPath);
-                    
+                    Logger.LogTrace("Deleting subscription '{SubscriptionName}' on topic '{Path}'...", SubscriptionName, serviceBusConnectionString.EntityPath);
                     await serviceBusClient.DeleteSubscriptionAsync(serviceBusConnectionString.EntityPath, SubscriptionName, cancellationToken);
-                    
-                    Logger.LogTrace(
-                        "Subscription '{SubscriptionName}' deleted on topic '{Path}'",
-                         SubscriptionName, serviceBusConnectionString.EntityPath);
+                    Logger.LogTrace("Subscription '{SubscriptionName}' deleted on topic '{Path}'", SubscriptionName, serviceBusConnectionString.EntityPath);
                 }
                 else
                 {
-                    Logger.LogTrace(
-                        "Cannot delete topic subscription with name '{SubscriptionName}' because no subscription exists on Service Bus resource",
-                         SubscriptionName); }
+                    Logger.LogTrace("Cannot delete topic subscription with name '{SubscriptionName}' because no subscription exists on Service Bus resource", SubscriptionName);
+                }
             }
             catch (Exception exception)
             {
-                Logger.LogWarning(exception, 
-                    "Failed to delete topic subscription with name '{SubscriptionName}' on Service Bus resource", 
-                     SubscriptionName);
+                Logger.LogWarning(exception, "Failed to delete topic subscription with name '{SubscriptionName}' on Service Bus resource", SubscriptionName);
             }
             finally
             {
@@ -479,33 +468,23 @@ namespace Arcus.Messaging.Pumps.ServiceBus
                 Logger.LogInformation("No operation ID was found on the message");
             }
 
-            try
+            MessageCorrelationInfo correlationInfo = message.GetCorrelationInfo();
+            using (IServiceScope serviceScope = ServiceProvider.CreateScope())
             {
-                MessageCorrelationInfo correlationInfo = message.GetCorrelationInfo();
-                using (IServiceScope serviceScope = ServiceProvider.CreateScope())
+                var correlationInfoAccessor = serviceScope.ServiceProvider.GetService<ICorrelationInfoAccessor<MessageCorrelationInfo>>();
+                if (correlationInfoAccessor is null)
                 {
-                    var correlationInfoAccessor = serviceScope.ServiceProvider.GetService<ICorrelationInfoAccessor<MessageCorrelationInfo>>();
-                    if (correlationInfoAccessor is null)
+                    Logger.LogTrace("No message correlation configured");
+                    await ProcessMessageWithFallbackAsync(message, cancellationToken, correlationInfo);
+                }
+                else
+                {
+                    correlationInfoAccessor.SetCorrelationInfo(correlationInfo);
+                    using (LogContext.Push(new MessageCorrelationInfoEnricher(correlationInfoAccessor)))
                     {
-                        Logger.LogTrace("No message correlation configured");
-                        await ProcessMessageAsync(message, cancellationToken, correlationInfo);
-                    }
-                    else
-                    {
-                        correlationInfoAccessor.SetCorrelationInfo(correlationInfo);
-                        using (LogContext.Push(new MessageCorrelationInfoEnricher(correlationInfoAccessor)))
-                        {
-                            await ProcessMessageAsync(message, cancellationToken, correlationInfo);
-                        }
+                        await ProcessMessageWithFallbackAsync(message, cancellationToken, correlationInfo);
                     }
                 }
-            }
-            catch (Exception ex)
-            {
-                Logger.LogCritical(ex, "Unable to process message with ID '{MessageId}'",  message.MessageId);
-                await HandleReceiveExceptionAsync(ex);
-
-                throw;
             }
         }
 
@@ -535,41 +514,58 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             return Task.CompletedTask;
         }
 
-        private async Task ProcessMessageAsync(
-            Message message,
-            CancellationToken cancellationToken,
-            MessageCorrelationInfo correlationInfo)
+        private async Task ProcessMessageWithFallbackAsync(Message message, CancellationToken cancellationToken, MessageCorrelationInfo correlationInfo)
         {
-            Logger.LogTrace("Received message '{MessageId}'", message.MessageId);
-
-            var messageContext = new AzureServiceBusMessageContext(message.MessageId, message.SystemProperties, message.UserProperties);
-            Encoding encoding = messageContext.GetMessageEncodingProperty(Logger);
-            string messageBody = encoding.GetString(message.Body);
-
-            if (_fallbackMessageHandler is null)
+            try
             {
-                await ProcessMessageAsync(messageBody, messageContext, correlationInfo, cancellationToken);
+                Logger.LogTrace("Received message '{MessageId}'", message.MessageId);
+
+                var messageContext = new AzureServiceBusMessageContext(message.MessageId, message.SystemProperties, message.UserProperties);
+                Encoding encoding = messageContext.GetMessageEncodingProperty(Logger);
+                string messageBody = encoding.GetString(message.Body);
+
+                if (_fallbackMessageHandler is null)
+                {
+                    await ProcessMessageAsync(messageBody, messageContext, correlationInfo, cancellationToken);
+                }
+                else
+                {
+                    await FallbackProcessMessageAsync(message, messageBody, messageContext, correlationInfo, cancellationToken);
+                }
+
+                Logger.LogTrace("Message '{MessageId}' processed", message.MessageId);
             }
-            else
+            catch (Exception exception)
             {
-                if (_fallbackMessageHandler is AzureServiceBusMessageHandlerTemplate specificMessageHandler)
-                {
-                    specificMessageHandler.SetMessageReceiver(_messageReceiver);
-                }
+                Logger.LogCritical(exception, "Unable to process message with ID '{MessageId}'",  message.MessageId);
+                await HandleReceiveExceptionAsync(exception);
 
-                MessageHandlerResult result = await ProcessMessageAndCaptureAsync(messageBody, messageContext, correlationInfo, cancellationToken);
-                if (result.Exception != null)
-                {
-                    throw result.Exception;
-                }
+                throw;
+            }
+        }
 
-                if (!result.IsProcessed)
-                {
-                    await _fallbackMessageHandler.ProcessMessageAsync(message, messageContext, correlationInfo, cancellationToken);
-                }
+        private async Task FallbackProcessMessageAsync(
+            Message message,
+            string messageBody,
+            AzureServiceBusMessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            if (_fallbackMessageHandler is AzureServiceBusMessageHandlerTemplate specificMessageHandler)
+            {
+                specificMessageHandler.SetMessageReceiver(_messageReceiver);
             }
 
-            Logger.LogTrace("Message '{MessageId}' processed", message.MessageId);
+            MessageHandlerResult result = await ProcessMessageAndCaptureAsync(messageBody, messageContext, correlationInfo, cancellationToken);
+            if (result.Exception != null)
+            {
+                throw result.Exception;
+            }
+
+            if (!result.IsProcessed)
+            {
+                await _fallbackMessageHandler.ProcessMessageAsync(message, messageContext, correlationInfo, cancellationToken);
+            }
         }
 
         private static async Task UntilCancelledAsync(CancellationToken cancellationToken)

--- a/src/Arcus.Messaging.Tests.Integration/Arcus.Messaging.Tests.Integration.csproj
+++ b/src/Arcus.Messaging.Tests.Integration/Arcus.Messaging.Tests.Integration.csproj
@@ -18,8 +18,11 @@
   <ItemGroup>
     <PackageReference Include="Arcus.EventGrid.Publishing" Version="3.0.0" />
     <PackageReference Include="Arcus.EventGrid.Testing" Version="3.0.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="0.4.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="0.4.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.3.0" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Azure.ApplicationInsights.Query" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.0" />
@@ -29,6 +32,9 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ApplicationInsightsConfig.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ApplicationInsightsConfig.cs
@@ -12,14 +12,17 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
         /// </summary>
         /// <param name="instrumentationKey">The instrumentation key of the Azure Application Insights resource.</param>
         /// <param name="applicationId">The application ID that has API access to the Azure Application Insights resource.</param>
-        /// <exception cref="System.ArgumentException">Thrown when the <paramref name="instrumentationKey"/> or <paramref name="applicationId"/> is blank.</exception>
-        public ApplicationInsightsConfig(string instrumentationKey, string applicationId)
+        /// <param name="apiKey">The application API key that has API access to the Azure Application Insights resource.</param>
+        /// <exception cref="System.ArgumentException">Thrown when the <paramref name="instrumentationKey"/> or <paramref name="apiKey"/> or <paramref name="apiKey"/> is blank.</exception>
+        public ApplicationInsightsConfig(string instrumentationKey, string applicationId, string apiKey)
         {
             Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires a non-blank Application Insights instrumentation key");
-            Guard.NotNullOrWhitespace(applicationId, nameof(applicationId), "Requires a non-blank Application Insights application id");
+            Guard.NotNullOrWhitespace(apiKey, nameof(apiKey), "Requires a non-blank Application Insights application application ID");
+            Guard.NotNullOrWhitespace(apiKey, nameof(apiKey), "Requires a non-blank Application Insights application API key");
 
             InstrumentationKey = instrumentationKey;
             ApplicationId = applicationId;
+            ApiKey = apiKey;
         }
 
         /// <summary>
@@ -31,5 +34,10 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
         /// Gets the application ID which has API access to the Application Insights resource.
         /// </summary>
         public string ApplicationId { get; }
+
+        /// <summary>
+        /// Gets the application API key which has API access to the Application Insights resource.
+        /// </summary>
+        public string ApiKey { get; }
     }
 }

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ApplicationInsightsConfig.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ApplicationInsightsConfig.cs
@@ -1,0 +1,35 @@
+﻿using GuardNet;
+
+namespace Arcus.Messaging.Tests.Integration.Fixture
+{
+    /// <summary>
+    /// Represents an application configuration section related to information regarding Azure Application Insights.
+    /// </summary>
+    public class ApplicationInsightsConfig
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApplicationInsightsConfig"/> class.
+        /// </summary>
+        /// <param name="instrumentationKey">The instrumentation key of the Azure Application Insights resource.</param>
+        /// <param name="applicationId">The application ID that has API access to the Azure Application Insights resource.</param>
+        /// <exception cref="System.ArgumentException">Thrown when the <paramref name="instrumentationKey"/> or <paramref name="applicationId"/> is blank.</exception>
+        public ApplicationInsightsConfig(string instrumentationKey, string applicationId)
+        {
+            Guard.NotNullOrWhitespace(instrumentationKey, nameof(instrumentationKey), "Requires a non-blank Application Insights instrumentation key");
+            Guard.NotNullOrWhitespace(applicationId, nameof(applicationId), "Requires a non-blank Application Insights application id");
+
+            InstrumentationKey = instrumentationKey;
+            ApplicationId = applicationId;
+        }
+
+        /// <summary>
+        /// Gets the instrumentation key to connect to the Application Insights resource.
+        /// </summary>
+        public string InstrumentationKey { get; }
+
+        /// <summary>
+        /// Gets the application ID which has API access to the Application Insights resource.
+        /// </summary>
+        public string ApplicationId { get; }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueTrackCorrelationOnExceptionProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueTrackCorrelationOnExceptionProgram.cs
@@ -1,0 +1,74 @@
+using System;
+using Arcus.EventGrid.Publishing;
+using Arcus.Messaging.Tests.Core.Messages.v1;
+using Arcus.Messaging.Tests.Workers.MessageHandlers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Serilog;
+using Serilog.Configuration;
+using Serilog.Events;
+
+// ReSharper disable once CheckNamespace
+namespace Arcus.Messaging.Tests.Workers.ServiceBus
+{
+    public class ServiceBusQueueTrackCorrelationOnExceptionProgram
+    {
+        public static void main(string[] args)
+        {
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .WriteTo.Console()
+                .CreateLogger();
+
+            try
+            {
+                CreateHostBuilder(args)
+                        .Build()
+                        .Run();
+            }
+            catch (Exception exception)
+            {
+                Log.Fatal(exception, "Host terminated unexpectedly");
+            }
+            finally
+            {
+                Log.CloseAndFlush();
+            }
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration(configuration =>
+                {
+                    configuration.AddCommandLine(args);
+                    configuration.AddEnvironmentVariables();
+                })
+                .UseSerilog(UpdateLoggerConfiguration)
+                .ConfigureServices((hostContext, services) =>
+                {
+                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
+                            .WithServiceBusMessageHandler<OrdersSabotageAzureServiceBusMessageHandler, Order>();
+
+                    services.AddTcpHealthProbes("ARCUS_HEALTH_PORT", builder => builder.AddCheck("sample", () => HealthCheckResult.Healthy()));
+                });
+
+        private static void UpdateLoggerConfiguration(
+            HostBuilderContext hostContext,
+            LoggerConfiguration currentLoggerConfiguration)
+        {
+            var instrumentationKey = hostContext.Configuration.GetValue<string>("APPLICATIONINSIGHTS_INSTRUMENTATIONKEY");
+
+            currentLoggerConfiguration
+                .MinimumLevel.Debug()
+                .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+                .Enrich.FromLogContext()
+                .Enrich.WithVersion()
+                .Enrich.WithComponentName("Service Bus Queue Worker")
+                .WriteTo.Console()
+                .WriteTo.AzureApplicationInsights(instrumentationKey);
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/TestConfig.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/TestConfig.cs
@@ -79,6 +79,18 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
         }
 
         /// <summary>
+        /// Gets the Application Insights configuration from the application configuration.
+        /// </summary>
+        /// <exception cref="ArgumentException">Thrown when one of the Application Insights configuration values is blank.</exception>
+        public ApplicationInsightsConfig GetApplicationInsightsConfig()
+        {
+            var instrumentationKey = _config.GetValue<string>("Arcus:ApplicationInsights:InstrumentationKey");
+            var applicationId = _config.GetValue<string>("Arcus:ApplicationInsights:ApplicationId");
+
+            return new ApplicationInsightsConfig(instrumentationKey, applicationId);
+        }
+
+        /// <summary>
         /// Gets the project directory where the fixtures are located.
         /// </summary>
         public DirectoryInfo GetIntegrationTestProjectDirectory()

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/TestConfig.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/TestConfig.cs
@@ -86,8 +86,9 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
         {
             var instrumentationKey = _config.GetValue<string>("Arcus:ApplicationInsights:InstrumentationKey");
             var applicationId = _config.GetValue<string>("Arcus:ApplicationInsights:ApplicationId");
+            var apiKey = _config.GetValue<string>("Arcus:ApplicationInsights:ApiKey");
 
-            return new ApplicationInsightsConfig(instrumentationKey, applicationId);
+            return new ApplicationInsightsConfig(instrumentationKey, applicationId, apiKey);
         }
 
         /// <summary>

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -214,7 +214,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             await service.SendMessageToServiceBusAsync(connectionString, orderMessage);
 
             // Assert
-            using (ApplicationInsightsDataClient client = CreateApplicationInsightsClient(applicationInsightsConfig.InstrumentationKey))
+            using (ApplicationInsightsDataClient client = CreateApplicationInsightsClient(applicationInsightsConfig.ApiKey))
             {
                 await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
                 {
@@ -295,7 +295,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             RetryPolicy retryPolicy =
                 Policy.Handle<Exception>(exception =>
                       {
-                          _logger.LogError(exception, "Failed to contact Azure Application Insights");
+                          _logger.LogError(exception, "Failed to contact Azure Application Insights. Reason: {Message}", exception.Message);
                           return true;
                       })
                       .WaitAndRetryForeverAsync(index => TimeSpan.FromSeconds(1));

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -1,19 +1,25 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Pumps.ServiceBus;
 using Arcus.Messaging.Tests.Core.Generators;
 using Arcus.Messaging.Tests.Core.Messages.v1;
 using Arcus.Messaging.Tests.Integration.Fixture;
 using Arcus.Messaging.Tests.Integration.ServiceBus;
 using Arcus.Messaging.Tests.Workers.ServiceBus;
+using Arcus.Observability.Telemetry.Core;
 using Arcus.Security.Providers.AzureKeyVault.Authentication;
 using Arcus.Testing.Logging;
+using Microsoft.Azure.ApplicationInsights.Query;
+using Microsoft.Azure.ApplicationInsights.Query.Models;
 using Microsoft.Azure.KeyVault;
 using Microsoft.Azure.Management.ServiceBus.Models;
 using Microsoft.Azure.ServiceBus;
 using Microsoft.Extensions.Logging;
+using Polly;
 using Xunit;
 using Xunit.Abstractions;
+using RetryPolicy = Polly.Retry.RetryPolicy;
 
 namespace Arcus.Messaging.Tests.Integration.MessagePump
 {
@@ -186,6 +192,48 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
         }
 
         [Fact]
+        public async Task ServiceBusMessagePump_FailureDuringMessageHandling_TracksCorrelationInApplicationInsights()
+        {
+            // Arrange
+            string operationId = $"operation-{Guid.NewGuid()}", transactionId = $"transaction-{Guid.NewGuid()}";
+
+            var config = TestConfig.Create();
+            ApplicationInsightsConfig applicationInsightsConfig = config.GetApplicationInsightsConfig();
+            string connectionString = config.GetServiceBusConnectionString(ServiceBusEntity.Queue);
+            var commandArguments = new[]
+            {
+                CommandArgument.CreateSecret("APPLICATIONINSIGHTS_INSTRUMENTATIONKEY", applicationInsightsConfig.InstrumentationKey),
+                CommandArgument.CreateSecret("ARCUS_SERVICEBUS_CONNECTIONSTRING", connectionString)
+            };
+
+            using var project = await ServiceBusWorkerProject.StartNewWithAsync<ServiceBusQueueTrackCorrelationOnExceptionProgram>(config, _logger, commandArguments);
+            await using var service = await TestMessagePumpService.StartNewAsync(config, _logger);
+            Message orderMessage = OrderGenerator.Generate().AsServiceBusMessage(operationId, transactionId);
+                    
+            // Act
+            await service.SendMessageToServiceBusAsync(connectionString, orderMessage);
+
+            // Assert
+            using (ApplicationInsightsDataClient client = CreateApplicationInsightsClient(applicationInsightsConfig.InstrumentationKey))
+            {
+                await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
+                {
+                    const string onlyLastHourFilter = "timestamp gt now() sub duration'PT1H'";
+                    EventsResults<EventsExceptionResult> results = 
+                        await client.Events.GetExceptionEventsAsync(applicationInsightsConfig.ApplicationId, filter: onlyLastHourFilter);
+
+                    Assert.Contains(results.Value, result =>
+                    {
+                        result.CustomDimensions.TryGetValue(ContextProperties.Correlation.TransactionId, out string actualTransactionId);
+                        result.CustomDimensions.TryGetValue(ContextProperties.Correlation.OperationId, out string actualOperationId);
+
+                        return transactionId == actualTransactionId && operationId == actualOperationId;
+                    });
+                }, timeout: TimeSpan.FromMinutes(5));
+            }
+        }
+
+        [Fact]
         public async Task ServiceBusMessagePump_RotateServiceBusConnectionKeys_MessagePumpRestartsThenMessageSuccessfullyProcessed()
         {
             // Arrange
@@ -232,6 +280,29 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                 vaultBaseUrl: keyRotationConfig.KeyVaultSecret.VaultUri,
                 secretName: keyRotationConfig.KeyVaultSecret.SecretName,
                 value: rotatedConnectionString);
+        }
+
+        private static ApplicationInsightsDataClient CreateApplicationInsightsClient(string instrumentationKey)
+        {
+            var clientCredentials = new ApiKeyClientCredentials(instrumentationKey);
+            var client = new ApplicationInsightsDataClient(clientCredentials);
+
+            return client;
+        }
+
+        private async Task RetryAssertUntilTelemetryShouldBeAvailableAsync(Func<Task> assertion, TimeSpan timeout)
+        {
+            RetryPolicy retryPolicy =
+                Policy.Handle<Exception>(exception =>
+                      {
+                          _logger.LogError(exception, "Failed to contact Azure Application Insights");
+                          return true;
+                      })
+                      .WaitAndRetryForeverAsync(index => TimeSpan.FromSeconds(1));
+
+            await Policy.TimeoutAsync(timeout)
+                        .WrapAsync(retryPolicy)
+                        .ExecuteAsync(assertion);
         }
     }
 }

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -227,7 +227,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                         result.CustomDimensions.TryGetValue(ContextProperties.Correlation.TransactionId, out string actualTransactionId);
                         result.CustomDimensions.TryGetValue(ContextProperties.Correlation.OperationId, out string actualOperationId);
 
-                        return transactionId == actualTransactionId && operationId == actualOperationId;
+                        return transactionId == actualTransactionId && operationId == actualOperationId && operationId == result.Operation.Id;
                     });
                 }, timeout: TimeSpan.FromMinutes(5));
             }

--- a/src/Arcus.Messaging.Tests.Integration/appsettings.json
+++ b/src/Arcus.Messaging.Tests.Integration/appsettings.json
@@ -22,7 +22,11 @@
       "SelfContained": {
         "ConnectionStringWithQueue": "#{Arcus.ServiceBus.ConnectionStringWithQueue}#",
         "ConnectionStringWithTopic": "#{Arcus.ServiceBus.ConnectionStringWithTopic}#"
-      } 
+      }
+    },
+    "ApplicationInsights": {
+      "InstrumentationKey": "#{Arcus.ApplicationInsights.InstrumentationKey}#",
+      "ApplicationId": "#{Arcus.ApplicationInsights.ApplicationId}#" 
     },
     "KeyRotation": {
       "ServicePrincipal": {

--- a/src/Arcus.Messaging.Tests.Integration/appsettings.json
+++ b/src/Arcus.Messaging.Tests.Integration/appsettings.json
@@ -6,7 +6,6 @@
     "Infra": {
       "ServiceBus": {
         "TopicName": "#{Arcus.TestInfra.ServiceBus.Topic.Name}#",
-        
         "ConnectionString": "#{Arcus.TestInfra.ServiceBus.Topic.ConnectionString}#"
       },
       "EventGrid": {
@@ -26,7 +25,8 @@
     },
     "ApplicationInsights": {
       "InstrumentationKey": "#{Arcus.ApplicationInsights.InstrumentationKey}#",
-      "ApplicationId": "#{Arcus.ApplicationInsights.ApplicationId}#" 
+      "ApplicationId": "#{Arcus.ApplicationInsights.ApplicationId}#",
+      "ApiKey": "#{Arcus.ApplicationInsights.ApiKey}#" 
     },
     "KeyRotation": {
       "ServicePrincipal": {

--- a/src/Arcus.Messaging.Tests.Workers.ServiceBus/Arcus.Messaging.Tests.Workers.ServiceBus.csproj
+++ b/src/Arcus.Messaging.Tests.Workers.ServiceBus/Arcus.Messaging.Tests.Workers.ServiceBus.csproj
@@ -14,12 +14,17 @@
   <ItemGroup>
     <PackageReference Include="Arcus.EventGrid.Publishing" Version="3.0.0" />
     <PackageReference Include="Arcus.EventGrid.Testing" Version="3.0.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="0.4.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="0.4.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.3.0" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.5" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersSabotageAzureServiceBusMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersSabotageAzureServiceBusMessageHandler.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Tests.Core.Messages.v1;
+
+namespace Arcus.Messaging.Tests.Workers.MessageHandlers
+{
+    public class OrdersSabotageAzureServiceBusMessageHandler : IAzureServiceBusMessageHandler<Order>
+    {
+        /// <summary>
+        ///     Process a new message that was received
+        /// </summary>
+        /// <param name="message">Message that was received</param>
+        /// <param name="messageContext">Context providing more information concerning the processing</param>
+        /// <param name="correlationInfo">
+        ///     Information concerning correlation of telemetry and processes by using a variety of unique
+        ///     identifiers
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        public Task ProcessMessageAsync(
+            Order message,
+            AzureServiceBusMessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            throw new InvalidOperationException(
+                "Sabotage the message processing with an unhandled exception");
+        }
+    }
+}


### PR DESCRIPTION
Moved the try/catch/track block inside the correlation information scope.
This wasn't the case which meant that exceptions where tracked without correlation information.

Related to #132 