### PR TITLE
Fix - combine context predicate w/ Service Bus operations

### DIFF
--- a/src/Arcus.Messaging.Pumps.Abstractions/MessageHandling/MessageHandlerRegistration.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/MessageHandling/MessageHandlerRegistration.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Reflection;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Arcus.Messaging.Abstractions;
@@ -9,15 +6,22 @@ using GuardNet;
 
 namespace Arcus.Messaging.Pumps.Abstractions.MessageHandling
 {
+    /// <summary>
+    /// Represents an specific <see cref="IMessageHandler{TMessage,TMessageContext}"/> registration that requires more metadata information than only the instance itself.
+    /// </summary>
+    /// <typeparam name="TMessage">The type of the message the <see cref="IMessageHandler{TMessage,TMessageContext}"/> can handle.</typeparam>
+    /// <typeparam name="TMessageContext">The type of the message context the <see cref="IMessageHandler{TMessage,TMessageContext}"/> can handle.</typeparam>
     internal class MessageHandlerRegistration<TMessage, TMessageContext> : IMessageHandler<TMessage, TMessageContext> 
         where TMessageContext : MessageContext
     {
         private readonly Func<TMessageContext, bool> _messageContextFilter;
-        private readonly IMessageHandler<TMessage, TMessageContext> _messageHandlerImplementation;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="MessageHandlerRegistration"/> class.
+        /// Initializes a new instance of the <see cref="MessageHandlerRegistration{TMessage, TMessageContext}"/> class.
         /// </summary>
+        /// <param name="messageContextFilter">The filter to determine if a given <see cref="MessageContext"/> can be handled by the <see cref="IMessageHandler{TMessage,TMessageContext}"/> implementation.</param>
+        /// <param name="messageHandlerImplementation">The <see cref="IMessageHandler{TMessage,TMessageContext}"/> implementation that this registration instance represents.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="messageContextFilter"/> or <paramref name="messageHandlerImplementation"/> is <c>null</c>.</exception>
         internal MessageHandlerRegistration(
             Func<TMessageContext, bool> messageContextFilter,
             IMessageHandler<TMessage, TMessageContext> messageHandlerImplementation)
@@ -26,14 +30,22 @@ namespace Arcus.Messaging.Pumps.Abstractions.MessageHandling
             Guard.NotNull(messageHandlerImplementation, nameof(messageHandlerImplementation));
 
             _messageContextFilter = messageContextFilter;
-            _messageHandlerImplementation = messageHandlerImplementation;
+            
+            Service = messageHandlerImplementation;
         }
 
         /// <summary>
-        /// 
+        /// Gets the type of the <see cref="IMessageHandler{TMessage,TMessageContext}"/> implementation.
         /// </summary>
-        /// <param name="messageContext"></param>
-        /// <returns></returns>
+        internal IMessageHandler<TMessage, TMessageContext> Service { get; }
+
+        /// <summary>
+        /// Determine if the <see cref="IMessageHandler{TMessage,TMessageContext}"/> can process messages within the given <paramref name="messageContext"/> type.
+        /// </summary>
+        /// <param name="messageContext">The specific message context, providing information about the received message.</param>
+        /// <returns>
+        ///     [true] if the <see cref="IMessageHandler{TMessage,TMessageContext}"/> can process the message within the given <paramref name="messageContext"/>; [false] otherwise.
+        /// </returns>
         internal bool CanProcessMessage(TMessageContext messageContext)
         {
             return _messageContextFilter(messageContext);
@@ -42,7 +54,6 @@ namespace Arcus.Messaging.Pumps.Abstractions.MessageHandling
         /// <summary>
         /// Process the given <paramref name="message"/> in the current <see cref="IMessageHandler{TMessage,TMessageContext}"/> representation.
         /// </summary>
-        /// <typeparam name="TMessageContext">The type of the message context used in the <see cref="IMessageHandler{TMessage,TMessageContext}"/>.</typeparam>
         /// <param name="message">The parsed message to be processed by the <see cref="IMessageHandler{TMessage,TMessageContext}"/>.</param>
         /// <param name="messageContext">The context providing more information concerning the processing.</param>
         /// <param name="correlationInfo">
@@ -56,7 +67,7 @@ namespace Arcus.Messaging.Pumps.Abstractions.MessageHandling
             MessageCorrelationInfo correlationInfo,
             CancellationToken cancellationToken)
         {
-            await _messageHandlerImplementation.ProcessMessageAsync(message, messageContext, correlationInfo, cancellationToken);
+            await Service.ProcessMessageAsync(message, messageContext, correlationInfo, cancellationToken);
         }
     }
 }

--- a/src/Arcus.Messaging.Pumps.Abstractions/MessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/MessagePump.cs
@@ -231,18 +231,19 @@ namespace Arcus.Messaging.Pumps.Abstractions
                 return true;
             }
 
