### PR TITLE
Docs - add missing 'usings' to feature docs

### DIFF
--- a/docs/features/message-pumps/customization.md
+++ b/docs/features/message-pumps/customization.md
@@ -18,6 +18,12 @@ When inheriting from an `...MessagePump` type, there's a way to control how the 
 Based on the message type of the registered message handlers, the pump determines if the incoming message can be deserialized to that type.
 
 ```csharp
+using System;
+using Arcus.Messaging.Pumps.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 public class OrderMessagePump : MessagePump
 {
     public OrderMessagePump(
@@ -55,6 +61,9 @@ Following example shows how a message handler should only process a certain mess
 We'll use a simple message handler implementation:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
+
 public class OrderMessageHandler : IMessageHandler<Order>
 {
     public async Task ProcessMessageAsync(Order order, MessageContext context, ...)
@@ -67,9 +76,14 @@ public class OrderMessageHandler : IMessageHandler<Order>
 We would like that this handler only processed the message when the context contains `MessageType` equals `Order`.
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    services.WithMessageHandler<OrderMessageHandler, Order>(context => context.Properties["MessageType"].ToString() == "Order");
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.WithMessageHandler<OrderMessageHandler, Order>(context => context.Properties["MessageType"].ToString() == "Order");
+    }
 }
 ```
 
@@ -88,6 +102,10 @@ This extra message handler will then process the remaining messages that can't b
 Following example shows how such a message handler can be implemented:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
+using Microsoft.Extensions.Logging;
+
 public class WarnsUserFallbackMessageHandler : IFallbackMessageHandller
 {
     private readonly ILogger _logger;
@@ -107,9 +125,14 @@ public class WarnsUserFallbackMessageHandler : IFallbackMessageHandller
 And to register such an implementation:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    services.WithFallbackMessageHandler<WarnsUserFallbackMessageHandler>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.WithFallbackMessageHandler<WarnsUserFallbackMessageHandler>();
+    }
 }
 ```
 

--- a/docs/features/message-pumps/service-bus.md
+++ b/docs/features/message-pumps/service-bus.md
@@ -19,19 +19,30 @@ You can do this by creating a message handler which implements from `IAzureServi
 Here is an example of a message handler that expects messages of type `Order`:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.ServiceBus;
+using Microsoft.Extensions.Logging;
+
 public class OrdersMessageHandler : IAzureServiceBusMessageHandler<Order>
 {
-    public async Task ProcessMessageAsync(
-    Order orderMessage, 
-    AzureServiceBusMessageContext messageContext, 
-    MessageCorrelationInfo correlationInfo, 
-    CancellationToken cancellationToken)
+    private readonly ILogger _logger;
+
+    public OrdersMessageHandler(ILogger<OrdersMessageHandler> logger)
     {
-        Logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
+        _logger = logger;
+    }
+
+    public async Task ProcessMessageAsync(
+        Order orderMessage, 
+        AzureServiceBusMessageContext messageContext, 
+        MessageCorrelationInfo correlationInfo, 
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
 
         // Custom logic
 
-        Logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
+        _logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
     }
 }
 ```
@@ -39,19 +50,30 @@ public class OrdersMessageHandler : IAzureServiceBusMessageHandler<Order>
 or with using the more general `IMessageHandler<>`, that will use the more general `MessageContext` instead of the one specific for Azure Service Bus.
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.ServiceBus;
+using Microsoft.Extensions.Logging;
+
 public class OrdersMessageHandler : IMessageHandler<Order>
 {
-    public async Task ProcessMessageAsync(
-    Order orderMessage, 
-    MessageContext messageContext, 
-    MessageCorrelationInfo correlationInfo, 
-    CancellationToken cancellationToken)
+    private readonly ILogger _logger;
+
+    public OrdersMessageHandler(ILogger<OrdersMessageHandler> logger)
     {
-        Logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
+        _logger = logger;
+    }
+
+    public async Task ProcessMessageAsync(
+        Order orderMessage, 
+        MessageContext messageContext, 
+        MessageCorrelationInfo correlationInfo, 
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
 
         // Custom logic
 
-        Logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
+        _logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
     }
 }
 ```
@@ -68,19 +90,24 @@ Other topics:
 Once the message handler is created, you can very easily configure it:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    // Add Service Bus Queue message pump and use OrdersMessageHandler to process the messages
