### PR TITLE
Feature - log security event upon Azure Service Bus connection string retrieval

### DIFF
--- a/docs/preview/features/message-pumps/service-bus.md
+++ b/docs/preview/features/message-pumps/service-bus.md
@@ -125,6 +125,9 @@ public void ConfigureServices(IServiceCollection services)
             // if no exceptions occured andprocessing has finished (default: true).
             options.AutoComplete = true;
 
+            // Indicate whether or not the message pump should emit security events (default: false).
+            options.EmitSecurityEvents = true;
+
             // The amount of concurrent calls to process messages 
             // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
             options.MaxConcurrentCalls = 5;
@@ -145,6 +148,9 @@ public void ConfigureServices(IServiceCollection services)
             // Indicate whether or not messages should be automatically marked as completed 
             // if no exceptions occured andprocessing has finished (default: true).
             options.AutoComplete = true;
+
+            // Indicate whether or not the message pump should emit security events (default: false).
+            options.EmitSecurityEvents = true;
 
             // The amount of concurrent calls to process messages 
             // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpConfiguration.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpConfiguration.cs
@@ -12,25 +12,29 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// Initializes a new instance of the <see cref="AzureServiceBusMessagePumpConfiguration"/> class.
         /// </summary>
         public AzureServiceBusMessagePumpConfiguration(AzureServiceBusQueueMessagePumpOptions options)
+            : this((AzureServiceBusMessagePumpOptions) options)
         {
             Guard.NotNull(options, nameof(options));
-
-            MaxConcurrentCalls = options.MaxConcurrentCalls;
-            AutoComplete = options.AutoComplete;
-            JobId = options.JobId;
-            KeyRotationTimeout = options.KeyRotationTimeout;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureServiceBusMessagePumpConfiguration"/> class.
         /// </summary>
-        public AzureServiceBusMessagePumpConfiguration(AzureServiceBusTopicMessagePumpOptions options)
+        public AzureServiceBusMessagePumpConfiguration(AzureServiceBusTopicMessagePumpOptions options) 
+            : this((AzureServiceBusMessagePumpOptions) options)
+        {
+            Guard.NotNull(options, nameof(options));
+
+            TopicSubscription = options.TopicSubscription;
+        }
+
+        private AzureServiceBusMessagePumpConfiguration(AzureServiceBusMessagePumpOptions options)
         {
             Guard.NotNull(options, nameof(options));
 
             MaxConcurrentCalls = options.MaxConcurrentCalls;
-            TopicSubscription = options.TopicSubscription;
             AutoComplete = options.AutoComplete;
+            EmitSecurityEvents = options.EmitSecurityEvents;
             JobId = options.JobId;
             KeyRotationTimeout = options.KeyRotationTimeout;
         }
@@ -55,6 +59,11 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// </summary>
         /// <remarks>When turned off, clients have to explicitly mark the messages as completed</remarks>
         internal bool AutoComplete { get; set; }
+
+        /// <summary>
+        /// Gets or sets the flag to indicate whether or not to emit security events during the lifetime of the message pump.
+        /// </summary>
+        internal bool EmitSecurityEvents { get; set; }
 
         /// <summary>
         /// Gets or sets the unique identifier for this background job to distinguish this job instance in a multi-instance deployment.

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
@@ -37,6 +37,11 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         public bool AutoComplete { get; set; }
 
         /// <summary>
+        /// Gets or sets the flag to indicate whether or not to emit security events during the lifetime of the message pump.
+        /// </summary>
+        public bool EmitSecurityEvents { get; set; } = false;
+
+        /// <summary>
         /// Gets or sets the unique identifier for this background job to distinguish this job instance in a multi-instance deployment.
         /// </summary>
         public string JobId

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpSettings.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpSettings.cs
@@ -83,16 +83,19 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// <returns>Connection string to authenticate with</returns>
         public async Task<string> GetConnectionStringAsync()
         {
-            ILogger logger = 
-                _serviceProvider.GetService<ILogger<AzureServiceBusMessagePumpSettings>>() 
-                ?? NullLogger<AzureServiceBusMessagePumpSettings>.Instance;
-
-            logger.LogSecurityEvent("Get Azure Service Bus connection string", new Dictionary<string, object>
+            if (Options.EmitSecurityEvents)
             {
-                ["Service Bus entity"] = ServiceBusEntity,
-                ["Entity name"] = EntityName,
-                ["Job ID"] = Options.JobId
-            });
+                ILogger logger =
+                    _serviceProvider.GetService<ILogger<AzureServiceBusMessagePumpSettings>>()
+                    ?? NullLogger<AzureServiceBusMessagePumpSettings>.Instance;
+
+                logger.LogSecurityEvent("Get Azure Service Bus connection string", new Dictionary<string, object>
+                {
+                    ["Service Bus entity"] = ServiceBusEntity,
+                    ["Entity name"] = EntityName,
+                    ["Job ID"] = Options.JobId
+                }); 
+            }
             
             if (_getConnectionStringFromSecretFunc != null)
             {


### PR DESCRIPTION
Make sure that we track the retrieval of the Azure Service Bus connection string when the message pump requests this. 