+            Type messageHandlerType = handler.GetMessageHandlerType();
             if (!canProcessMessage)
             {
                 Logger.LogTrace(
                     "Message handler '{MessageHandlerType}' is not able to process the message because the message context '{MessageContextType}' didn't match the correct message handler's message context",
-                    handler.ServiceType.Name, handler.MessageContextType.Name);
+                    messageHandlerType.Name, handler.MessageContextType.Name);
             }
 
             if (!tryDeserializeToMessageFormat)
             {
                 Logger.LogTrace(
                     "Message handler '{MessageHandlerType}' is not able to process the message because the incoming message cannot be deserialized to the message that the message handler can handle",
-                    handler.ServiceType.Name);
+                    messageHandlerType.Name);
             }
 
             return false;

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -498,9 +498,12 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             Guard.NotNull(messageHandler, nameof(messageHandler), "Requires a message handler instance to pre-process the message");
             Guard.NotNull(messageContext, nameof(messageContext), "Requires a message context to pre-process the message");
 
-            Logger.LogTrace("Start pre-processing message handler {MessageHandlerType}...", messageHandler.ServiceType.Name);
+            object messageHandlerInstance = messageHandler.GetMessageHandlerInstance();
+            Type messageHandlerType = messageHandlerInstance.GetType();
 