-    // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
-    services.AddServiceBusQueueMessagePump("ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
-            .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Add Service Bus Queue message pump and use OrdersMessageHandler to process the messages
+        // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
+        services.AddServiceBusQueueMessagePump("ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
+                .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
 
-    // Add Service Bus Topic message pump and use OrdersMessageHandler to process the messages on the 'My-Subscription-Name' subscription
-    // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
-    services.AddServiceBusTopicMessagePump("My-Subscription-Name", "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
-            .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
+        // Add Service Bus Topic message pump and use OrdersMessageHandler to process the messages on the 'My-Subscription-Name' subscription
+        // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
+        services.AddServiceBusTopicMessagePump("My-Subscription-Name", "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
+                .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
 
-    // Note, that only a single call to the `.WithServiceBusMessageHandler` has to be made when the handler should be used across message pumps.
+        // Note, that only a single call to the `.WithServiceBusMessageHandler` has to be made when the handler should be used across message pumps.
+    }
 }
 ```
 
@@ -98,67 +125,72 @@ Next to that, we provide a **variety of overloads** to allow you to:
 - Read the connection string from the configuration *(although we highly recommend using a secret store instead)*
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    // Specify the name of the Service Bus Queue:
-    services.AddServiceBusQueueMessagePump(
-        "My-Service-Bus-Queue-Name",
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Specify the name of the Service Bus Queue:
+        services.AddServiceBusQueueMessagePump(
+            "My-Service-Bus-Queue-Name",
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
 
-    // Specify the name of the Service Bus Topic, and provide a name for the Topic subscription:
-    services.AddServiceBusMessageTopicPump<OrdersMessageHandler>(
-        "My-Service-Bus-Topic-Name",
-        "My-Service-Bus-Topic-Subscription-Name",
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
+        // Specify the name of the Service Bus Topic, and provide a name for the Topic subscription:
+        services.AddServiceBusMessageTopicPump<OrdersMessageHandler>(
+            "My-Service-Bus-Topic-Name",
+            "My-Service-Bus-Topic-Subscription-Name",
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
 
-    // Specify a topic subscription prefix instead of a name to separate topic message pumps.
-    services.AddServiceBusTopicPumpWithPrefix(
-        "My-Service-Bus-Topic-Name"
-        "My-Service-Bus-Subscription-Prefix",
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
+        // Specify a topic subscription prefix instead of a name to separate topic message pumps.
+        services.AddServiceBusTopicPumpWithPrefix(
+            "My-Service-Bus-Topic-Name"
+            "My-Service-Bus-Subscription-Prefix",
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
 
-    services.AddServiceBusTopicMessagePump(
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
-        options => 
-        {
-            // Indicate whether or not messages should be automatically marked as completed 
-            // if no exceptions occured andprocessing has finished (default: true).
-            options.AutoComplete = true;
+        services.AddServiceBusTopicMessagePump(
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
+            options => 
+            {
+                // Indicate whether or not messages should be automatically marked as completed 
+                // if no exceptions occured andprocessing has finished (default: true).
+                options.AutoComplete = true;
 
-            // The amount of concurrent calls to process messages 
-            // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
-            options.MaxConcurrentCalls = 5;
+                // The amount of concurrent calls to process messages 
+                // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
+                options.MaxConcurrentCalls = 5;
 
-            // The unique identifier for this background job to distinguish 
-            // this job instance in a multi-instance deployment (default: guid).
-            options.JobId = Guid.NewGuid().ToString();
+                // The unique identifier for this background job to distinguish 
+                // this job instance in a multi-instance deployment (default: guid).
+                options.JobId = Guid.NewGuid().ToString();
 
-            // Indicate whether or not a new Azure Service Bus Topic subscription should be created/deleted
-            // when the message pump starts/stops (default: CreateOnStart & DeleteOnStop).
-            options.TopicSubscription = TopicSubscription.CreateOnStart | TopicSubscription.DeleteOnStop;
-        });
+                // Indicate whether or not a new Azure Service Bus Topic subscription should be created/deleted
+                // when the message pump starts/stops (default: CreateOnStart & DeleteOnStop).
+                options.TopicSubscription = TopicSubscription.CreateOnStart | TopicSubscription.DeleteOnStop;
+            });
 
-    services.AddServiceBusQueueMessagePump(
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
-        options => 
-        {
-            // Indicate whether or not messages should be automatically marked as completed 
-            // if no exceptions occured andprocessing has finished (default: true).
-            options.AutoComplete = true;
+        services.AddServiceBusQueueMessagePump(
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
+            options => 
+            {
+                // Indicate whether or not messages should be automatically marked as completed 
+                // if no exceptions occured andprocessing has finished (default: true).
+                options.AutoComplete = true;
 
-            // The amount of concurrent calls to process messages 
-            // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
-            options.MaxConcurrentCalls = 5;
+                // The amount of concurrent calls to process messages 
+                // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
+                options.MaxConcurrentCalls = 5;
 
-            // The unique identifier for this background job to distinguish 
-            // this job instance in a multi-instance deployment (default: guid).
-            options.JobId = Guid.NewGuid().ToString();
-        });
+                // The unique identifier for this background job to distinguish 
+                // this job instance in a multi-instance deployment (default: guid).
+                options.JobId = Guid.NewGuid().ToString();
+            });
 
-    // Multiple message handlers can be added to the servies, based on the message type (ex. 'Order', 'Customer'...), 
-    // the correct message handler will be selected.
-    services.WithServiceBusMessageHandler<OrdersMessageHandler, Order>()
-            .WithMessageHandler<CustomerMessageHandler, Customer>();
+        // Multiple message handlers can be added to the servies, based on the message type (ex. 'Order', 'Customer'...), 
+        // the correct message handler will be selected.
+        services.WithServiceBusMessageHandler<OrdersMessageHandler, Order>()
+                .WithMessageHandler<CustomerMessageHandler, Customer>();
+    }
 }
 ```
 
@@ -173,6 +205,10 @@ This extra message handler will then process the remaining messages that can't b
 Following example shows how such a message handler can be implemented:
 
 ```csharp
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
+using Microsoft.Extensions.Logging;
+
 public class WarnsUserFallbackMessageHandler : IAzureServiceBusFallbackMessageHandller
 {
     private readonly ILogger _logger;
@@ -194,9 +230,14 @@ public class WarnsUserFallbackMessageHandler : IAzureServiceBusFallbackMessageHa
 And to register such an implementation:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    services.WithServiceBusFallbackMessageHandler<WarnsUserFallbackMessageHandler>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.WithServiceBusFallbackMessageHandler<WarnsUserFallbackMessageHandler>();
+    }
 }
 ```
 
@@ -218,6 +259,10 @@ This base class provides several protected methods to call the Azure Service Bus
 Example:
 
 ```csharp
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
+using Microsoft.Extensions.Logging;
+
 public class AbandonsUnknownOrderMessageHandler : AzureServiceBusMessageHandler<Order>
 {
     public AbandonsUnknownOrderMessageHandler(ILogger<AbandonsUnknownOrderMessageHandler> logger)
@@ -242,9 +287,14 @@ public class AbandonsUnknownOrderMessageHandler : AzureServiceBusMessageHandler<
 The registration happens the same as any other regular message handler:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    services.WithServiceBusMessageHandler<AbandonUnknownOrderMessageHandler, Order>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.WithServiceBusMessageHandler<AbandonUnknownOrderMessageHandler, Order>();
+    }
 }
 ```
 
@@ -261,6 +311,11 @@ This base class provides several protected methods to call the Azure Service Bus
 Example:
 
 ```csharp
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
+using Microsoft.Azure.ServiceBus;
+using Microsoft.Extensions.Logging;
+
 public class DeadLetterFallbackMessageHandler : AzureServiceBusFallbackMessageHandler
 {
     public DeadLetterFallbackMessageHandler(ILogger<DeadLetterFallbackMessageHandler> logger)
@@ -279,9 +334,14 @@ public class DeadLetterFallbackMessageHandler : AzureServiceBusFallbackMessageHa
 The registration happens the same way as any other fallback message handler:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.Logging;
+
+public class Startup
 {
-    services.WithServiceBusFallbackMessageHandler<DeadLetterFallbackMessageHandler>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.WithServiceBusFallbackMessageHandler<DeadLetterFallbackMessageHandler>();
+    }
 }
 ```
 
@@ -290,8 +350,9 @@ public void ConfigureServices(IServiceCollection services)
 To retrieve the correlation information of Azure Service Bus messages, we provide an extension that wraps all correlation information.
 
 ```csharp
-Message message = ...
+using Microsoft.Azure.ServiceBus;
 
+Message message = ...
 MessageCorrelationInfo correlationInfo = message.GetCorrelationInfo();
 
 // Unique identifier that indicates an attempt to process a given message.

--- a/docs/features/service-bus.md
+++ b/docs/features/service-bus.md
@@ -20,6 +20,8 @@ PM > Install-Package Arcus.Messaging.ServiceBus.Core
 Starting from the message body, we provide an extension to quickly wrap the content in a valid Azure Service Bus `Message` type that can be send.
 
 ```csharp
+using Microsoft.Azure.ServiceBus;
+
 string rawString = "Some raw content";
 Message stringMessage = rawString.AsServiceBusMessage();
 
@@ -30,6 +32,8 @@ Message orderMessage = order.AsServiceBusMessage();
 We also provide additional, optional parameters during the creation:
 
 ```csharp
+using Microsoft.Azure.ServiceBus;
+
 byte[] rawBytes = new [] { 0x54, 0x12 };
 Message = byteMessage = rawBytes.AsServiceBusMessage(
     operationId: Guid.NewGuid().ToString(),
@@ -43,6 +47,9 @@ On receive, the Azure Service Bus message contains a set of `.UserProperties` wi
 This information can be accessed in a more simplified way:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Microsoft.Azure.ServiceBus;
+
 Message message = ...
 
 // Extracted all correlation information from the `.UserProperties` and wrapped inside a valid correlation type.
@@ -61,6 +68,8 @@ On receive, the context in which the message is received contains a set of `.Pro
 This information can be acces in a more simplified way:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+
 // Extract the encoding information from the `.UserProperties` and wrapped inside a valid `Encoding` type.
 MessageContext messageContext = ...
 Encoding encoding = messageContext.GetMessageEncodingProperty();

--- a/docs/features/tcp-health-probe.md
+++ b/docs/features/tcp-health-probe.md
@@ -20,18 +20,24 @@ PM > Install-Package Arcus.Messaging.Health
 To include the TCP endpoint, add the following line of code in the `Startup.ConfigureServices` method:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
-{
-    // Add TCP health probe without extra health checks.
-    services.AddTcpHealthProbes("MyConfigurationKeyToTcpHealthPort");
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
-    // Or, add your extra health checks in a configuration delegate.
-    services.AddTcpHealthProbes(
-        "MyConfigurationkeyToTcpHealthPort",
-        configureHealthChecks: healthBuilder => 
-        {
-            healthBuilder.AddCheck("Example", () => HealthCheckResult.Healthy("Example is OK!"), tags: new[] { "example" })
-        });
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Add TCP health probe without extra health checks.
+        services.AddTcpHealthProbes("MyConfigurationKeyToTcpHealthPort");
+
+        // Or, add your extra health checks in a configuration delegate.
+        services.AddTcpHealthProbes(
+            "MyConfigurationkeyToTcpHealthPort",
+            configureHealthChecks: healthBuilder => 
+            {
+                healthBuilder.AddCheck("Example", () => HealthCheckResult.Healthy("Example is OK!"), tags: new[] { "example" })
+            });
+    }
 }
 ```
 
@@ -40,20 +46,28 @@ public void ConfigureServices(IServiceCollection services)
 The TCP probe allows several additional configuration options.
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
-{
-    // Add TCP health probe with or whitout extra health checks.
-    services.AddTcpHealthProbes(
-        "MyConfigurationKeyToTcpHealthPort",
-        configureTcpListenerOptions: options =>
-        {
-            // Configure the configuration key on which the health report is exposed.
-            options.TcpPortConfigurationKey = "MyConfigurationKey";
+using Microsoft.Extensions.DependencyInjection;
 
-            // Configure how the health report should be serialized.
-            options.HealthReportSerializer = new MyHealthReportSerializer();
-        });
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Add TCP health probe with or whitout extra health checks.
+        services.AddTcpHealthProbes(
+            "MyConfigurationKeyToTcpHealthPort",
+            configureTcpListenerOptions: options =>
+            {
+                // Configure the configuration key on which the health report is exposed.
+                options.TcpPortConfigurationKey = "MyConfigurationKey";
+
+                // Configure how the health report should be serialized.
+                options.HealthReportSerializer = new MyHealthReportSerializer();
+            });
+    }
 }
+
+using Arcus.Messaging.Health;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 public class MyHealthReportSerializer : IHealthReportSerializer
 {

--- a/docs/preview/features/message-pumps/customization.md
+++ b/docs/preview/features/message-pumps/customization.md
@@ -25,6 +25,9 @@ Following example shows how a message handler should only process a certain mess
 We'll use a simple message handler implementation:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.Abstractions.MessagingHandling;
+
 public class OrderMessageHandler : IMessageHandler<Order>
 {
     public async Task ProcessMessageAsync(Order order, MessageContext context, ...)
@@ -37,9 +40,14 @@ public class OrderMessageHandler : IMessageHandler<Order>
 We would like that this handler only processed the message when the context contains `MessageType` equals `Order`.
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    services.WithMessageHandler<OrderMessageHandler, Order>(context => context.Properties["MessageType"].ToString() == "Order");
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.WithMessageHandler<OrderMessageHandler, Order>(context => context.Properties["MessageType"].ToString() == "Order");
+    }
 }
 ```
 
@@ -54,6 +62,12 @@ When inheriting from an `...MessagePump` type, there's a way to control how the 
 Based on the message type of the registered message handlers, the pump determines if the incoming message can be deserialized to that type.
 
 ```csharp
+using System;
+using Arcus.Messaging.Pumps.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 public class OrderMessagePump : MessagePump
 {
     public OrderMessagePump(
@@ -89,6 +103,8 @@ You start by implemeting an `IMessageBodySerializer`. The following example show
 The result type (in this case `OrderBatch`) will be then be used to check if there is an `IMessageHandler` registered with that message type.
 
 ```csharp
+using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
+
 public class OrderBatchMessageBodySerializer : IMessageBodySerializer
 {
     public async Task<MessageResult> DeserializeMessageAsync(string messageBody)
@@ -106,17 +122,22 @@ public class OrderBatchMessageBodySerializer : IMessageBodySerializer
 The registration of these message body handlers can be done just as easily as an `IMessageSerializer`:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
-{
-    // Register the message body serializer in the dependency container where the dependent services will be injected.
-    services.WithMessageHandler<OrderBatchMessageHandler>(..., messageBodySerializer: new OrderBatchMessageBodySerializer());
+using Microsoft.Extensions.DependencyInjection;
 
-    // Register the message body serializer  in the dependency container where the dependent services are manually injected.
-    services.WithMessageHandler(..., messageBodySerializerImplementationFactory: serviceProvider => 
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
     {
-        var logger = serviceProvider.GetService<ILogger<OrderBatchMessageHandler>>();
-        return new OrderBatchMessageHandler(logger);
-    });
+        // Register the message body serializer in the dependency container where the dependent services will be injected.
+        services.WithMessageHandler<OrderBatchMessageHandler>(..., messageBodySerializer: new OrderBatchMessageBodySerializer());
+
+        // Register the message body serializer  in the dependency container where the dependent services are manually injected.
+        services.WithMessageHandler(..., messageBodySerializerImplementationFactory: serviceProvider => 
+        {
+            var logger = serviceProvider.GetService<ILogger<OrderBatchMessageHandler>>();
+            return new OrderBatchMessageHandler(logger);
+        });
+    }
 }
 ```
 
@@ -140,6 +161,9 @@ public class Order
     public Department Type { get; set; }
 }
 
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
+
 // Message handler
 public class OrderMessageHandler : IMessageHandler<Order>
 {
@@ -148,6 +172,8 @@ public class OrderMessageHandler : IMessageHandler<Order>
         // Do some processing...
     }
 }
+
+using Microsoft.Extensions.DependencyInjection;
 
 // Message handler registration
 public class Startup
@@ -173,6 +199,10 @@ This extra message handler will then process the remaining messages that can't b
 Following example shows how such a message handler can be implemented:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
+using Microsoft.Extensions.Logging;
+
 public class WarnsUserFallbackMessageHandler : IFallbackMessageHandller
 {
     private readonly ILogger _logger;
@@ -192,9 +222,14 @@ public class WarnsUserFallbackMessageHandler : IFallbackMessageHandller
 And to register such an implementation:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    services.WithFallbackMessageHandler<WarnsUserFallbackMessageHandler>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.WithFallbackMessageHandler<WarnsUserFallbackMessageHandler>();
+    }
 }
 ```
 

--- a/docs/preview/features/message-pumps/service-bus.md
+++ b/docs/preview/features/message-pumps/service-bus.md
@@ -19,19 +19,30 @@ You can do this by creating a message handler which implements from `IAzureServi
 Here is an example of a message handler that expects messages of type `Order`:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.ServiceBus;
+using Microsoft.Extensions.Logging;
+
 public class OrdersMessageHandler : IAzureServiceBusMessageHandler<Order>
 {
-    public async Task ProcessMessageAsync(
-    Order orderMessage, 
-    AzureServiceBusMessageContext messageContext, 
-    MessageCorrelationInfo correlationInfo, 
-    CancellationToken cancellationToken)
+    private readonly ILogger _logger;
+
+    public OrdersMessageHandler(ILogger<OrdersMessageHandler> logger)
     {
-        Logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
+        _logger = logger;
+    }
+
+    public async Task ProcessMessageAsync(
+        Order orderMessage, 
+        AzureServiceBusMessageContext messageContext, 
+        MessageCorrelationInfo correlationInfo, 
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
 
         // Custom logic
 
-        Logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
+        _logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
     }
 }
 ```
@@ -39,19 +50,30 @@ public class OrdersMessageHandler : IAzureServiceBusMessageHandler<Order>
 or with using the more general `IMessageHandler<>`, that will use the more general `MessageContext` instead of the one specific for Azure Service Bus.
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
+using Microsoft.Extensions.Logging;
+
 public class OrdersMessageHandler : IMessageHandler<Order>
 {
-    public async Task ProcessMessageAsync(
-    Order orderMessage, 
-    MessageContext messageContext, 
-    MessageCorrelationInfo correlationInfo, 
-    CancellationToken cancellationToken)
+    private readonly ILogger _logger;
+
+    public OrdersMessageHandler(ILogger<OrdersMessageHandler> logger)
     {
-        Logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
+        _logger = logger;
+    }
+
+    public async Task ProcessMessageAsync(
+        Order orderMessage, 
+        MessageContext messageContext, 
+        MessageCorrelationInfo correlationInfo, 
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
 
         // Custom logic
 
-        Logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
+        _logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
     }
 }
 ```
@@ -68,19 +90,24 @@ Other topics:
 Once the message handler is created, you can very easily configure it:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    // Add Service Bus Queue message pump and use OrdersMessageHandler to process the messages
-    // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
-    services.AddServiceBusQueueMessagePump("ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
-            .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Add Service Bus Queue message pump and use OrdersMessageHandler to process the messages
+        // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
+        services.AddServiceBusQueueMessagePump("ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
+                .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
 
-    // Add Service Bus Topic message pump and use OrdersMessageHandler to process the messages on the 'My-Subscription-Name' subscription
-    // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
-    services.AddServiceBusTopicMessagePump("My-Subscription-Name", "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
-            .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
+        // Add Service Bus Topic message pump and use OrdersMessageHandler to process the messages on the 'My-Subscription-Name' subscription
+        // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
+        services.AddServiceBusTopicMessagePump("My-Subscription-Name", "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
+                .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
 
-    // Note, that only a single call to the `.WithServiceBusMessageHandler` has to be made when the handler should be used across message pumps.
+        // Note, that only a single call to the `.WithServiceBusMessageHandler` has to be made when the handler should be used across message pumps.
+    }
 }
 ```
 
@@ -98,73 +125,78 @@ Next to that, we provide a **variety of overloads** to allow you to:
 - Read the connection string from the configuration *(although we highly recommend using a secret store instead)*
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    // Specify the name of the Service Bus Queue:
-    services.AddServiceBusQueueMessagePump(
-        "My-Service-Bus-Queue-Name",
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Specify the name of the Service Bus Queue:
+        services.AddServiceBusQueueMessagePump(
+            "My-Service-Bus-Queue-Name",
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
 
-    // Specify the name of the Service Bus Topic, and provide a name for the Topic subscription:
-    services.AddServiceBusMessageTopicPump<OrdersMessageHandler>(
-        "My-Service-Bus-Topic-Name",
-        "My-Service-Bus-Topic-Subscription-Name",
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
+        // Specify the name of the Service Bus Topic, and provide a name for the Topic subscription:
+        services.AddServiceBusMessageTopicPump<OrdersMessageHandler>(
+            "My-Service-Bus-Topic-Name",
+            "My-Service-Bus-Topic-Subscription-Name",
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
 
-    // Specify a topic subscription prefix instead of a name to separate topic message pumps.
-    services.AddServiceBusTopicPumpWithPrefix(
-        "My-Service-Bus-Topic-Name"
-        "My-Service-Bus-Subscription-Prefix",
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
+        // Specify a topic subscription prefix instead of a name to separate topic message pumps.
+        services.AddServiceBusTopicPumpWithPrefix(
+            "My-Service-Bus-Topic-Name"
+            "My-Service-Bus-Subscription-Prefix",
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
 
-    services.AddServiceBusTopicMessagePump(
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
-        options => 
-        {
-            // Indicate whether or not messages should be automatically marked as completed 
-            // if no exceptions occured andprocessing has finished (default: true).
-            options.AutoComplete = true;
+        services.AddServiceBusTopicMessagePump(
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
+            options => 
+            {
+                // Indicate whether or not messages should be automatically marked as completed 
+                // if no exceptions occured andprocessing has finished (default: true).
+                options.AutoComplete = true;
 
-            // Indicate whether or not the message pump should emit security events (default: false).
-            options.EmitSecurityEvents = true;
+                // Indicate whether or not the message pump should emit security events (default: false).
+                options.EmitSecurityEvents = true;
 
-            // The amount of concurrent calls to process messages 
-            // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
-            options.MaxConcurrentCalls = 5;
+                // The amount of concurrent calls to process messages 
+                // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
+                options.MaxConcurrentCalls = 5;
 
-            // The unique identifier for this background job to distinguish 
-            // this job instance in a multi-instance deployment (default: guid).
-            options.JobId = Guid.NewGuid().ToString();
+                // The unique identifier for this background job to distinguish 
+                // this job instance in a multi-instance deployment (default: guid).
+                options.JobId = Guid.NewGuid().ToString();
 
-            // Indicate whether or not a new Azure Service Bus Topic subscription should be created/deleted
-            // when the message pump starts/stops (default: CreateOnStart & DeleteOnStop).
-            options.TopicSubscription = TopicSubscription.CreateOnStart | TopicSubscription.DeleteOnStop;
-        });
+                // Indicate whether or not a new Azure Service Bus Topic subscription should be created/deleted
+                // when the message pump starts/stops (default: CreateOnStart & DeleteOnStop).
+                options.TopicSubscription = TopicSubscription.CreateOnStart | TopicSubscription.DeleteOnStop;
+            });
 
-    services.AddServiceBusQueueMessagePump(
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
-        options => 
-        {
-            // Indicate whether or not messages should be automatically marked as completed 
-            // if no exceptions occured andprocessing has finished (default: true).
-            options.AutoComplete = true;
+        services.AddServiceBusQueueMessagePump(
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
+            options => 
+            {
+                // Indicate whether or not messages should be automatically marked as completed 
+                // if no exceptions occured andprocessing has finished (default: true).
+                options.AutoComplete = true;
 
-            // Indicate whether or not the message pump should emit security events (default: false).
-            options.EmitSecurityEvents = true;
+                // Indicate whether or not the message pump should emit security events (default: false).
+                options.EmitSecurityEvents = true;
 
-            // The amount of concurrent calls to process messages 
-            // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
-            options.MaxConcurrentCalls = 5;
+                // The amount of concurrent calls to process messages 
+                // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
+                options.MaxConcurrentCalls = 5;
 
-            // The unique identifier for this background job to distinguish 
-            // this job instance in a multi-instance deployment (default: guid).
-            options.JobId = Guid.NewGuid().ToString();
-        });
+                // The unique identifier for this background job to distinguish 
+                // this job instance in a multi-instance deployment (default: guid).
+                options.JobId = Guid.NewGuid().ToString();
+            });
 
-    // Multiple message handlers can be added to the servies, based on the message type (ex. 'Order', 'Customer'...), 
-    // the correct message handler will be selected.
-    services.WithServiceBusMessageHandler<OrdersMessageHandler, Order>()
-            .WithMessageHandler<CustomerMessageHandler, Customer>();
+        // Multiple message handlers can be added to the servies, based on the message type (ex. 'Order', 'Customer'...), 
+        // the correct message handler will be selected.
+        services.WithServiceBusMessageHandler<OrdersMessageHandler, Order>()
+                .WithMessageHandler<CustomerMessageHandler, Customer>();
+    }
 }
 ```
 
@@ -179,6 +211,11 @@ This extra message handler will then process the remaining messages that can't b
 Following example shows how such a message handler can be implemented:
 
 ```csharp
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
+using Microsoft.Azure.ServiceBus;
+using Microsoft.Extensions.Logging;
+
 public class WarnsUserFallbackMessageHandler : IAzureServiceBusFallbackMessageHandller
 {
     private readonly ILogger _logger;
@@ -200,9 +237,14 @@ public class WarnsUserFallbackMessageHandler : IAzureServiceBusFallbackMessageHa
 And to register such an implementation:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    services.WithServiceBusFallbackMessageHandler<WarnsUserFallbackMessageHandler>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.WithServiceBusFallbackMessageHandler<WarnsUserFallbackMessageHandler>();
+    }
 }
 ```
 
@@ -224,6 +266,10 @@ This base class provides several protected methods to call the Azure Service Bus
 Example:
 
 ```csharp
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
+using Microsoft.Extensions.Logging;
+
 public class AbandonsUnknownOrderMessageHandler : AzureServiceBusMessageHandler<Order>
 {
     public AbandonsUnknownOrderMessageHandler(ILogger<AbandonsUnknownOrderMessageHandler> logger)
@@ -248,9 +294,14 @@ public class AbandonsUnknownOrderMessageHandler : AzureServiceBusMessageHandler<
 The registration happens the same as any other regular message handler:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    services.WithServiceBusMessageHandler<AbandonUnknownOrderMessageHandler, Order>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.WithServiceBusMessageHandler<AbandonUnknownOrderMessageHandler, Order>();
+    }
 }
 ```
 
@@ -267,6 +318,11 @@ This base class provides several protected methods to call the Azure Service Bus
 Example:
 
 ```csharp
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
+using Microsoft.Azure.ServiceBus;
+using Microsoft.Extensions.Logging;
+
 public class DeadLetterFallbackMessageHandler : AzureServiceBusFallbackMessageHandler
 {
     public DeadLetterFallbackMessageHandler(ILogger<DeadLetterFallbackMessageHandler> logger)
@@ -285,9 +341,14 @@ public class DeadLetterFallbackMessageHandler : AzureServiceBusFallbackMessageHa
 The registration happens the same way as any other fallback message handler:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    services.WithServiceBusFallbackMessageHandler<DeadLetterFallbackMessageHandler>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.WithServiceBusFallbackMessageHandler<DeadLetterFallbackMessageHandler>();
+    }
 }
 ```
 
@@ -296,8 +357,10 @@ public void ConfigureServices(IServiceCollection services)
 To retrieve the correlation information of Azure Service Bus messages, we provide an extension that wraps all correlation information.
 
 ```csharp
-Message message = ...
+using Arcus.Messaging.Abstractions;
+using Microsoft.Azure.ServiceBus;
 
+Message message = ...
 MessageCorrelationInfo correlationInfo = message.GetCorrelationInfo();
 
 // Unique identifier that indicates an attempt to process a given message.

--- a/docs/preview/features/service-bus.md
+++ b/docs/preview/features/service-bus.md
@@ -20,6 +20,8 @@ PM > Install-Package Arcus.Messaging.ServiceBus.Core
 Starting from the message body, we provide an extension to quickly wrap the content in a valid Azure Service Bus `Message` type that can be send.
 
 ```csharp
+using Microsoft.Azure.ServiceBus;
+
 string rawString = "Some raw content";
 Message stringMessage = rawString.AsServiceBusMessage();
 
@@ -30,6 +32,8 @@ Message orderMessage = order.AsServiceBusMessage();
 We also provide additional, optional parameters during the creation:
 
 ```csharp
+using Microsoft.Azure.ServiceBus;
+
 byte[] rawBytes = new [] { 0x54, 0x12 };
 Message = byteMessage = rawBytes.AsServiceBusMessage(
     operationId: Guid.NewGuid().ToString(),
@@ -43,6 +47,9 @@ On receive, the Azure Service Bus message contains a set of `.UserProperties` wi
 This information can be accessed in a more simplified way:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Microsoft.Azure.ServiceBus;
+
 Message message = ...
 
 // Extracted all correlation information from the `.UserProperties` and wrapped inside a valid correlation type.
@@ -61,6 +68,8 @@ On receive, the context in which the message is received contains a set of `.Pro
 This information can be acces in a more simplified way:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+
 // Extract the encoding information from the `.UserProperties` and wrapped inside a valid `Encoding` type.
 MessageContext messageContext = ...
 Encoding encoding = messageContext.GetMessageEncodingProperty();

--- a/docs/preview/features/tcp-health-probe.md
+++ b/docs/preview/features/tcp-health-probe.md
@@ -20,18 +20,24 @@ PM > Install-Package Arcus.Messaging.Health
 To include the TCP endpoint, add the following line of code in the `Startup.ConfigureServices` method:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
-{
-    // Add TCP health probe without extra health checks.
-    services.AddTcpHealthProbes("MyConfigurationKeyToTcpHealthPort");
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
-    // Or, add your extra health checks in a configuration delegate.
-    services.AddTcpHealthProbes(
-        "MyConfigurationkeyToTcpHealthPort",
-        configureHealthChecks: healthBuilder => 
-        {
-            healthBuilder.AddCheck("Example", () => HealthCheckResult.Healthy("Example is OK!"), tags: new[] { "example" })
-        });
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Add TCP health probe without extra health checks.
+        services.AddTcpHealthProbes("MyConfigurationKeyToTcpHealthPort");
+
+        // Or, add your extra health checks in a configuration delegate.
+        services.AddTcpHealthProbes(
+            "MyConfigurationkeyToTcpHealthPort",
+            configureHealthChecks: healthBuilder => 
+            {
+                healthBuilder.AddCheck("Example", () => HealthCheckResult.Healthy("Example is OK!"), tags: new[] { "example" })
+            });
+    }
 }
 ```
 
@@ -40,20 +46,28 @@ public void ConfigureServices(IServiceCollection services)
 The TCP probe allows several additional configuration options.
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
-{
-    // Add TCP health probe with or whitout extra health checks.
-    services.AddTcpHealthProbes(
-        "MyConfigurationKeyToTcpHealthPort",
-        configureTcpListenerOptions: options =>
-        {
-            // Configure the configuration key on which the health report is exposed.
-            options.TcpPortConfigurationKey = "MyConfigurationKey";
+using Microsoft.Extensions.DependencyInjection;
 
-            // Configure how the health report should be serialized.
-            options.HealthReportSerializer = new MyHealthReportSerializer();
-        });
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Add TCP health probe with or whitout extra health checks.
+        services.AddTcpHealthProbes(
+            "MyConfigurationKeyToTcpHealthPort",
+            configureTcpListenerOptions: options =>
+            {
+                // Configure the configuration key on which the health report is exposed.
+                options.TcpPortConfigurationKey = "MyConfigurationKey";
+
+                // Configure how the health report should be serialized.
+                options.HealthReportSerializer = new MyHealthReportSerializer();
+            });
+    }
 }
+
+using Arcus.Messaging.Health;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 public class MyHealthReportSerializer : IHealthReportSerializer
 {

--- a/docs/v0.1.0/features/message-pumps/customization.md
+++ b/docs/v0.1.0/features/message-pumps/customization.md
@@ -14,6 +14,12 @@ When inheriting from an `...MessagePump` type, there's a way to control how the 
 Based on the message type of the registered message handlers, the pump determines if the incoming message can be deserialized to that type.
 
 ```csharp
+using System;
+using Arcus.Messaging.Pumps.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 public class OrderMessagePump : MessagePump
 {
     public OrderMessagePump(

--- a/docs/v0.1.0/features/message-pumps/service-bus.md
+++ b/docs/v0.1.0/features/message-pumps/service-bus.md
@@ -20,19 +20,29 @@ You can do this by creating a message handler which implements from `IAzureServi
 Here is an example of a message handler that expects messages of type `Order`:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.ServiceBus;
+
 public class OrdersMessageHandler : IAzureServiceBusMessageHandler<Order>
 {
-    public async Task ProcessMessageAsync(
-    Order orderMessage, 
-    AzureServiceBusMessageContext messageContext, 
-    MessageCorrelationInfo correlationInfo, 
-    CancellationToken cancellationToken)
+    private readonly ILogger _logger;
+
+    public OrdersMessageHandler(ILogger<OrdersMessageHandler> logger)
     {
-        Logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
+        _logger = logger;
+    }
+
+    public async Task ProcessMessageAsync(
+        Order orderMessage, 
+        AzureServiceBusMessageContext messageContext, 
+        MessageCorrelationInfo correlationInfo, 
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
 
         // Custom logic
 
-        Logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
+        _logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
     }
 }
 ```
@@ -40,13 +50,16 @@ public class OrdersMessageHandler : IAzureServiceBusMessageHandler<Order>
 or with using the more general `IMessageHandler<>`, that will use the more general `MessageContext` instead of the one specific for Azure Service Bus.
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.Abstractions.MessageHanlding;
+
 public class OrdersMessageHandler : IMessageHandler<Order>
 {
     public async Task ProcessMessageAsync(
-    Order orderMessage, 
-    MessageContext messageContext, 
-    MessageCorrelationInfo correlationInfo, 
-    CancellationToken cancellationToken)
+        Order orderMessage, 
+        MessageContext messageContext, 
+        MessageCorrelationInfo correlationInfo, 
+        CancellationToken cancellationToken)
     {
         Logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
 
@@ -62,19 +75,24 @@ public class OrdersMessageHandler : IMessageHandler<Order>
 Once the message handler is created, you can very easily configure it:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    // Add Service Bus Queue message pump and use OrdersMessageHandler to process the messages
-    // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
-    services.AddServiceBusQueueMessagePump("ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
-            .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Add Service Bus Queue message pump and use OrdersMessageHandler to process the messages
+        // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
+        services.AddServiceBusQueueMessagePump("ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
+                .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
 
-    // Add Service Bus Topic message pump and use OrdersMessageHandler to process the messages on the 'My-Subscription-Name' subscription
-    // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
-    services.AddServiceBusTopicMessagePump("My-Subscription-Name", "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
-            .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
+        // Add Service Bus Topic message pump and use OrdersMessageHandler to process the messages on the 'My-Subscription-Name' subscription
+        // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
+        services.AddServiceBusTopicMessagePump("My-Subscription-Name", "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
+                .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
 
-    // Note, that only a single call to the `.WithServiceBusMessageHandler` has to be made when the handler should be used across message pumps.
+        // Note, that only a single call to the `.WithServiceBusMessageHandler` has to be made when the handler should be used across message pumps.
+    }
 }
 ```
 
@@ -92,67 +110,72 @@ Next to that, we provide a **variety of overloads** to allow you to:
 - Read the connection string from the configuration *(although we highly recommend using a secret store instead)*
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    // Specify the name of the Service Bus Queue:
-    services.AddServiceBusQueueMessagePump(
-        "My-Service-Bus-Queue-Name",
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Specify the name of the Service Bus Queue:
+        services.AddServiceBusQueueMessagePump(
+            "My-Service-Bus-Queue-Name",
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
 
-    // Specify the name of the Service Bus Topic, and provide a name for the Topic subscription:
-    services.AddServiceBusMessageTopicPump<OrdersMessageHandler>(
-        "My-Service-Bus-Topic-Name",
-        "My-Service-Bus-Topic-Subscription-Name",
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
+        // Specify the name of the Service Bus Topic, and provide a name for the Topic subscription:
+        services.AddServiceBusMessageTopicPump<OrdersMessageHandler>(
+            "My-Service-Bus-Topic-Name",
+            "My-Service-Bus-Topic-Subscription-Name",
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
 
-    // Specify a topic subscription prefix instead of a name to separate topic message pumps.
-    services.AddServiceBusTopicPumpWithPrefix(
-        "My-Service-Bus-Topic-Name"
-        "My-Service-Bus-Subscription-Prefix",
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
+        // Specify a topic subscription prefix instead of a name to separate topic message pumps.
+        services.AddServiceBusTopicPumpWithPrefix(
+            "My-Service-Bus-Topic-Name"
+            "My-Service-Bus-Subscription-Prefix",
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
 
-    services.AddServiceBusTopicMessagePump(
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
-        options => 
-        {
-            // Indicate whether or not messages should be automatically marked as completed 
-            // if no exceptions occured andprocessing has finished (default: true).
-            options.AutoComplete = true;
+        services.AddServiceBusTopicMessagePump(
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
+            options => 
+            {
+                // Indicate whether or not messages should be automatically marked as completed 
+                // if no exceptions occured andprocessing has finished (default: true).
+                options.AutoComplete = true;
 
-            // The amount of concurrent calls to process messages 
-            // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
-            options.MaxConcurrentCalls = 5;
+                // The amount of concurrent calls to process messages 
+                // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
+                options.MaxConcurrentCalls = 5;
 
-            // The unique identifier for this background job to distinguish 
-            // this job instance in a multi-instance deployment (default: guid).
-            options.JobId = Guid.NewGuid().ToString();
+                // The unique identifier for this background job to distinguish 
+                // this job instance in a multi-instance deployment (default: guid).
+                options.JobId = Guid.NewGuid().ToString();
 
-            // Indicate whether or not a new Azure Service Bus Topic subscription should be created/deleted
-            // when the message pump starts/stops (default: CreateOnStart & DeleteOnStop).
-            options.TopicSubscription = TopicSubscription.CreateOnStart | TopicSubscription.DeleteOnStop;
-        });
+                // Indicate whether or not a new Azure Service Bus Topic subscription should be created/deleted
+                // when the message pump starts/stops (default: CreateOnStart & DeleteOnStop).
+                options.TopicSubscription = TopicSubscription.CreateOnStart | TopicSubscription.DeleteOnStop;
+            });
 
-    services.AddServiceBusQueueMessagePump(
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
-        options => 
-        {
-            // Indicate whether or not messages should be automatically marked as completed 
-            // if no exceptions occured andprocessing has finished (default: true).
-            options.AutoComplete = true;
+        services.AddServiceBusQueueMessagePump(
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
+            options => 
+            {
+                // Indicate whether or not messages should be automatically marked as completed 
+                // if no exceptions occured andprocessing has finished (default: true).
+                options.AutoComplete = true;
 
-            // The amount of concurrent calls to process messages 
-            // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
-            options.MaxConcurrentCalls = 5;
+                // The amount of concurrent calls to process messages 
+                // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
+                options.MaxConcurrentCalls = 5;
 
-            // The unique identifier for this background job to distinguish 
-            // this job instance in a multi-instance deployment (default: guid).
-            options.JobId = Guid.NewGuid().ToString();
-        });
+                // The unique identifier for this background job to distinguish 
+                // this job instance in a multi-instance deployment (default: guid).
+                options.JobId = Guid.NewGuid().ToString();
+            });
 
-    // Multiple message handlers can be added to the servies, based on the message type (ex. 'Order', 'Customer'...), 
-    // the correct message handler will be selected.
-    services.WithServiceBusMessageHandler<OrdersMessageHandler, Order>()
-            .WithMessageHandler<CustomerMessageHandler, Customer>();
+        // Multiple message handlers can be added to the servies, based on the message type (ex. 'Order', 'Customer'...), 
+        // the correct message handler will be selected.
+        services.WithServiceBusMessageHandler<OrdersMessageHandler, Order>()
+                .WithMessageHandler<CustomerMessageHandler, Customer>();
+    }
 }
 ```
 
@@ -161,6 +184,9 @@ public void ConfigureServices(IServiceCollection services)
 To retrieve the correlation information of Azure Service Bus messages, we provide an extension that wraps all correlation information.
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Microsoft.Azure.ServiceBus;
+
 Message message = ...
 
 MessageCorrelationInfo correlationInfo = message.GetCorrelationInfo();

--- a/docs/v0.1.0/features/service-bus.md
+++ b/docs/v0.1.0/features/service-bus.md
@@ -20,6 +20,8 @@ PM > Install-Package Arcus.Messaging.ServiceBus.Core -Version 0.1.0
 Starting from the message body, we provide an extension to quickly wrap the content in a valid Azure Service Bus `Message` type that can be send.
 
 ```csharp
+using Microsoft.Azure.ServiceBus;
+
 string rawString = "Some raw content";
 Message stringMessage = rawString.AsServiceBusMessage();
 
@@ -30,6 +32,8 @@ Message orderMessage = order.AsServiceBusMessage();
 We also provide additional, optional parameters during the creation:
 
 ```csharp
+using Microsoft.Azure.ServiceBus;
+
 byte[] rawBytes = new [] { 0x54, 0x12 };
 Message = byteMessage = rawBytes.AsServiceBusMessage(
     operationId: Guid.NewGuid().ToString(),
@@ -43,6 +47,9 @@ On receive, the Azure Service Bus message contains a set of `.UserProperties` wi
 This information can be accessed in a more simplified way:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Microsoft.Azure.ServiceBus;
+
 Message message = ...
 
 // Extracted all correlation information from the `.UserProperties` and wrapped inside a valid correlation type.
@@ -61,6 +68,8 @@ On receive, the context in which the message is received contains a set of `.Pro
 This information can be acces in a more simplified way:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+
 // Extract the encoding information from the `.UserProperties` and wrapped inside a valid `Encoding` type.
 MessageContext messageContext = ...
 Encoding encoding = messageContext.GetMessageEncodingProperty();

--- a/docs/v0.1.0/features/tcp-health-probe.md
+++ b/docs/v0.1.0/features/tcp-health-probe.md
@@ -20,18 +20,24 @@ PM > Install-Package Arcus.Messaging.Health -Version 0.1.0
 To include the TCP endpoint, add the following line of code in the `Startup.ConfigureServices` method:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
-{
-    // Add TCP health probe without extra health checks.
-    services.AddTcpHealthProbes("MyConfigurationKeyToTcpHealthPort");
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
-    // Or, add your extra health checks in a configuration delegate.
-    services.AddTcpHealthProbes(
-        "MyConfigurationkeyToTcpHealthPort",
-        configureHealthChecks: healthBuilder => 
-        {
-            healthBuilder.AddCheck("Example", () => HealthCheckResult.Healthy("Example is OK!"), tags: new[] { "example" })
-        });
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Add TCP health probe without extra health checks.
+        services.AddTcpHealthProbes("MyConfigurationKeyToTcpHealthPort");
+
+        // Or, add your extra health checks in a configuration delegate.
+        services.AddTcpHealthProbes(
+            "MyConfigurationkeyToTcpHealthPort",
+            configureHealthChecks: healthBuilder => 
+            {
+                healthBuilder.AddCheck("Example", () => HealthCheckResult.Healthy("Example is OK!"), tags: new[] { "example" })
+            });
+    }
 }
 ```
 
@@ -40,20 +46,28 @@ public void ConfigureServices(IServiceCollection services)
 The TCP probe allows several additional configuration options.
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
-{
-    // Add TCP health probe with or whitout extra health checks.
-    services.AddTcpHealthProbes(
-        "MyConfigurationKeyToTcpHealthPort",
-        configureTcpListenerOptions: options =>
-        {
-            // Configure the configuration key on which the health report is exposed.
-            options.TcpPortConfigurationKey = "MyConfigurationKey";
+using Microsoft.Extensions.DependencyInjection;
 
-            // Configure how the health report should be serialized.
-            options.HealthReportSerializer = new MyHealthReportSerializer();
-        });
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Add TCP health probe with or whitout extra health checks.
+        services.AddTcpHealthProbes(
+            "MyConfigurationKeyToTcpHealthPort",
+            configureTcpListenerOptions: options =>
+            {
+                // Configure the configuration key on which the health report is exposed.
+                options.TcpPortConfigurationKey = "MyConfigurationKey";
+
+                // Configure how the health report should be serialized.
+                options.HealthReportSerializer = new MyHealthReportSerializer();
+            });
+    }
 }
+
+using Arcus.Messaging.Health;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 public class MyHealthReportSerializer : IHealthReportSerializer
 {

--- a/docs/v0.2.0/features/message-pumps/customization.md
+++ b/docs/v0.2.0/features/message-pumps/customization.md
@@ -14,6 +14,12 @@ When inheriting from an `...MessagePump` type, there's a way to control how the 
 Based on the message type of the registered message handlers, the pump determines if the incoming message can be deserialized to that type.
 
 ```csharp
+using System;
+using Arcus.Messaging.Pumps.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 public class OrderMessagePump : MessagePump
 {
     public OrderMessagePump(
@@ -51,6 +57,9 @@ Following example shows how a message handler should only process a certain mess
 We'll use a simple message handler implementation:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
+
 public class OrderMessageHandler : IMessageHandler<Order>
 {
     public async Task ProcessMessageAsync(Order order, MessageContext context, ...)
@@ -63,9 +72,14 @@ public class OrderMessageHandler : IMessageHandler<Order>
 We would like that this handler only processed the message when the context contains `MessageType` equals `Order`.
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    services.WithMessageHandler<OrderMessageHandler, Order>(context => context.Properties["MessageType"].ToString() == "Order");
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.WithMessageHandler<OrderMessageHandler, Order>(context => context.Properties["MessageType"].ToString() == "Order");
+    }
 }
 ```
 

--- a/docs/v0.2.0/features/message-pumps/service-bus.md
+++ b/docs/v0.2.0/features/message-pumps/service-bus.md
@@ -20,19 +20,29 @@ You can do this by creating a message handler which implements from `IAzureServi
 Here is an example of a message handler that expects messages of type `Order`:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.ServiceBus;
+
 public class OrdersMessageHandler : IAzureServiceBusMessageHandler<Order>
 {
-    public async Task ProcessMessageAsync(
-    Order orderMessage, 
-    AzureServiceBusMessageContext messageContext, 
-    MessageCorrelationInfo correlationInfo, 
-    CancellationToken cancellationToken)
+    private readonly ILogger _logger;
+
+    public OrdersMessageHandler(ILogger<OrdersMessageHandler> logger)
     {
-        Logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
+        _logger = logger;
+    }
+
+    public async Task ProcessMessageAsync(
+        Order orderMessage, 
+        AzureServiceBusMessageContext messageContext, 
+        MessageCorrelationInfo correlationInfo, 
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
 
         // Custom logic
 
-        Logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
+        _logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
     }
 }
 ```
@@ -40,19 +50,29 @@ public class OrdersMessageHandler : IAzureServiceBusMessageHandler<Order>
 or with using the more general `IMessageHandler<>`, that will use the more general `MessageContext` instead of the one specific for Azure Service Bus.
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.Abstractions;
+
 public class OrdersMessageHandler : IMessageHandler<Order>
 {
-    public async Task ProcessMessageAsync(
-    Order orderMessage, 
-    MessageContext messageContext, 
-    MessageCorrelationInfo correlationInfo, 
-    CancellationToken cancellationToken)
+    private readonly ILogger _logger;
+
+    public OrdersMessageHandler(ILogger<OrdersMessageHandler> logger)
     {
-        Logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
+        _logger = logger;
+    }
+
+    public async Task ProcessMessageAsync(
+        Order orderMessage, 
+        MessageContext messageContext, 
+        MessageCorrelationInfo correlationInfo, 
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
 
         // Custom logic
 
-        Logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
+        _logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
     }
 }
 ```
@@ -62,19 +82,24 @@ public class OrdersMessageHandler : IMessageHandler<Order>
 Once the message handler is created, you can very easily configure it:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    // Add Service Bus Queue message pump and use OrdersMessageHandler to process the messages
-    // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
-    services.AddServiceBusQueueMessagePump("ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
-            .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Add Service Bus Queue message pump and use OrdersMessageHandler to process the messages
+        // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
+        services.AddServiceBusQueueMessagePump("ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
+                .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
 
-    // Add Service Bus Topic message pump and use OrdersMessageHandler to process the messages on the 'My-Subscription-Name' subscription
-    // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
-    services.AddServiceBusTopicMessagePump("My-Subscription-Name", "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
-            .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
+        // Add Service Bus Topic message pump and use OrdersMessageHandler to process the messages on the 'My-Subscription-Name' subscription
+        // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
+        services.AddServiceBusTopicMessagePump("My-Subscription-Name", "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
+                .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
 
-    // Note, that only a single call to the `.WithServiceBusMessageHandler` has to be made when the handler should be used across message pumps.
+        // Note, that only a single call to the `.WithServiceBusMessageHandler` has to be made when the handler should be used across message pumps.
+    }
 }
 ```
 
@@ -92,67 +117,72 @@ Next to that, we provide a **variety of overloads** to allow you to:
 - Read the connection string from the configuration *(although we highly recommend using a secret store instead)*
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    // Specify the name of the Service Bus Queue:
-    services.AddServiceBusQueueMessagePump(
-        "My-Service-Bus-Queue-Name",
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Specify the name of the Service Bus Queue:
+        services.AddServiceBusQueueMessagePump(
+            "My-Service-Bus-Queue-Name",
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
 
-    // Specify the name of the Service Bus Topic, and provide a name for the Topic subscription:
-    services.AddServiceBusMessageTopicPump<OrdersMessageHandler>(
-        "My-Service-Bus-Topic-Name",
-        "My-Service-Bus-Topic-Subscription-Name",
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
+        // Specify the name of the Service Bus Topic, and provide a name for the Topic subscription:
+        services.AddServiceBusMessageTopicPump<OrdersMessageHandler>(
+            "My-Service-Bus-Topic-Name",
+            "My-Service-Bus-Topic-Subscription-Name",
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
 
-    // Specify a topic subscription prefix instead of a name to separate topic message pumps.
-    services.AddServiceBusTopicPumpWithPrefix(
-        "My-Service-Bus-Topic-Name"
-        "My-Service-Bus-Subscription-Prefix",
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
+        // Specify a topic subscription prefix instead of a name to separate topic message pumps.
+        services.AddServiceBusTopicPumpWithPrefix(
+            "My-Service-Bus-Topic-Name"
+            "My-Service-Bus-Subscription-Prefix",
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
 
-    services.AddServiceBusTopicMessagePump(
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
-        options => 
-        {
-            // Indicate whether or not messages should be automatically marked as completed 
-            // if no exceptions occured andprocessing has finished (default: true).
-            options.AutoComplete = true;
+        services.AddServiceBusTopicMessagePump(
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
+            options => 
+            {
+                // Indicate whether or not messages should be automatically marked as completed 
+                // if no exceptions occured andprocessing has finished (default: true).
+                options.AutoComplete = true;
 
-            // The amount of concurrent calls to process messages 
-            // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
-            options.MaxConcurrentCalls = 5;
+                // The amount of concurrent calls to process messages 
+                // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
+                options.MaxConcurrentCalls = 5;
 
-            // The unique identifier for this background job to distinguish 
-            // this job instance in a multi-instance deployment (default: guid).
-            options.JobId = Guid.NewGuid().ToString();
+                // The unique identifier for this background job to distinguish 
+                // this job instance in a multi-instance deployment (default: guid).
+                options.JobId = Guid.NewGuid().ToString();
 
-            // Indicate whether or not a new Azure Service Bus Topic subscription should be created/deleted
-            // when the message pump starts/stops (default: CreateOnStart & DeleteOnStop).
-            options.TopicSubscription = TopicSubscription.CreateOnStart | TopicSubscription.DeleteOnStop;
-        });
+                // Indicate whether or not a new Azure Service Bus Topic subscription should be created/deleted
+                // when the message pump starts/stops (default: CreateOnStart & DeleteOnStop).
+                options.TopicSubscription = TopicSubscription.CreateOnStart | TopicSubscription.DeleteOnStop;
+            });
 
-    services.AddServiceBusQueueMessagePump(
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
-        options => 
-        {
-            // Indicate whether or not messages should be automatically marked as completed 
-            // if no exceptions occured andprocessing has finished (default: true).
-            options.AutoComplete = true;
+        services.AddServiceBusQueueMessagePump(
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
+            options => 
+            {
+                // Indicate whether or not messages should be automatically marked as completed 
+                // if no exceptions occured andprocessing has finished (default: true).
+                options.AutoComplete = true;
 
-            // The amount of concurrent calls to process messages 
-            // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
-            options.MaxConcurrentCalls = 5;
+                // The amount of concurrent calls to process messages 
+                // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
+                options.MaxConcurrentCalls = 5;
 
-            // The unique identifier for this background job to distinguish 
-            // this job instance in a multi-instance deployment (default: guid).
-            options.JobId = Guid.NewGuid().ToString();
-        });
+                // The unique identifier for this background job to distinguish 
+                // this job instance in a multi-instance deployment (default: guid).
+                options.JobId = Guid.NewGuid().ToString();
+            });
 
-    // Multiple message handlers can be added to the servies, based on the message type (ex. 'Order', 'Customer'...), 
-    // the correct message handler will be selected.
-    services.WithServiceBusMessageHandler<OrdersMessageHandler, Order>()
-            .WithMessageHandler<CustomerMessageHandler, Customer>();
+        // Multiple message handlers can be added to the servies, based on the message type (ex. 'Order', 'Customer'...), 
+        // the correct message handler will be selected.
+        services.WithServiceBusMessageHandler<OrdersMessageHandler, Order>()
+                .WithMessageHandler<CustomerMessageHandler, Customer>();
+    }
 }
 ```
 
@@ -161,6 +191,9 @@ public void ConfigureServices(IServiceCollection services)
 To retrieve the correlation information of Azure Service Bus messages, we provide an extension that wraps all correlation information.
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Microsoft.Azure.ServiceBus;
+
 Message message = ...
 
 MessageCorrelationInfo correlationInfo = message.GetCorrelationInfo();

--- a/docs/v0.2.0/features/service-bus.md
+++ b/docs/v0.2.0/features/service-bus.md
@@ -20,6 +20,8 @@ PM > Install-Package Arcus.Messaging.ServiceBus.Core
 Starting from the message body, we provide an extension to quickly wrap the content in a valid Azure Service Bus `Message` type that can be send.
 
 ```csharp
+using Microsoft.Azure.ServiceBus;
+
 string rawString = "Some raw content";
 Message stringMessage = rawString.AsServiceBusMessage();
 
@@ -30,6 +32,8 @@ Message orderMessage = order.AsServiceBusMessage();
 We also provide additional, optional parameters during the creation:
 
 ```csharp
+using Microsoft.Azure.ServiceBus;
+
 byte[] rawBytes = new [] { 0x54, 0x12 };
 Message = byteMessage = rawBytes.AsServiceBusMessage(
     operationId: Guid.NewGuid().ToString(),
@@ -43,6 +47,9 @@ On receive, the Azure Service Bus message contains a set of `.UserProperties` wi
 This information can be accessed in a more simplified way:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Microsoft.Azure.ServiceBus;
+
 Message message = ...
 
 // Extracted all correlation information from the `.UserProperties` and wrapped inside a valid correlation type.
@@ -61,6 +68,8 @@ On receive, the context in which the message is received contains a set of `.Pro
 This information can be acces in a more simplified way:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+
 // Extract the encoding information from the `.UserProperties` and wrapped inside a valid `Encoding` type.
 MessageContext messageContext = ...
 Encoding encoding = messageContext.GetMessageEncodingProperty();

--- a/docs/v0.2.0/features/tcp-health-probe.md
+++ b/docs/v0.2.0/features/tcp-health-probe.md
@@ -20,18 +20,24 @@ PM > Install-Package Arcus.Messaging.Health
 To include the TCP endpoint, add the following line of code in the `Startup.ConfigureServices` method:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
-{
-    // Add TCP health probe without extra health checks.
-    services.AddTcpHealthProbes("MyConfigurationKeyToTcpHealthPort");
+using Microsoft.Extenions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
-    // Or, add your extra health checks in a configuration delegate.
-    services.AddTcpHealthProbes(
-        "MyConfigurationkeyToTcpHealthPort",
-        configureHealthChecks: healthBuilder => 
-        {
-            healthBuilder.AddCheck("Example", () => HealthCheckResult.Healthy("Example is OK!"), tags: new[] { "example" })
-        });
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Add TCP health probe without extra health checks.
+        services.AddTcpHealthProbes("MyConfigurationKeyToTcpHealthPort");
+    
+        // Or, add your extra health checks in a configuration delegate.
+        services.AddTcpHealthProbes(
+            "MyConfigurationkeyToTcpHealthPort",
+            configureHealthChecks: healthBuilder => 
+            {
+                healthBuilder.AddCheck("Example", () => HealthCheckResult.Healthy("Example is OK!"), tags: new[] { "example" })
+            });
+    }
 }
 ```
 
@@ -40,20 +46,28 @@ public void ConfigureServices(IServiceCollection services)
 The TCP probe allows several additional configuration options.
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
-{
-    // Add TCP health probe with or whitout extra health checks.
-    services.AddTcpHealthProbes(
-        "MyConfigurationKeyToTcpHealthPort",
-        configureTcpListenerOptions: options =>
-        {
-            // Configure the configuration key on which the health report is exposed.
-            options.TcpPortConfigurationKey = "MyConfigurationKey";
+using Microsoft.Extensions.DependencyInjection;
 
-            // Configure how the health report should be serialized.
-            options.HealthReportSerializer = new MyHealthReportSerializer();
-        });
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Add TCP health probe with or whitout extra health checks.
+        services.AddTcpHealthProbes(
+            "MyConfigurationKeyToTcpHealthPort",
+            configureTcpListenerOptions: options =>
+            {
+                // Configure the configuration key on which the health report is exposed.
+                options.TcpPortConfigurationKey = "MyConfigurationKey";
+
+                // Configure how the health report should be serialized.
+                options.HealthReportSerializer = new MyHealthReportSerializer();
+            });
+    }
 }
+
+using Arcus.Messaging.Health;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 public class MyHealthReportSerializer : IHealthReportSerializer
 {

--- a/docs/v0.3.0/features/message-pumps/customization.md
+++ b/docs/v0.3.0/features/message-pumps/customization.md
@@ -14,6 +14,12 @@ When inheriting from an `...MessagePump` type, there's a way to control how the 
 Based on the message type of the registered message handlers, the pump determines if the incoming message can be deserialized to that type.
 
 ```csharp
+using System;
+using Arcus.Messaging.Pumps.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjeciton;
+using Microsoft.Extensions.Logging;
+
 public class OrderMessagePump : MessagePump
 {
     public OrderMessagePump(
@@ -51,6 +57,9 @@ Following example shows how a message handler should only process a certain mess
 We'll use a simple message handler implementation:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
+
 public class OrderMessageHandler : IMessageHandler<Order>
 {
     public async Task ProcessMessageAsync(Order order, MessageContext context, ...)
@@ -63,9 +72,14 @@ public class OrderMessageHandler : IMessageHandler<Order>
 We would like that this handler only processed the message when the context contains `MessageType` equals `Order`.
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    services.WithMessageHandler<OrderMessageHandler, Order>(context => context.Properties["MessageType"].ToString() == "Order");
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.WithMessageHandler<OrderMessageHandler, Order>(context => context.Properties["MessageType"].ToString() == "Order");
+    }
 }
 ```
 
@@ -84,6 +98,10 @@ This extra message handler will then process the remaining messages that can't b
 Following example shows how such a message handler can be implemented:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
+using Microsoft.Extensions.Logging;
+
 public class WarnsUserFallbackMessageHandler : IFallbackMessageHandller
 {
     private readonly ILogger _logger;
@@ -103,9 +121,14 @@ public class WarnsUserFallbackMessageHandler : IFallbackMessageHandller
 And to register such an implementation:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    services.WithFallbackMessageHandler<WarnsUserFallbackMessageHandler>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.WithFallbackMessageHandler<WarnsUserFallbackMessageHandler>();
+    }
 }
 ```
 

--- a/docs/v0.3.0/features/message-pumps/service-bus.md
+++ b/docs/v0.3.0/features/message-pumps/service-bus.md
@@ -20,19 +20,30 @@ You can do this by creating a message handler which implements from `IAzureServi
 Here is an example of a message handler that expects messages of type `Order`:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.ServiceBus;
+using Microsoft.Extensions.Logging;
+
 public class OrdersMessageHandler : IAzureServiceBusMessageHandler<Order>
 {
-    public async Task ProcessMessageAsync(
-    Order orderMessage, 
-    AzureServiceBusMessageContext messageContext, 
-    MessageCorrelationInfo correlationInfo, 
-    CancellationToken cancellationToken)
+    private readonly ILogger _logger;
+
+    public OrdersMessageHandler(ILogger<OrdersMessageHandler> logger)
     {
-        Logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
+        _logger = logger;
+    }
+
+    public async Task ProcessMessageAsync(
+        Order orderMessage, 
+        AzureServiceBusMessageContext messageContext, 
+        MessageCorrelationInfo correlationInfo, 
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
 
         // Custom logic
 
-        Logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
+        _logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
     }
 }
 ```
@@ -40,19 +51,30 @@ public class OrdersMessageHandler : IAzureServiceBusMessageHandler<Order>
 or with using the more general `IMessageHandler<>`, that will use the more general `MessageContext` instead of the one specific for Azure Service Bus.
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Abstractions.MessageHandling;
+using Microsoft.Extensions.Logging;
+
 public class OrdersMessageHandler : IMessageHandler<Order>
 {
-    public async Task ProcessMessageAsync(
-    Order orderMessage, 
-    MessageContext messageContext, 
-    MessageCorrelationInfo correlationInfo, 
-    CancellationToken cancellationToken)
+    private readonly ILogger _logger;
+
+    public OrdersMessageHandler(ILogger<OrdersMessageHandler> logger)
     {
-        Logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
+        _logger = logger;
+    }
+
+    public async Task ProcessMessageAsync(
+        Order orderMessage, 
+        MessageContext messageContext, 
+        MessageCorrelationInfo correlationInfo, 
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
 
         // Custom logic
 
-        Logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
+        _logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
     }
 }
 ```
@@ -62,19 +84,24 @@ public class OrdersMessageHandler : IMessageHandler<Order>
 Once the message handler is created, you can very easily configure it:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    // Add Service Bus Queue message pump and use OrdersMessageHandler to process the messages
-    // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
-    services.AddServiceBusQueueMessagePump("ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
-            .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Add Service Bus Queue message pump and use OrdersMessageHandler to process the messages
+        // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
+        services.AddServiceBusQueueMessagePump("ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
+                .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
 
-    // Add Service Bus Topic message pump and use OrdersMessageHandler to process the messages on the 'My-Subscription-Name' subscription
-    // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
-    services.AddServiceBusTopicMessagePump("My-Subscription-Name", "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
-            .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
+        // Add Service Bus Topic message pump and use OrdersMessageHandler to process the messages on the 'My-Subscription-Name' subscription
+        // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
+        services.AddServiceBusTopicMessagePump("My-Subscription-Name", "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
+                .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
 
-    // Note, that only a single call to the `.WithServiceBusMessageHandler` has to be made when the handler should be used across message pumps.
+        // Note, that only a single call to the `.WithServiceBusMessageHandler` has to be made when the handler should be used across message pumps.
+    }
 }
 ```
 
@@ -92,67 +119,72 @@ Next to that, we provide a **variety of overloads** to allow you to:
 - Read the connection string from the configuration *(although we highly recommend using a secret store instead)*
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    // Specify the name of the Service Bus Queue:
-    services.AddServiceBusQueueMessagePump(
-        "My-Service-Bus-Queue-Name",
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Specify the name of the Service Bus Queue:
+        services.AddServiceBusQueueMessagePump(
+            "My-Service-Bus-Queue-Name",
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
 
-    // Specify the name of the Service Bus Topic, and provide a name for the Topic subscription:
-    services.AddServiceBusMessageTopicPump<OrdersMessageHandler>(
-        "My-Service-Bus-Topic-Name",
-        "My-Service-Bus-Topic-Subscription-Name",
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
+        // Specify the name of the Service Bus Topic, and provide a name for the Topic subscription:
+        services.AddServiceBusMessageTopicPump<OrdersMessageHandler>(
+            "My-Service-Bus-Topic-Name",
+            "My-Service-Bus-Topic-Subscription-Name",
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
 
-    // Specify a topic subscription prefix instead of a name to separate topic message pumps.
-    services.AddServiceBusTopicPumpWithPrefix(
-        "My-Service-Bus-Topic-Name"
-        "My-Service-Bus-Subscription-Prefix",
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
+        // Specify a topic subscription prefix instead of a name to separate topic message pumps.
+        services.AddServiceBusTopicPumpWithPrefix(
+            "My-Service-Bus-Topic-Name"
+            "My-Service-Bus-Subscription-Prefix",
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
 
-    services.AddServiceBusTopicMessagePump(
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
-        options => 
-        {
-            // Indicate whether or not messages should be automatically marked as completed 
-            // if no exceptions occured andprocessing has finished (default: true).
-            options.AutoComplete = true;
+        services.AddServiceBusTopicMessagePump(
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
+            options => 
+            {
+                // Indicate whether or not messages should be automatically marked as completed 
+                // if no exceptions occured andprocessing has finished (default: true).
+                options.AutoComplete = true;
 
-            // The amount of concurrent calls to process messages 
-            // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
-            options.MaxConcurrentCalls = 5;
+                // The amount of concurrent calls to process messages 
+                // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
+                options.MaxConcurrentCalls = 5;
 
-            // The unique identifier for this background job to distinguish 
-            // this job instance in a multi-instance deployment (default: guid).
-            options.JobId = Guid.NewGuid().ToString();
+                // The unique identifier for this background job to distinguish 
+                // this job instance in a multi-instance deployment (default: guid).
+                options.JobId = Guid.NewGuid().ToString();
 
-            // Indicate whether or not a new Azure Service Bus Topic subscription should be created/deleted
-            // when the message pump starts/stops (default: CreateOnStart & DeleteOnStop).
-            options.TopicSubscription = TopicSubscription.CreateOnStart | TopicSubscription.DeleteOnStop;
-        });
+                // Indicate whether or not a new Azure Service Bus Topic subscription should be created/deleted
+                // when the message pump starts/stops (default: CreateOnStart & DeleteOnStop).
+                options.TopicSubscription = TopicSubscription.CreateOnStart | TopicSubscription.DeleteOnStop;
+            });
 
-    services.AddServiceBusQueueMessagePump(
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
-        options => 
-        {
-            // Indicate whether or not messages should be automatically marked as completed 
-            // if no exceptions occured andprocessing has finished (default: true).
-            options.AutoComplete = true;
+        services.AddServiceBusQueueMessagePump(
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
+            options => 
+            {
+                // Indicate whether or not messages should be automatically marked as completed 
+                // if no exceptions occured andprocessing has finished (default: true).
+                options.AutoComplete = true;
 
-            // The amount of concurrent calls to process messages 
-            // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
-            options.MaxConcurrentCalls = 5;
+                // The amount of concurrent calls to process messages 
+                // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
+                options.MaxConcurrentCalls = 5;
 
-            // The unique identifier for this background job to distinguish 
-            // this job instance in a multi-instance deployment (default: guid).
-            options.JobId = Guid.NewGuid().ToString();
-        });
+                // The unique identifier for this background job to distinguish 
+                // this job instance in a multi-instance deployment (default: guid).
+                options.JobId = Guid.NewGuid().ToString();
+            });
 
-    // Multiple message handlers can be added to the servies, based on the message type (ex. 'Order', 'Customer'...), 
-    // the correct message handler will be selected.
-    services.WithServiceBusMessageHandler<OrdersMessageHandler, Order>()
-            .WithMessageHandler<CustomerMessageHandler, Customer>();
+        // Multiple message handlers can be added to the servies, based on the message type (ex. 'Order', 'Customer'...), 
+        // the correct message handler will be selected.
+        services.WithServiceBusMessageHandler<OrdersMessageHandler, Order>()
+                .WithMessageHandler<CustomerMessageHandler, Customer>();
+    }
 }
 ```
 
@@ -167,6 +199,11 @@ This extra message handler will then process the remaining messages that can't b
 Following example shows how such a message handler can be implemented:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
+using Microsoft.Extensions.Logging;
+
 public class WarnsUserFallbackMessageHandler : IAzureServiceBusFallbackMessageHandller
 {
     private readonly ILogger _logger;
@@ -188,9 +225,14 @@ public class WarnsUserFallbackMessageHandler : IAzureServiceBusFallbackMessageHa
 And to register such an implementation:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    services.WithServiceBusFallbackMessageHandler<WarnsUserFallbackMessageHandler>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.WithServiceBusFallbackMessageHandler<WarnsUserFallbackMessageHandler>();
+    }
 }
 ```
 
@@ -199,6 +241,9 @@ public void ConfigureServices(IServiceCollection services)
 To retrieve the correlation information of Azure Service Bus messages, we provide an extension that wraps all correlation information.
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Microsoft.Azure.ServiceBus;
+
 Message message = ...
 
 MessageCorrelationInfo correlationInfo = message.GetCorrelationInfo();

--- a/docs/v0.3.0/features/service-bus.md
+++ b/docs/v0.3.0/features/service-bus.md
@@ -20,6 +20,8 @@ PM > Install-Package Arcus.Messaging.ServiceBus.Core
 Starting from the message body, we provide an extension to quickly wrap the content in a valid Azure Service Bus `Message` type that can be send.
 
 ```csharp
+using Microsoft.Azure.ServiceBus;
+
 string rawString = "Some raw content";
 Message stringMessage = rawString.AsServiceBusMessage();
 
@@ -30,6 +32,8 @@ Message orderMessage = order.AsServiceBusMessage();
 We also provide additional, optional parameters during the creation:
 
 ```csharp
+using Microsoft.Azure.ServiceBus;
+
 byte[] rawBytes = new [] { 0x54, 0x12 };
 Message = byteMessage = rawBytes.AsServiceBusMessage(
     operationId: Guid.NewGuid().ToString(),
@@ -43,6 +47,9 @@ On receive, the Azure Service Bus message contains a set of `.UserProperties` wi
 This information can be accessed in a more simplified way:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Microsoft.Azure.ServiceBus;
+
 Message message = ...
 
 // Extracted all correlation information from the `.UserProperties` and wrapped inside a valid correlation type.
@@ -61,6 +68,8 @@ On receive, the context in which the message is received contains a set of `.Pro
 This information can be acces in a more simplified way:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+
 // Extract the encoding information from the `.UserProperties` and wrapped inside a valid `Encoding` type.
 MessageContext messageContext = ...
 Encoding encoding = messageContext.GetMessageEncodingProperty();

--- a/docs/v0.3.0/features/tcp-health-probe.md
+++ b/docs/v0.3.0/features/tcp-health-probe.md
@@ -20,18 +20,24 @@ PM > Install-Package Arcus.Messaging.Health
 To include the TCP endpoint, add the following line of code in the `Startup.ConfigureServices` method:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
-{
-    // Add TCP health probe without extra health checks.
-    services.AddTcpHealthProbes("MyConfigurationKeyToTcpHealthPort");
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
-    // Or, add your extra health checks in a configuration delegate.
-    services.AddTcpHealthProbes(
-        "MyConfigurationkeyToTcpHealthPort",
-        configureHealthChecks: healthBuilder => 
-        {
-            healthBuilder.AddCheck("Example", () => HealthCheckResult.Healthy("Example is OK!"), tags: new[] { "example" })
-        });
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Add TCP health probe without extra health checks.
+        services.AddTcpHealthProbes("MyConfigurationKeyToTcpHealthPort");
+
+        // Or, add your extra health checks in a configuration delegate.
+        services.AddTcpHealthProbes(
+            "MyConfigurationkeyToTcpHealthPort",
+            configureHealthChecks: healthBuilder => 
+            {
+                healthBuilder.AddCheck("Example", () => HealthCheckResult.Healthy("Example is OK!"), tags: new[] { "example" })
+            });
+    }
 }
 ```
 
@@ -40,20 +46,28 @@ public void ConfigureServices(IServiceCollection services)
 The TCP probe allows several additional configuration options.
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
-{
-    // Add TCP health probe with or whitout extra health checks.
-    services.AddTcpHealthProbes(
-        "MyConfigurationKeyToTcpHealthPort",
-        configureTcpListenerOptions: options =>
-        {
-            // Configure the configuration key on which the health report is exposed.
-            options.TcpPortConfigurationKey = "MyConfigurationKey";
+using Microsoft.Extensions.DependencyInjection;
 
-            // Configure how the health report should be serialized.
-            options.HealthReportSerializer = new MyHealthReportSerializer();
-        });
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Add TCP health probe with or whitout extra health checks.
+        services.AddTcpHealthProbes(
+            "MyConfigurationKeyToTcpHealthPort",
+            configureTcpListenerOptions: options =>
+            {
+                // Configure the configuration key on which the health report is exposed.
+                options.TcpPortConfigurationKey = "MyConfigurationKey";
+
+                // Configure how the health report should be serialized.
+                options.HealthReportSerializer = new MyHealthReportSerializer();
+            });
+    }
 }
+
+using Arcus.Messaging.Health;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 public class MyHealthReportSerializer : IHealthReportSerializer
 {

--- a/docs/v0.4.0/features/message-pumps/customization.md
+++ b/docs/v0.4.0/features/message-pumps/customization.md
@@ -18,6 +18,12 @@ When inheriting from an `...MessagePump` type, there's a way to control how the 
 Based on the message type of the registered message handlers, the pump determines if the incoming message can be deserialized to that type.
 
 ```csharp
+using System;
+using Arcus.Messaging.Pumps.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DepenedencyInjection;
+using Microsoft.Extensions.Logging;
+
 public class OrderMessagePump : MessagePump
 {
     public OrderMessagePump(
@@ -55,6 +61,9 @@ Following example shows how a message handler should only process a certain mess
 We'll use a simple message handler implementation:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
+
 public class OrderMessageHandler : IMessageHandler<Order>
 {
     public async Task ProcessMessageAsync(Order order, MessageContext context, ...)
@@ -67,9 +76,14 @@ public class OrderMessageHandler : IMessageHandler<Order>
 We would like that this handler only processed the message when the context contains `MessageType` equals `Order`.
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    services.WithMessageHandler<OrderMessageHandler, Order>(context => context.Properties["MessageType"].ToString() == "Order");
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.WithMessageHandler<OrderMessageHandler, Order>(context => context.Properties["MessageType"].ToString() == "Order");
+    }
 }
 ```
 
@@ -88,6 +102,10 @@ This extra message handler will then process the remaining messages that can't b
 Following example shows how such a message handler can be implemented:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.Abstractions.MessageHandling;
+using Microsoft.Extensions.Logging;
+
 public class WarnsUserFallbackMessageHandler : IFallbackMessageHandller
 {
     private readonly ILogger _logger;
@@ -107,9 +125,14 @@ public class WarnsUserFallbackMessageHandler : IFallbackMessageHandller
 And to register such an implementation:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    services.WithFallbackMessageHandler<WarnsUserFallbackMessageHandler>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.WithFallbackMessageHandler<WarnsUserFallbackMessageHandler>();
+    }
 }
 ```
 

--- a/docs/v0.4.0/features/message-pumps/customization.md
+++ b/docs/v0.4.0/features/message-pumps/customization.md
@@ -21,7 +21,7 @@ Based on the message type of the registered message handlers, the pump determine
 using System;
 using Arcus.Messaging.Pumps.Abstractions;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DepenedencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 public class OrderMessagePump : MessagePump

--- a/docs/v0.4.0/features/message-pumps/service-bus.md
+++ b/docs/v0.4.0/features/message-pumps/service-bus.md
@@ -19,19 +19,30 @@ You can do this by creating a message handler which implements from `IAzureServi
 Here is an example of a message handler that expects messages of type `Order`:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.ServiceBus;
+using Microsoft.Extensions.Logging;
+
 public class OrdersMessageHandler : IAzureServiceBusMessageHandler<Order>
 {
-    public async Task ProcessMessageAsync(
-    Order orderMessage, 
-    AzureServiceBusMessageContext messageContext, 
-    MessageCorrelationInfo correlationInfo, 
-    CancellationToken cancellationToken)
+    private readonly ILogger _logger;
+
+    public OrdersMessageHandler(ILogger<OrdersMessageHandler> logger)
     {
-        Logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
+        _logger = logger;
+    }
+
+    public async Task ProcessMessageAsync(
+        Order orderMessage, 
+        AzureServiceBusMessageContext messageContext, 
+        MessageCorrelationInfo correlationInfo, 
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
 
         // Custom logic
 
-        Logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
+        _logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
     }
 }
 ```
@@ -39,19 +50,30 @@ public class OrdersMessageHandler : IAzureServiceBusMessageHandler<Order>
 or with using the more general `IMessageHandler<>`, that will use the more general `MessageContext` instead of the one specific for Azure Service Bus.
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.Abstractions;
+using Microsoft.Extensions.Logging;
+
 public class OrdersMessageHandler : IMessageHandler<Order>
 {
-    public async Task ProcessMessageAsync(
-    Order orderMessage, 
-    MessageContext messageContext, 
-    MessageCorrelationInfo correlationInfo, 
-    CancellationToken cancellationToken)
+    private readonly ILogger _logger;
+
+    public OrdersMessageHandler(ILogger<OrdersMessageHandler> logger)
     {
-        Logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
+        _logger = logger;
+    }
+
+    public async Task ProcessMessageAsync(
+        Order orderMessage, 
+        MessageContext messageContext, 
+        MessageCorrelationInfo correlationInfo, 
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
 
         // Custom logic
 
-        Logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
+        _logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
     }
 }
 ```
@@ -68,19 +90,24 @@ Other topics:
 Once the message handler is created, you can very easily configure it:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    // Add Service Bus Queue message pump and use OrdersMessageHandler to process the messages
-    // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
-    services.AddServiceBusQueueMessagePump("ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
-            .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Add Service Bus Queue message pump and use OrdersMessageHandler to process the messages
+        // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
+        services.AddServiceBusQueueMessagePump("ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
+                .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
 
-    // Add Service Bus Topic message pump and use OrdersMessageHandler to process the messages on the 'My-Subscription-Name' subscription
-    // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
-    services.AddServiceBusTopicMessagePump("My-Subscription-Name", "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
-            .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
+        // Add Service Bus Topic message pump and use OrdersMessageHandler to process the messages on the 'My-Subscription-Name' subscription
+        // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
+        services.AddServiceBusTopicMessagePump("My-Subscription-Name", "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
+                .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
 
-    // Note, that only a single call to the `.WithServiceBusMessageHandler` has to be made when the handler should be used across message pumps.
+        // Note, that only a single call to the `.WithServiceBusMessageHandler` has to be made when the handler should be used across message pumps.
+    }
 }
 ```
 
@@ -98,67 +125,72 @@ Next to that, we provide a **variety of overloads** to allow you to:
 - Read the connection string from the configuration *(although we highly recommend using a secret store instead)*
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    // Specify the name of the Service Bus Queue:
-    services.AddServiceBusQueueMessagePump(
-        "My-Service-Bus-Queue-Name",
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Specify the name of the Service Bus Queue:
+        services.AddServiceBusQueueMessagePump(
+            "My-Service-Bus-Queue-Name",
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
 
-    // Specify the name of the Service Bus Topic, and provide a name for the Topic subscription:
-    services.AddServiceBusMessageTopicPump<OrdersMessageHandler>(
-        "My-Service-Bus-Topic-Name",
-        "My-Service-Bus-Topic-Subscription-Name",
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
+        // Specify the name of the Service Bus Topic, and provide a name for the Topic subscription:
+        services.AddServiceBusMessageTopicPump<OrdersMessageHandler>(
+            "My-Service-Bus-Topic-Name",
+            "My-Service-Bus-Topic-Subscription-Name",
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
 
-    // Specify a topic subscription prefix instead of a name to separate topic message pumps.
-    services.AddServiceBusTopicPumpWithPrefix(
-        "My-Service-Bus-Topic-Name"
-        "My-Service-Bus-Subscription-Prefix",
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
+        // Specify a topic subscription prefix instead of a name to separate topic message pumps.
+        services.AddServiceBusTopicPumpWithPrefix(
+            "My-Service-Bus-Topic-Name"
+            "My-Service-Bus-Subscription-Prefix",
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
 
-    services.AddServiceBusTopicMessagePump(
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
-        options => 
-        {
-            // Indicate whether or not messages should be automatically marked as completed 
-            // if no exceptions occured andprocessing has finished (default: true).
-            options.AutoComplete = true;
+        services.AddServiceBusTopicMessagePump(
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
+            options => 
+            {
+                // Indicate whether or not messages should be automatically marked as completed 
+                // if no exceptions occured andprocessing has finished (default: true).
+                options.AutoComplete = true;
 
-            // The amount of concurrent calls to process messages 
-            // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
-            options.MaxConcurrentCalls = 5;
+                // The amount of concurrent calls to process messages 
+                // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
+                options.MaxConcurrentCalls = 5;
 
-            // The unique identifier for this background job to distinguish 
-            // this job instance in a multi-instance deployment (default: guid).
-            options.JobId = Guid.NewGuid().ToString();
+                // The unique identifier for this background job to distinguish 
+                // this job instance in a multi-instance deployment (default: guid).
+                options.JobId = Guid.NewGuid().ToString();
 
-            // Indicate whether or not a new Azure Service Bus Topic subscription should be created/deleted
-            // when the message pump starts/stops (default: CreateOnStart & DeleteOnStop).
-            options.TopicSubscription = TopicSubscription.CreateOnStart | TopicSubscription.DeleteOnStop;
-        });
+                // Indicate whether or not a new Azure Service Bus Topic subscription should be created/deleted
+                // when the message pump starts/stops (default: CreateOnStart & DeleteOnStop).
+                options.TopicSubscription = TopicSubscription.CreateOnStart | TopicSubscription.DeleteOnStop;
+            });
 
-    services.AddServiceBusQueueMessagePump(
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
-        options => 
-        {
-            // Indicate whether or not messages should be automatically marked as completed 
-            // if no exceptions occured andprocessing has finished (default: true).
-            options.AutoComplete = true;
+        services.AddServiceBusQueueMessagePump(
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
+            options => 
+            {
+                // Indicate whether or not messages should be automatically marked as completed 
+                // if no exceptions occured andprocessing has finished (default: true).
+                options.AutoComplete = true;
 
-            // The amount of concurrent calls to process messages 
-            // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
-            options.MaxConcurrentCalls = 5;
+                // The amount of concurrent calls to process messages 
+                // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
+                options.MaxConcurrentCalls = 5;
 
-            // The unique identifier for this background job to distinguish 
-            // this job instance in a multi-instance deployment (default: guid).
-            options.JobId = Guid.NewGuid().ToString();
-        });
+                // The unique identifier for this background job to distinguish 
+                // this job instance in a multi-instance deployment (default: guid).
+                options.JobId = Guid.NewGuid().ToString();
+            });
 
-    // Multiple message handlers can be added to the servies, based on the message type (ex. 'Order', 'Customer'...), 
-    // the correct message handler will be selected.
-    services.WithServiceBusMessageHandler<OrdersMessageHandler, Order>()
-            .WithMessageHandler<CustomerMessageHandler, Customer>();
+        // Multiple message handlers can be added to the servies, based on the message type (ex. 'Order', 'Customer'...), 
+        // the correct message handler will be selected.
+        services.WithServiceBusMessageHandler<OrdersMessageHandler, Order>()
+                .WithMessageHandler<CustomerMessageHandler, Customer>();
+    }
 }
 ```
 
@@ -173,6 +205,11 @@ This extra message handler will then process the remaining messages that can't b
 Following example shows how such a message handler can be implemented:
 
 ```csharp
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
+using Microsoft.Azure.ServiceBus;
+using Microsoft.Extensions.Logging;
+
 public class WarnsUserFallbackMessageHandler : IAzureServiceBusFallbackMessageHandller
 {
     private readonly ILogger _logger;
@@ -194,9 +231,14 @@ public class WarnsUserFallbackMessageHandler : IAzureServiceBusFallbackMessageHa
 And to register such an implementation:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    services.WithServiceBusFallbackMessageHandler<WarnsUserFallbackMessageHandler>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.WithServiceBusFallbackMessageHandler<WarnsUserFallbackMessageHandler>();
+    }
 }
 ```
 
@@ -217,6 +259,10 @@ This base class provides several protected methods to call the Azure Service Bus
 Example:
 
 ```csharp
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
+using Microsoft.Extensions.Logging;
+
 public class AbandonsUnknownOrderMessageHandler : AzureServiceBusMessageHandler<Order>
 {
     public AbandonsUnknownOrderMessageHandler(ILogger<AbandonsUnknownOrderMessageHandler> logger)
@@ -241,9 +287,14 @@ public class AbandonsUnknownOrderMessageHandler : AzureServiceBusMessageHandler<
 The registration happens the same as any other regular message handler:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    services.WithServiceBusMessageHandler<AbandonUnknownOrderMessageHandler, Order>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.WithServiceBusMessageHandler<AbandonUnknownOrderMessageHandler, Order>();
+    }
 }
 ```
 
@@ -259,6 +310,11 @@ This base class provides several protected methods to call the Azure Service Bus
 Example:
 
 ```csharp
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
+using Microsoft.Azure.ServiceBus;
+using Microsoft.Extensions.Logging;
+
 public class DeadLetterFallbackMessageHandler : AzureServiceBusFallbackMessageHandler
 {
     public DeadLetterFallbackMessageHandler(ILogger<DeadLetterFallbackMessageHandler> logger)
@@ -277,9 +333,14 @@ public class DeadLetterFallbackMessageHandler : AzureServiceBusFallbackMessageHa
 The registration happens the same way as any other fallback message handler:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    services.WithServiceBusFallbackMessageHandler<DeadLetterFallbackMessageHandler>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.WithServiceBusFallbackMessageHandler<DeadLetterFallbackMessageHandler>();
+    }
 }
 ```
 
@@ -288,6 +349,9 @@ public void ConfigureServices(IServiceCollection services)
 To retrieve the correlation information of Azure Service Bus messages, we provide an extension that wraps all correlation information.
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Microsoft.Azure.ServiceBus;
+
 Message message = ...
 
 MessageCorrelationInfo correlationInfo = message.GetCorrelationInfo();

--- a/docs/v0.4.0/features/service-bus.md
+++ b/docs/v0.4.0/features/service-bus.md
@@ -20,6 +20,8 @@ PM > Install-Package Arcus.Messaging.ServiceBus.Core
 Starting from the message body, we provide an extension to quickly wrap the content in a valid Azure Service Bus `Message` type that can be send.
 
 ```csharp
+using Microsoft.Azure.ServiceBus;
+
 string rawString = "Some raw content";
 Message stringMessage = rawString.AsServiceBusMessage();
 
@@ -30,6 +32,8 @@ Message orderMessage = order.AsServiceBusMessage();
 We also provide additional, optional parameters during the creation:
 
 ```csharp
+using Microsoft.Azure.ServiceBus;
+
 byte[] rawBytes = new [] { 0x54, 0x12 };
 Message = byteMessage = rawBytes.AsServiceBusMessage(
     operationId: Guid.NewGuid().ToString(),
@@ -43,6 +47,9 @@ On receive, the Azure Service Bus message contains a set of `.UserProperties` wi
 This information can be accessed in a more simplified way:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Microsoft.Azure.ServiceBus;
+
 Message message = ...
 
 // Extracted all correlation information from the `.UserProperties` and wrapped inside a valid correlation type.
@@ -61,6 +68,8 @@ On receive, the context in which the message is received contains a set of `.Pro
 This information can be acces in a more simplified way:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+
 // Extract the encoding information from the `.UserProperties` and wrapped inside a valid `Encoding` type.
 MessageContext messageContext = ...
 Encoding encoding = messageContext.GetMessageEncodingProperty();

--- a/docs/v0.4.0/features/tcp-health-probe.md
+++ b/docs/v0.4.0/features/tcp-health-probe.md
@@ -20,18 +20,24 @@ PM > Install-Package Arcus.Messaging.Health
 To include the TCP endpoint, add the following line of code in the `Startup.ConfigureServices` method:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
-{
-    // Add TCP health probe without extra health checks.
-    services.AddTcpHealthProbes("MyConfigurationKeyToTcpHealthPort");
+using Microsoft.Extensions.DependencyInjeciton;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
-    // Or, add your extra health checks in a configuration delegate.
-    services.AddTcpHealthProbes(
-        "MyConfigurationkeyToTcpHealthPort",
-        configureHealthChecks: healthBuilder => 
-        {
-            healthBuilder.AddCheck("Example", () => HealthCheckResult.Healthy("Example is OK!"), tags: new[] { "example" })
-        });
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Add TCP health probe without extra health checks.
+        services.AddTcpHealthProbes("MyConfigurationKeyToTcpHealthPort");
+
+        // Or, add your extra health checks in a configuration delegate.
+        services.AddTcpHealthProbes(
+            "MyConfigurationkeyToTcpHealthPort",
+            configureHealthChecks: healthBuilder => 
+            {
+                healthBuilder.AddCheck("Example", () => HealthCheckResult.Healthy("Example is OK!"), tags: new[] { "example" })
+            });
+    }
 }
 ```
 
@@ -40,20 +46,28 @@ public void ConfigureServices(IServiceCollection services)
 The TCP probe allows several additional configuration options.
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
-{
-    // Add TCP health probe with or whitout extra health checks.
-    services.AddTcpHealthProbes(
-        "MyConfigurationKeyToTcpHealthPort",
-        configureTcpListenerOptions: options =>
-        {
-            // Configure the configuration key on which the health report is exposed.
-            options.TcpPortConfigurationKey = "MyConfigurationKey";
+using Microsoft.Extensions.DependencyInjection;
 
-            // Configure how the health report should be serialized.
-            options.HealthReportSerializer = new MyHealthReportSerializer();
-        });
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Add TCP health probe with or whitout extra health checks.
+        services.AddTcpHealthProbes(
+            "MyConfigurationKeyToTcpHealthPort",
+            configureTcpListenerOptions: options =>
+            {
+                // Configure the configuration key on which the health report is exposed.
+                options.TcpPortConfigurationKey = "MyConfigurationKey";
+
+                // Configure how the health report should be serialized.
+                options.HealthReportSerializer = new MyHealthReportSerializer();
+            });
+    }
 }
+
+using Arcus.Messaging.Health;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 public class MyHealthReportSerializer : IHealthReportSerializer
 {

--- a/docs/v0.5.0/features/message-pumps/customization.md
+++ b/docs/v0.5.0/features/message-pumps/customization.md
@@ -18,6 +18,12 @@ When inheriting from an `...MessagePump` type, there's a way to control how the 
 Based on the message type of the registered message handlers, the pump determines if the incoming message can be deserialized to that type.
 
 ```csharp
+using System;
+using Arcus.Messaging.Pumps.Abstractions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 public class OrderMessagePump : MessagePump
 {
     public OrderMessagePump(
@@ -55,6 +61,9 @@ Following example shows how a message handler should only process a certain mess
 We'll use a simple message handler implementation:
 
 ```csharp
+using Arcus.Messaging.Abstrations;
+using Arcus.Messaging.Pumps.Abstractions;
+
 public class OrderMessageHandler : IMessageHandler<Order>
 {
     public async Task ProcessMessageAsync(Order order, MessageContext context, ...)
@@ -67,9 +76,14 @@ public class OrderMessageHandler : IMessageHandler<Order>
 We would like that this handler only processed the message when the context contains `MessageType` equals `Order`.
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    services.WithMessageHandler<OrderMessageHandler, Order>(context => context.Properties["MessageType"].ToString() == "Order");
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.WithMessageHandler<OrderMessageHandler, Order>(context => context.Properties["MessageType"].ToString() == "Order");
+    }
 }
 ```
 
@@ -88,6 +102,10 @@ This extra message handler will then process the remaining messages that can't b
 Following example shows how such a message handler can be implemented:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.Abstractions;
+using Microsoft.Extensions.Logging;
+
 public class WarnsUserFallbackMessageHandler : IFallbackMessageHandller
 {
     private readonly ILogger _logger;
@@ -107,9 +125,14 @@ public class WarnsUserFallbackMessageHandler : IFallbackMessageHandller
 And to register such an implementation:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    services.WithFallbackMessageHandler<WarnsUserFallbackMessageHandler>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.WithFallbackMessageHandler<WarnsUserFallbackMessageHandler>();
+    }
 }
 ```
 

--- a/docs/v0.5.0/features/message-pumps/service-bus.md
+++ b/docs/v0.5.0/features/message-pumps/service-bus.md
@@ -19,19 +19,30 @@ You can do this by creating a message handler which implements from `IAzureServi
 Here is an example of a message handler that expects messages of type `Order`:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.ServiceBus;
+using Microsoft.Extensions.Logging;
+
 public class OrdersMessageHandler : IAzureServiceBusMessageHandler<Order>
 {
-    public async Task ProcessMessageAsync(
-    Order orderMessage, 
-    AzureServiceBusMessageContext messageContext, 
-    MessageCorrelationInfo correlationInfo, 
-    CancellationToken cancellationToken)
+    private readonly ILogger _logger;
+
+    public OrdersMessageHandler(ILogger<OrdersMessageHandler> logger)
     {
-        Logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
+        _logger = logger;
+    }
+
+    public async Task ProcessMessageAsync(
+        Order orderMessage, 
+        AzureServiceBusMessageContext messageContext, 
+        MessageCorrelationInfo correlationInfo, 
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
 
         // Custom logic
 
-        Logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
+        _logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
     }
 }
 ```
@@ -39,19 +50,30 @@ public class OrdersMessageHandler : IAzureServiceBusMessageHandler<Order>
 or with using the more general `IMessageHandler<>`, that will use the more general `MessageContext` instead of the one specific for Azure Service Bus.
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.Abstractions;
+using Microsoft.Extensions.Logging;
+
 public class OrdersMessageHandler : IMessageHandler<Order>
 {
-    public async Task ProcessMessageAsync(
-    Order orderMessage, 
-    MessageContext messageContext, 
-    MessageCorrelationInfo correlationInfo, 
-    CancellationToken cancellationToken)
+    private readonly ILogger _logger;
+
+    public OrdersMessageHandler(ILogger<OrdersMessageHandler> logger)
     {
-        Logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
+        _logger = logger;
+    }
+
+    public async Task ProcessMessageAsync(
+        Order orderMessage, 
+        MessageContext messageContext, 
+        MessageCorrelationInfo correlationInfo, 
+        CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", orderMessage.Id, orderMessage.Amount, orderMessage.ArticleNumber, orderMessage.Customer.FirstName, orderMessage.Customer.LastName);
 
         // Custom logic
 
-        Logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
+        _logger.LogInformation("Order {OrderId} processed", orderMessage.Id);
     }
 }
 ```
@@ -68,19 +90,24 @@ Other topics:
 Once the message handler is created, you can very easily configure it:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    // Add Service Bus Queue message pump and use OrdersMessageHandler to process the messages
-    // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
-    services.AddServiceBusQueueMessagePump("ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
-            .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
-
-    // Add Service Bus Topic message pump and use OrdersMessageHandler to process the messages on the 'My-Subscription-Name' subscription
-    // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
-    services.AddServiceBusTopicMessagePump("My-Subscription-Name", "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
-            .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
-
-    // Note, that only a single call to the `.WithServiceBusMessageHandler` has to be made when the handler should be used across message pumps.
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Add Service Bus Queue message pump and use OrdersMessageHandler to process the messages
+        // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
+        services.AddServiceBusQueueMessagePump("ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
+                .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
+    
+        // Add Service Bus Topic message pump and use OrdersMessageHandler to process the messages on the 'My-Subscription-Name' subscription
+        // ISecretProvider will be used to lookup the connection string scoped to the queue for secret ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING
+        services.AddServiceBusTopicMessagePump("My-Subscription-Name", "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING")
+                .WithServiceBusMessageHandler<OrdersMessageHandler, Order>();
+    
+        // Note, that only a single call to the `.WithServiceBusMessageHandler` has to be made when the handler should be used across message pumps.
+    }
 }
 ```
 
@@ -98,67 +125,72 @@ Next to that, we provide a **variety of overloads** to allow you to:
 - Read the connection string from the configuration *(although we highly recommend using a secret store instead)*
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    // Specify the name of the Service Bus Queue:
-    services.AddServiceBusQueueMessagePump(
-        "My-Service-Bus-Queue-Name",
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Specify the name of the Service Bus Queue:
+        services.AddServiceBusQueueMessagePump(
+            "My-Service-Bus-Queue-Name",
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
 
-    // Specify the name of the Service Bus Topic, and provide a name for the Topic subscription:
-    services.AddServiceBusMessageTopicPump<OrdersMessageHandler>(
-        "My-Service-Bus-Topic-Name",
-        "My-Service-Bus-Topic-Subscription-Name",
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
+        // Specify the name of the Service Bus Topic, and provide a name for the Topic subscription:
+        services.AddServiceBusMessageTopicPump<OrdersMessageHandler>(
+            "My-Service-Bus-Topic-Name",
+            "My-Service-Bus-Topic-Subscription-Name",
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
 
-    // Specify a topic subscription prefix instead of a name to separate topic message pumps.
-    services.AddServiceBusTopicPumpWithPrefix(
-        "My-Service-Bus-Topic-Name"
-        "My-Service-Bus-Subscription-Prefix",
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
+        // Specify a topic subscription prefix instead of a name to separate topic message pumps.
+        services.AddServiceBusTopicPumpWithPrefix(
+            "My-Service-Bus-Topic-Name"
+            "My-Service-Bus-Subscription-Prefix",
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING");
 
-    services.AddServiceBusTopicMessagePump(
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
-        options => 
-        {
-            // Indicate whether or not messages should be automatically marked as completed 
-            // if no exceptions occured andprocessing has finished (default: true).
-            options.AutoComplete = true;
+        services.AddServiceBusTopicMessagePump(
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
+            options => 
+            {
+                // Indicate whether or not messages should be automatically marked as completed 
+                // if no exceptions occured andprocessing has finished (default: true).
+                options.AutoComplete = true;
 
-            // The amount of concurrent calls to process messages 
-            // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
-            options.MaxConcurrentCalls = 5;
+                // The amount of concurrent calls to process messages 
+                // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
+                options.MaxConcurrentCalls = 5;
 
-            // The unique identifier for this background job to distinguish 
-            // this job instance in a multi-instance deployment (default: guid).
-            options.JobId = Guid.NewGuid().ToString();
+                // The unique identifier for this background job to distinguish 
+                // this job instance in a multi-instance deployment (default: guid).
+                options.JobId = Guid.NewGuid().ToString();
 
-            // Indicate whether or not a new Azure Service Bus Topic subscription should be created/deleted
-            // when the message pump starts/stops (default: CreateOnStart & DeleteOnStop).
-            options.TopicSubscription = TopicSubscription.CreateOnStart | TopicSubscription.DeleteOnStop;
-        });
+                // Indicate whether or not a new Azure Service Bus Topic subscription should be created/deleted
+                // when the message pump starts/stops (default: CreateOnStart & DeleteOnStop).
+                options.TopicSubscription = TopicSubscription.CreateOnStart | TopicSubscription.DeleteOnStop;
+            });
 
-    services.AddServiceBusQueueMessagePump(
-        "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
-        options => 
-        {
-            // Indicate whether or not messages should be automatically marked as completed 
-            // if no exceptions occured andprocessing has finished (default: true).
-            options.AutoComplete = true;
+        services.AddServiceBusQueueMessagePump(
+            "ARCUS_SERVICEBUS_ORDERS_CONNECTIONSTRING",
+            options => 
+            {
+                // Indicate whether or not messages should be automatically marked as completed 
+                // if no exceptions occured andprocessing has finished (default: true).
+                options.AutoComplete = true;
 
-            // The amount of concurrent calls to process messages 
-            // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
-            options.MaxConcurrentCalls = 5;
+                // The amount of concurrent calls to process messages 
+                // (default: null, leading to the defaults of the Azure Service Bus SDK message handler options).
+                options.MaxConcurrentCalls = 5;
 
-            // The unique identifier for this background job to distinguish 
-            // this job instance in a multi-instance deployment (default: guid).
-            options.JobId = Guid.NewGuid().ToString();
-        });
+                // The unique identifier for this background job to distinguish 
+                // this job instance in a multi-instance deployment (default: guid).
+                options.JobId = Guid.NewGuid().ToString();
+            });
 
-    // Multiple message handlers can be added to the servies, based on the message type (ex. 'Order', 'Customer'...), 
-    // the correct message handler will be selected.
-    services.WithServiceBusMessageHandler<OrdersMessageHandler, Order>()
-            .WithMessageHandler<CustomerMessageHandler, Customer>();
+        // Multiple message handlers can be added to the servies, based on the message type (ex. 'Order', 'Customer'...), 
+        // the correct message handler will be selected.
+        services.WithServiceBusMessageHandler<OrdersMessageHandler, Order>()
+                .WithMessageHandler<CustomerMessageHandler, Customer>();
+    }
 }
 ```
 
@@ -173,6 +205,11 @@ This extra message handler will then process the remaining messages that can't b
 Following example shows how such a message handler can be implemented:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
+using Microsoft.Extensions.Logging;
+
 public class WarnsUserFallbackMessageHandler : IAzureServiceBusFallbackMessageHandller
 {
     private readonly ILogger _logger;
@@ -194,9 +231,14 @@ public class WarnsUserFallbackMessageHandler : IAzureServiceBusFallbackMessageHa
 And to register such an implementation:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DepdencencyInjection;
+
+public class Startup
 {
-    services.WithServiceBusFallbackMessageHandler<WarnsUserFallbackMessageHandler>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.WithServiceBusFallbackMessageHandler<WarnsUserFallbackMessageHandler>();
+    }
 }
 ```
 
@@ -218,6 +260,11 @@ This base class provides several protected methods to call the Azure Service Bus
 Example:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
+using Microsoft.Extensions.Logging;
+
 public class AbandonsUnknownOrderMessageHandler : AzureServiceBusMessageHandler<Order>
 {
     public AbandonsUnknownOrderMessageHandler(ILogger<AbandonsUnknownOrderMessageHandler> logger)
@@ -242,9 +289,14 @@ public class AbandonsUnknownOrderMessageHandler : AzureServiceBusMessageHandler<
 The registration happens the same as any other regular message handler:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    services.WithServiceBusMessageHandler<AbandonUnknownOrderMessageHandler, Order>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.WithServiceBusMessageHandler<AbandonUnknownOrderMessageHandler, Order>();
+    }
 }
 ```
 
@@ -261,6 +313,11 @@ This base class provides several protected methods to call the Azure Service Bus
 Example:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
+using Microsoft.Extensions.Logging;
+
 public class DeadLetterFallbackMessageHandler : AzureServiceBusFallbackMessageHandler
 {
     public DeadLetterFallbackMessageHandler(ILogger<DeadLetterFallbackMessageHandler> logger)
@@ -279,9 +336,14 @@ public class DeadLetterFallbackMessageHandler : AzureServiceBusFallbackMessageHa
 The registration happens the same way as any other fallback message handler:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
+using Microsoft.Extensions.DependencyInjection;
+
+public class Startup
 {
-    services.WithServiceBusFallbackMessageHandler<DeadLetterFallbackMessageHandler>();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.WithServiceBusFallbackMessageHandler<DeadLetterFallbackMessageHandler>();
+    }
 }
 ```
 
@@ -290,6 +352,9 @@ public void ConfigureServices(IServiceCollection services)
 To retrieve the correlation information of Azure Service Bus messages, we provide an extension that wraps all correlation information.
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Microsoft.Azure.ServiceBus;
+
 Message message = ...
 
 MessageCorrelationInfo correlationInfo = message.GetCorrelationInfo();

--- a/docs/v0.5.0/features/service-bus.md
+++ b/docs/v0.5.0/features/service-bus.md
@@ -20,6 +20,8 @@ PM > Install-Package Arcus.Messaging.ServiceBus.Core
 Starting from the message body, we provide an extension to quickly wrap the content in a valid Azure Service Bus `Message` type that can be send.
 
 ```csharp
+using Microsoft.Azure.ServiceBus;
+
 string rawString = "Some raw content";
 Message stringMessage = rawString.AsServiceBusMessage();
 
@@ -30,6 +32,8 @@ Message orderMessage = order.AsServiceBusMessage();
 We also provide additional, optional parameters during the creation:
 
 ```csharp
+using Microsoft.Azure.ServiceBus;
+
 byte[] rawBytes = new [] { 0x54, 0x12 };
 Message = byteMessage = rawBytes.AsServiceBusMessage(
     operationId: Guid.NewGuid().ToString(),
@@ -43,6 +47,9 @@ On receive, the Azure Service Bus message contains a set of `.UserProperties` wi
 This information can be accessed in a more simplified way:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+using Microsoft.Azure.ServiceBus;
+
 Message message = ...
 
 // Extracted all correlation information from the `.UserProperties` and wrapped inside a valid correlation type.
@@ -61,6 +68,8 @@ On receive, the context in which the message is received contains a set of `.Pro
 This information can be acces in a more simplified way:
 
 ```csharp
+using Arcus.Messaging.Abstractions;
+
 // Extract the encoding information from the `.UserProperties` and wrapped inside a valid `Encoding` type.
 MessageContext messageContext = ...
 Encoding encoding = messageContext.GetMessageEncodingProperty();

--- a/docs/v0.5.0/features/tcp-health-probe.md
+++ b/docs/v0.5.0/features/tcp-health-probe.md
@@ -20,18 +20,24 @@ PM > Install-Package Arcus.Messaging.Health
 To include the TCP endpoint, add the following line of code in the `Startup.ConfigureServices` method:
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
-{
-    // Add TCP health probe without extra health checks.
-    services.AddTcpHealthProbes("MyConfigurationKeyToTcpHealthPort");
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
-    // Or, add your extra health checks in a configuration delegate.
-    services.AddTcpHealthProbes(
-        "MyConfigurationkeyToTcpHealthPort",
-        configureHealthChecks: healthBuilder => 
-        {
-            healthBuilder.AddCheck("Example", () => HealthCheckResult.Healthy("Example is OK!"), tags: new[] { "example" })
-        });
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Add TCP health probe without extra health checks.
+        services.AddTcpHealthProbes("MyConfigurationKeyToTcpHealthPort");
+
+        // Or, add your extra health checks in a configuration delegate.
+        services.AddTcpHealthProbes(
+            "MyConfigurationkeyToTcpHealthPort",
+            configureHealthChecks: healthBuilder => 
+            {
+                healthBuilder.AddCheck("Example", () => HealthCheckResult.Healthy("Example is OK!"), tags: new[] { "example" })
+            });
+    }
 }
 ```
 
@@ -40,20 +46,28 @@ public void ConfigureServices(IServiceCollection services)
 The TCP probe allows several additional configuration options.
 
 ```csharp
-public void ConfigureServices(IServiceCollection services)
-{
-    // Add TCP health probe with or whitout extra health checks.
-    services.AddTcpHealthProbes(
-        "MyConfigurationKeyToTcpHealthPort",
-        configureTcpListenerOptions: options =>
-        {
-            // Configure the configuration key on which the health report is exposed.
-            options.TcpPortConfigurationKey = "MyConfigurationKey";
+using Microsoft.Extensions.DependencyInjection;
 
-            // Configure how the health report should be serialized.
-            options.HealthReportSerializer = new MyHealthReportSerializer();
-        });
+public class Startup
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Add TCP health probe with or whitout extra health checks.
+        services.AddTcpHealthProbes(
+            "MyConfigurationKeyToTcpHealthPort",
+            configureTcpListenerOptions: options =>
+            {
+                // Configure the configuration key on which the health report is exposed.
+                options.TcpPortConfigurationKey = "MyConfigurationKey";
+
+                // Configure how the health report should be serialized.
+                options.HealthReportSerializer = new MyHealthReportSerializer();
+            });
+    }
 }
+
+using Arcus.Messaging.Health;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 public class MyHealthReportSerializer : IHealthReportSerializer
 {


### PR DESCRIPTION
Adds the missing `using` statements to the feature docs.

Relates to https://github.com/arcus-azure/arcus/issues/107