-            if (messageHandler.Service is AzureServiceBusMessageHandlerTemplate template 
+            Logger.LogTrace("Start pre-processing message handler {MessageHandlerType}...", messageHandlerType.Name);
+            
+            if (messageHandlerInstance is AzureServiceBusMessageHandlerTemplate template 
                 && messageContext is AzureServiceBusMessageContext serviceBusMessageContext)
             {
                 template.SetLockToken(serviceBusMessageContext.SystemProperties.LockToken);
@@ -508,7 +511,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             }
             else
             {
-                Logger.LogTrace("Nothing to pre-process for message handler type '{MessageHandlerType}'", messageHandler.ServiceType.Name);
+                Logger.LogTrace("Nothing to pre-process for message handler type '{MessageHandlerType}'", messageHandlerType.Name);
             }
             
             return Task.CompletedTask;

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueContextPredicateSelectionWithDeadLetterProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueContextPredicateSelectionWithDeadLetterProgram.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Arcus.Messaging.Tests.Integration.Fixture
 {
-    public class ServiceBusTopicContextPredicateSelectionWithDeadLetterProgram
+    public class ServiceBusQueueContextPredicateSelectionWithDeadLetterProgram
     {
         public static void main(string[] args)
         {
@@ -31,18 +31,7 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
                 .ConfigureLogging(loggingBuilder => loggingBuilder.AddConsole(options => options.IncludeScopes = true))
                 .ConfigureServices((hostContext, services) =>
                 {
-                    services.AddTransient(svc =>
-                    {
-                        var configuration = svc.GetRequiredService<IConfiguration>();
-                        var eventGridTopic = configuration.GetValue<string>("EVENTGRID_TOPIC_URI");
-                        var eventGridKey = configuration.GetValue<string>("EVENTGRID_AUTH_KEY");
-
-                        return EventGridPublisherBuilder
-                               .ForTopic(eventGridTopic)
-                               .UsingAuthenticationKey(eventGridKey)
-                               .Build();
-                    });
-                    services.AddServiceBusTopicMessagePump("Test-Receive-All-Topic-Only", configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"], options => options.AutoComplete = false)
+                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"], options => options.AutoComplete = false)
                             .WithMessageHandler<PassThruOrderMessageHandler, Order, AzureServiceBusMessageContext>(context => false)
                             .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>(context => context.Properties["Topic"].ToString() == "Customers")
                             .WithServiceBusMessageHandler<OrdersAzureServiceBusDeadLetterMessageHandler, Order>(context => context.Properties["Topic"].ToString() == "Orders");

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusTopicContextPredicateSelectionWithDeadLetterProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusTopicContextPredicateSelectionWithDeadLetterProgram.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Arcus.EventGrid.Publishing;
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Tests.Core.Messages.v1;
+using Arcus.Messaging.Tests.Workers.MessageHandlers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Arcus.Messaging.Tests.Integration.Fixture
+{
+    public class ServiceBusTopicContextPredicateSelectionWithDeadLetterProgram
+    {
+        public static void main(string[] args)
+        {
+            CreateHostBuilder(args)
+                .Build()
+                .Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration(configuration =>
+                {
+                    configuration.AddCommandLine(args);
+                    configuration.AddEnvironmentVariables();
+                })
+                .ConfigureLogging(loggingBuilder => loggingBuilder.AddConsole(options => options.IncludeScopes = true))
+                .ConfigureServices((hostContext, services) =>
+                {
+                    services.AddTransient(svc =>
+                    {
+                        var configuration = svc.GetRequiredService<IConfiguration>();
+                        var eventGridTopic = configuration.GetValue<string>("EVENTGRID_TOPIC_URI");
+                        var eventGridKey = configuration.GetValue<string>("EVENTGRID_AUTH_KEY");
+
+                        return EventGridPublisherBuilder
+                               .ForTopic(eventGridTopic)
+                               .UsingAuthenticationKey(eventGridKey)
+                               .Build();
+                    });
+                    services.AddServiceBusTopicMessagePump("Test-Receive-All-Topic-Only", configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"], options => options.AutoComplete = false)
+                            .WithMessageHandler<PassThruOrderMessageHandler, Order, AzureServiceBusMessageContext>(context => false)
+                            .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>(context => context.Properties["Topic"].ToString() == "Customers")
+                            .WithServiceBusMessageHandler<OrdersAzureServiceBusDeadLetterMessageHandler, Order>(context => context.Properties["Topic"].ToString() == "Orders");
+
+                    services.AddTcpHealthProbes("ARCUS_HEALTH_PORT");
+                });
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusTopicContextPredicateSelectionWithServiceBusAbandonProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusTopicContextPredicateSelectionWithServiceBusAbandonProgram.cs
@@ -1,0 +1,52 @@
+using Arcus.EventGrid.Publishing;
+using Arcus.Messaging.Tests.Core.Messages.v1;
+using Arcus.Messaging.Tests.Workers.MessageHandlers;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+// ReSharper disable once CheckNamespace
+namespace Arcus.Messaging.Tests.Workers.ServiceBus
+{
+    public class ServiceBusTopicContextPredicateSelectionWithServiceBusAbandonProgram
+    {
+        public static void main(string[] args)
+        {
+            CreateHostBuilder(args)
+                .Build()
+                .Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration(configuration =>
+                {
+                    configuration.AddCommandLine(args);
+                    configuration.AddEnvironmentVariables();
+                })
+                .ConfigureLogging(loggingBuilder => loggingBuilder.AddConsole(options => options.IncludeScopes = true))
+                .ConfigureServices((hostContext, services) =>
+                {
+                    services.AddTransient(svc =>
+                    {
+                        var configuration = svc.GetRequiredService<IConfiguration>();
+                        var eventGridTopic = configuration.GetValue<string>("EVENTGRID_TOPIC_URI");
+                        var eventGridKey = configuration.GetValue<string>("EVENTGRID_AUTH_KEY");
+
+                        return EventGridPublisherBuilder
+                            .ForTopic(eventGridTopic)
+                            .UsingAuthenticationKey(eventGridKey)
+                            .Build();
+                    });
+                    services.AddServiceBusTopicMessagePump(
+                                "Test-Receive-All-Topic-Only", 
+                                configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"], 
+                                options => options.AutoComplete = false)
+                            .WithServiceBusMessageHandler<PassThruOrderMessageHandler, Order>(context => false)
+                            .WithServiceBusMessageHandler<OrdersAzureServiceBusAbandonMessageHandler, Order>(context => true);
+
+                    services.AddTcpHealthProbes("ARCUS_HEALTH_PORT");
+                });
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -141,7 +141,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
         [Theory]
         [InlineData(typeof(ServiceBusQueueWithServiceBusDeadLetterProgram))]
         [InlineData(typeof(ServiceBusQueueWithServiceBusDeadLetterFallbackProgram))]
-        [InlineData(typeof(ServiceBusTopicContextPredicateSelectionWithDeadLetterProgram))]
+        [InlineData(typeof(ServiceBusQueueContextPredicateSelectionWithDeadLetterProgram))]
         public async Task ServiceBusMessagePumpWithServiceBusDeadLetter_PublishServiceBusMessage_MessageSuccessfullyProcessed(Type programType)
         {
             // Arrange

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -141,6 +141,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
         [Theory]
         [InlineData(typeof(ServiceBusQueueWithServiceBusDeadLetterProgram))]
         [InlineData(typeof(ServiceBusQueueWithServiceBusDeadLetterFallbackProgram))]
+        [InlineData(typeof(ServiceBusTopicContextPredicateSelectionWithDeadLetterProgram))]
         public async Task ServiceBusMessagePumpWithServiceBusDeadLetter_PublishServiceBusMessage_MessageSuccessfullyProcessed(Type programType)
         {
             // Arrange
@@ -169,6 +170,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
         [Theory]
         [InlineData(typeof(ServiceBusTopicWithServiceBusAbandonProgram))]
         [InlineData(typeof(ServiceBusTopicWithServiceBusAbandonFallbackProgram))]
+        [InlineData(typeof(ServiceBusTopicContextPredicateSelectionWithServiceBusAbandonProgram))]
         public async Task ServiceBusMessagePumpWithServiceBusAbandon_PublishServiceBusMessage_MessageSuccessfullyProcessed(Type programType)
         {
             // Arrange


### PR DESCRIPTION
The problem existed when we tried to use both the context filtering as the Azure Service Bus operations when handling a message.
By hiding how we determine the type and instance of the message handler, we're more in control and can cirvumvent this problem.

Closes #134 