### PR TITLE
Feature - add support to reject TCP client connections based on health report status

### DIFF
--- a/docs/preview/features/tcp-health-probe.md
+++ b/docs/preview/features/tcp-health-probe.md
@@ -67,6 +67,19 @@ public class Startup
                 // When set to `true`, unhealthy health reports will result in rejecting of TCP client connection attempts.
                 // When set to `false` (default), TCP client connection attempts will be accepted but the returned health report will have a uhealthy health status.
                 options.RejectTcpConnectionWhenUnhealthy = true;
+            },
+            configureHealthCheckPublisherOptions: options =>
+            {
+                // Configures additional options regarding how fast or slow changes in the health report should affect the TCP probe's availability.
+                // When the RejectTcpConnectionWhenUnhealthy is set to `true`.
+
+                // The initial delay after the application starts with monitoring the health report changes.
+                options.Delay = TimeSpan.Zero;
+
+                // The interval in which the health report is monitored for changes.
+                options.Period = TimeSpan.FromSeconds(5);
+
+                // See https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.diagnostics.healthchecks.healthcheckpublisheroptions?view=dotnet-plat-ext-5.0 for more information.
             });
     }
 }

--- a/docs/preview/features/tcp-health-probe.md
+++ b/docs/preview/features/tcp-health-probe.md
@@ -62,6 +62,11 @@ public class Startup
 
                 // Configure how the health report should be serialized.
                 options.HealthReportSerializer = new MyHealthReportSerializer();
+
+                // Configure how the health report status should affect the TCP probe's availability.
+                // When set to `true`, unhealthy health reports will result in rejecting of TCP client connection attempts.
+                // When set to `false` (default), TCP client connection attempts will be accepted but the returned health report will have a uhealthy health status.
+                options.RejectTcpConnectionWhenUnhealthy = true;
             });
     }
 }

--- a/src/Arcus.Messaging.Health/Arcus.Messaging.Health.csproj
+++ b/src/Arcus.Messaging.Health/Arcus.Messaging.Health.csproj
@@ -11,7 +11,7 @@
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.messaging/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/arcus-azure/arcus.messaging</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
-    <RepositoryUrl>>https://github.com/arcus-azure/arcus.messaging</RepositoryUrl>
+    <RepositoryUrl>&gt;https://github.com/arcus-azure/arcus.messaging</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>Azure;Messaging;Health;Operations</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Arcus.Messaging.Health/Arcus.Messaging.Health.csproj
+++ b/src/Arcus.Messaging.Health/Arcus.Messaging.Health.csproj
@@ -11,7 +11,7 @@
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.messaging/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/arcus-azure/arcus.messaging</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
-    <RepositoryUrl>&gt;https://github.com/arcus-azure/arcus.messaging</RepositoryUrl>
+    <RepositoryUrl>https://github.com/arcus-azure/arcus.messaging</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageTags>Azure;Messaging;Health;Operations</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Arcus.Messaging.Health/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Health/Extensions/IServiceCollectionExtensions.cs
@@ -49,12 +49,12 @@ namespace Microsoft.Extensions.DependencyInjection
                 options.TcpPortConfigurationKey = tcpConfigurationKey;
                 configureTcpListenerOptions?.Invoke(options);
             });
-            services.Configure<HealthCheckPublisherOptions>(options =>
-            {
-                configureHealthCheckPublisherOptions?.Invoke(options);
-            });
+            //services.Configure<HealthCheckPublisherOptions>(options =>
+            //{
+            //    configureHealthCheckPublisherOptions?.Invoke(options);
+            //});
 
-            services.AddSingleton<IHealthCheckPublisher, TcpHealthCheckPublisher>();
+            //services.AddSingleton<IHealthCheckPublisher, TcpHealthCheckPublisher>();
             services.AddSingleton<TcpHealthListener>();
             services.AddHostedService(serviceProvider => serviceProvider.GetRequiredService<TcpHealthListener>());
 

--- a/src/Arcus.Messaging.Health/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Health/Extensions/IServiceCollectionExtensions.cs
@@ -49,12 +49,12 @@ namespace Microsoft.Extensions.DependencyInjection
                 options.TcpPortConfigurationKey = tcpConfigurationKey;
                 configureTcpListenerOptions?.Invoke(options);
             });
-            //services.Configure<HealthCheckPublisherOptions>(options =>
-            //{
-            //    configureHealthCheckPublisherOptions?.Invoke(options);
-            //});
+            services.Configure<HealthCheckPublisherOptions>(options =>
+            {
+                configureHealthCheckPublisherOptions?.Invoke(options);
+            });
 
-            //services.AddSingleton<IHealthCheckPublisher, TcpHealthCheckPublisher>();
+            services.AddSingleton<IHealthCheckPublisher, TcpHealthCheckPublisher>();
             services.AddSingleton<TcpHealthListener>();
             services.AddHostedService(serviceProvider => serviceProvider.GetRequiredService<TcpHealthListener>());
 

--- a/src/Arcus.Messaging.Health/IHealthReportSerializer.cs
+++ b/src/Arcus.Messaging.Health/IHealthReportSerializer.cs
@@ -10,7 +10,7 @@ namespace Arcus.Messaging.Health
         /// <summary>
         /// Serializes the given <paramref name="healthReport"/> to a series of bytes.
         /// </summary>
-        /// <param name="healthReport">The report to serialize.</param>
+        /// <param name="healthReport">The healthReport to serialize.</param>
         byte[] Serialize(HealthReport healthReport);
     }
 }

--- a/src/Arcus.Messaging.Health/IHealthReportSerializer.cs
+++ b/src/Arcus.Messaging.Health/IHealthReportSerializer.cs
@@ -10,7 +10,7 @@ namespace Arcus.Messaging.Health
         /// <summary>
         /// Serializes the given <paramref name="healthReport"/> to a series of bytes.
         /// </summary>
-        /// <param name="healthReport">The healthReport to serialize.</param>
+        /// <param name="healthReport">The report to serialize.</param>
         byte[] Serialize(HealthReport healthReport);
     }
 }

--- a/src/Arcus.Messaging.Health/Publishing/TcpHealthCheckPublisher.cs
+++ b/src/Arcus.Messaging.Health/Publishing/TcpHealthCheckPublisher.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.Messaging.Health.Tcp;
+using GuardNet;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+
+namespace Arcus.Messaging.Health.Publishing
+{
+    /// <summary>
+    /// Represents an <see cref="IHealthCheckPublisher"/> that lets the <see cref="TcpHealthListener"/> accept or reject TCP connections based on the published <see cref="HealthReport"/>.
+    /// </summary>
+    public class TcpHealthCheckPublisher : IHealthCheckPublisher
+    {
+        private readonly TcpHealthListener _healthListener;
+        private readonly TcpHealthListenerOptions _options;
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TcpHealthListener"/> class.
+        /// </summary>
+        /// <param name="healthListener">The registered <see cref="TcpHealthListener"/> instance.</param>
+        /// <param name="options">The registered options to configure the <see cref="TcpHealthListener"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="healthListener"/>, or <paramref name="options"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="options"/> doesn't have a filled-out value.</exception>
+        public TcpHealthCheckPublisher(TcpHealthListener healthListener, IOptions<TcpHealthListenerOptions> options)
+            : this(healthListener, options, NullLogger<TcpHealthCheckPublisher>.Instance)
+        {
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TcpHealthListener"/> class.
+        /// </summary>
+        /// <param name="healthListener">The registered <see cref="TcpHealthListener"/> instance.</param>
+        /// <param name="options">The registered options to configure the <see cref="TcpHealthListener"/>.</param>
+        /// <param name="logger">The logger to write diagnostic trace messages during accepting or rejecting TCP connections.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="healthListener"/>, <paramref name="options"/>, or <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="options"/> doesn't have a filled-out value.</exception>
+        public TcpHealthCheckPublisher(TcpHealthListener healthListener, IOptions<TcpHealthListenerOptions> options, ILogger<TcpHealthCheckPublisher> logger)
+        {
+            Guard.NotNull(healthListener, nameof(healthListener), "Requires a TCP health listener to accept or reject TCP connections");
+            Guard.NotNull(options, nameof(options), "Requires a set of registered options to determine if the TCP connections should be accepted or rejected based on the health report");
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to write diagnostic trace messages when TCP connections are accepted or rejected");
+            Guard.For(() => options.Value is null, new ArgumentException("Requires a filled-out value for the registered options to determine if the TCP connections should be accepted or rejected based on the health report", nameof(options)));
+            
+            _healthListener = healthListener;
+            _options = options.Value;
+            _logger = logger;
+        }
+        
+        /// <summary>
+        /// Publishes the provided <paramref name="report" />.
+        /// </summary>
+        /// <param name="report">The <see cref="T:Microsoft.Extensions.Diagnostics.HealthChecks.HealthReport" />. The result of executing a set of health checks.</param>
+        /// <param name="cancellationToken">The <see cref="T:System.Threading.CancellationToken" />.</param>
+        /// <returns>A <see cref="T:System.Threading.Tasks.Task" /> which will complete when publishing is complete.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="report"/> is <c>null</c>.</exception>
+        public Task PublishAsync(HealthReport report, CancellationToken cancellationToken)
+        {
+            Guard.NotNull(report, nameof(report), "Requires a health report to determine whether or not to accept or reject TCP connections");
+
+            if (_options.RejectTcpConnectionWhenUnhealthy)
+            {
+                _logger.LogTrace("Health checks report is '{Status}'", report.Status);
+                if (report.Status is HealthStatus.Unhealthy)
+                {
+                    if (_healthListener.IsListening)
+                    {
+                        _logger.LogTrace("Reject TCP connections, stop existing TCP connections because the health check status is 'Unhealthy'");
+                        _healthListener.StopListeningForTcpConnections();
+                    }
+                }
+                else
+                {
+                    if (!_healthListener.IsListening)
+                    {
+                        _logger.LogTrace("Accept TCP connections because the health check status is not 'Unhealthy' anymore");
+                        _healthListener.StartListeningForTcpConnections();
+                    }
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Arcus.Messaging.Health/Publishing/TcpHealthCheckPublisher.cs
+++ b/src/Arcus.Messaging.Health/Publishing/TcpHealthCheckPublisher.cs
@@ -13,7 +13,7 @@ namespace Arcus.Messaging.Health.Publishing
     /// <summary>
     /// Represents an <see cref="IHealthCheckPublisher"/> that lets the <see cref="TcpHealthListener"/> accept or reject TCP connections based on the published <see cref="HealthReport"/>.
     /// </summary>
-    public class TcpHealthCheckPublisher : IHealthCheckPublisher
+    internal class TcpHealthCheckPublisher : IHealthCheckPublisher
     {
         private readonly TcpHealthListener _healthListener;
         private readonly TcpHealthListenerOptions _options;

--- a/src/Arcus.Messaging.Health/Tcp/CustomTcpListener.cs
+++ b/src/Arcus.Messaging.Health/Tcp/CustomTcpListener.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Arcus.Messaging.Health.Tcp
+{
+    /// <summary>
+    /// Custom <see cref="TcpListener"/> implementation to have access to the <c>protected</c> <see cref="Active"/> property.
+    /// </summary>
+    internal class CustomTcpListener : TcpListener
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomTcpListener"/> class.
+        /// </summary>
+        /// <param name="port">The port on which to listen for incoming connection attempts.</param>
+        [Obsolete("This method has been deprecated. Please use TcpListener(IPAddress localaddr, int port) instead. https://go.microsoft.com/fwlink/?linkid=14202")]
+        public CustomTcpListener(int port) : base(port)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomTcpListener"/> class.
+        /// </summary>
+        /// <param name="localaddr">The <see cref="IPAddress"/> that represents the local IP address.</param>
+        /// <param name="port">The port on which to listen for incoming connection attempts.</param>
+        public CustomTcpListener(IPAddress localaddr, int port) : base(localaddr, port)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomTcpListener"/> class.
+        /// </summary>
+        /// <param name="localEP">The <see cref="IPEndPoint"/> that represents the local endpoint to which to bind the listener <see cref="Socket"/>.</param>
+        public CustomTcpListener(IPEndPoint localEP) : base(localEP)
+        {
+        }
+
+        /// <summary>
+        /// Gets the flag indicating whether or not the <see cref="TcpListener"/> is actively listening for client connections.
+        /// </summary>
+        public new bool Active => base.Active;
+    }
+}

--- a/src/Arcus.Messaging.Health/Tcp/TcpHealthListener.cs
+++ b/src/Arcus.Messaging.Health/Tcp/TcpHealthListener.cs
@@ -124,7 +124,7 @@ namespace Arcus.Messaging.Health.Tcp
         {
             _logger.LogTrace("Starting TCP server on port {Port}...", Port);
             _listener.Start();
-            _logger.LogInformation("TCP server started on port {Port}", Port);
+            _logger.LogTrace("TCP server started on port {Port}", Port);
         }
 
         /// <summary>

--- a/src/Arcus.Messaging.Health/Tcp/TcpHealthListener.cs
+++ b/src/Arcus.Messaging.Health/Tcp/TcpHealthListener.cs
@@ -211,7 +211,7 @@ namespace Arcus.Messaging.Health.Tcp
         {
             _logger.LogTrace("Stopping TCP server on port {Port}...", Port);
             _listener.Stop();
-            _logger.LogInformation("TCP server stopped on port {Port}", Port);
+            _logger.LogTrace("TCP server stopped on port {Port}", Port);
         }
     }
 }

--- a/src/Arcus.Messaging.Health/Tcp/TcpHealthListener.cs
+++ b/src/Arcus.Messaging.Health/Tcp/TcpHealthListener.cs
@@ -105,7 +105,7 @@ namespace Arcus.Messaging.Health.Tcp
         /// <summary>
         /// Gets the flag indicating whether or not the TCP probe is listening for client connections.
         /// </summary>
-        public bool IsListening => _listener.Active;
+        internal bool IsListening => _listener.Active;
         
         /// <summary>
         /// Triggered when the application host is ready to start the service.
@@ -120,7 +120,7 @@ namespace Arcus.Messaging.Health.Tcp
         /// <summary>
         /// Accepts TCP client connections.
         /// </summary>
-        public void StartListeningForTcpConnections()
+        internal void StartListeningForTcpConnections()
         {
             _logger.LogTrace("Starting TCP server on port {Port}...", Port);
             _listener.Start();
@@ -210,7 +210,7 @@ namespace Arcus.Messaging.Health.Tcp
         /// <summary>
         /// Rejects TCP client connections.
         /// </summary>
-        public void StopListeningForTcpConnections()
+        internal void StopListeningForTcpConnections()
         {
             _logger.LogTrace("Stopping TCP server on port {Port}...", Port);
             _listener.Stop();

--- a/src/Arcus.Messaging.Health/Tcp/TcpHealthListener.cs
+++ b/src/Arcus.Messaging.Health/Tcp/TcpHealthListener.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -21,7 +22,7 @@ namespace Arcus.Messaging.Health.Tcp
     public class TcpHealthListener : BackgroundService
     {
         private readonly HealthCheckService _healthService;
-        private readonly TcpListener _listener;
+        private readonly CustomTcpListener _listener;
         private readonly TcpHealthListenerOptions _tcpListenerOptions;
         private readonly ILogger<TcpHealthListener> _logger;
 
@@ -33,7 +34,25 @@ namespace Arcus.Messaging.Health.Tcp
         /// <param name="configuration">The key-value application configuration properties.</param>
         /// <param name="tcpListenerOptions">The additional options to configure the TCP listener.</param>
         /// <param name="healthService">The service to retrieve the current health of the application.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="configuration"/>, <paramref name="tcpListenerOptions"/>, or <paramref name="healthService"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="tcpListenerOptions"/> doesn't have a filled-out value.</exception>
+        public TcpHealthListener(
+            IConfiguration configuration,
+            IOptions<TcpHealthListenerOptions> tcpListenerOptions,
+            HealthCheckService healthService)
+            : this(configuration, tcpListenerOptions, healthService, NullLogger<TcpHealthListener>.Instance)
+        {
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TcpHealthListener"/> class.
+        /// </summary>
+        /// <param name="configuration">The key-value application configuration properties.</param>
+        /// <param name="tcpListenerOptions">The additional options to configure the TCP listener.</param>
+        /// <param name="healthService">The service to retrieve the current health of the application.</param>
         /// <param name="logger">The logging implementation to write diagnostic messages during the running of the TCP listener.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="configuration"/>, <paramref name="tcpListenerOptions"/>, <paramref name="healthService"/>, or <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="tcpListenerOptions"/> doesn't have a filled-out value.</exception>
         public TcpHealthListener(
             IConfiguration configuration,
             IOptions<TcpHealthListenerOptions> tcpListenerOptions,
@@ -43,14 +62,14 @@ namespace Arcus.Messaging.Health.Tcp
             Guard.NotNull(tcpListenerOptions, nameof(tcpListenerOptions), "Requires a set of TCP listener options to correctly run the TCP listener");
             Guard.NotNull(healthService, nameof(healthService), "Requires a health service to retrieve the current health status of the application");
             Guard.NotNull(logger, nameof(logger), "Requires a logger implementation to write diagnostic messages during the running of the TCP listener");
-            Guard.For<ArgumentException>(() => tcpListenerOptions.Value is null, "Requires a set of TCP listener options to correctly run the TCP listener");
+            Guard.For(() => tcpListenerOptions.Value is null, new ArgumentException("Requires a set of TCP listener options to correctly run the TCP listener", nameof(tcpListenerOptions)));
 
             _tcpListenerOptions = tcpListenerOptions.Value;
             _healthService = healthService;
             _logger = logger;
 
             Port = GetTcpHealthPort(configuration, _tcpListenerOptions.TcpPortConfigurationKey);
-            _listener = new TcpListener(IPAddress.Any, Port);
+            _listener = new CustomTcpListener(IPAddress.Any, Port);
         }
 
         private static int GetTcpHealthPort(IConfiguration configuration, string tcpHealthPortKey)
@@ -84,28 +103,28 @@ namespace Arcus.Messaging.Health.Tcp
         public int Port { get; }
 
         /// <summary>
+        /// Gets the flag indicating whether or not the TCP probe is listening for client connections.
+        /// </summary>
+        public bool IsListening => _listener.Active;
+        
+        /// <summary>
         /// Triggered when the application host is ready to start the service.
         /// </summary>
         /// <param name="cancellationToken">Indicates that the start process has been aborted.</param>
-        public override Task StartAsync(CancellationToken cancellationToken)
+        public override async Task StartAsync(CancellationToken cancellationToken)
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return Task.FromCanceled(cancellationToken);
-            }
+            StartListeningForTcpConnections();
+            await base.StartAsync(cancellationToken);
+        }
 
-            try
-            {
-                _logger.LogTrace("Starting TCP server on port {Port}...", Port);
-                _listener.Start();
-                _logger.LogInformation("TCP server started on port {Port}", Port);
-
-                return base.StartAsync(cancellationToken);
-            }
-            catch (Exception exception)
-            {
-                return Task.FromException(exception);
-            }
+        /// <summary>
+        /// Accepts TCP client connections.
+        /// </summary>
+        public void StartListeningForTcpConnections()
+        {
+            _logger.LogTrace("Starting TCP server on port {Port}...", Port);
+            _listener.Start();
+            _logger.LogInformation("TCP server started on port {Port}", Port);
         }
 
         /// <summary>
@@ -118,33 +137,40 @@ namespace Arcus.Messaging.Health.Tcp
         {
             while (!stoppingToken.IsCancellationRequested)
             {
-                await AcceptConnectionAsync();
+                if (IsListening)
+                {
+                    HealthReport report = await _healthService.CheckHealthAsync(stoppingToken);
+                    await AcceptConnectionAsync(report);
+                }
             }
         }
 
-        private async Task AcceptConnectionAsync()
+        private async Task AcceptConnectionAsync(HealthReport report)
         {
-            _logger.LogTrace("Accepting TCP client on port {Port}...", Port);
-            using (TcpClient client = await _listener.AcceptTcpClientAsync())
+            try
             {
-                _logger.LogTrace("TCP client accepted on port {Port}!", Port);
-                using (NetworkStream clientStream = client.GetStream())
+                _logger.LogTrace("Accepting TCP client on port {Port}...", Port);
+                using (TcpClient client = await _listener.AcceptTcpClientAsync())
                 {
-                    HealthReport report = await _healthService.CheckHealthAsync();
-                    string clientId = client.Client?.RemoteEndPoint?.ToString() ?? string.Empty;
-                    _logger.LogTrace("Return '{Status}' health report to client {ClientId}", report.Status, clientId);
-
-                    if (report.Status != HealthStatus.Healthy)
+                    _logger.LogTrace("TCP client accepted on port {Port}!", Port);
+                    using (NetworkStream clientStream = client.GetStream())
                     {
-                        _logger.LogWarning($"Health probe is reporting '{report.Status}' status");
+                        string clientId = client.Client?.RemoteEndPoint?.ToString() ?? string.Empty;
+                        _logger.LogTrace("Return '{Status}' health report to client {ClientId}", report.Status, clientId);
+
+                        if (report.Status != HealthStatus.Healthy)
+                        {
+                            _logger.LogWarning($"Health probe is reporting '{report.Status}' status");
+                        }
+
+                        byte[] response = SerializeHealthReport(report);
+                        clientStream.Write(response, 0, response.Length);
                     }
-
-                    byte[] response = SerializeHealthReport(report);
-                    clientStream.Write(response, 0, response.Length);
-
-                    clientStream.Close();
-                    client.Close();
                 }
+            }
+            catch (Exception exception) when (exception is ObjectDisposedException || exception is InvalidOperationException)
+            {
+                _logger.LogTrace("Rejected TCP client on port {Port}", Port);
             }
         }
 
@@ -175,25 +201,20 @@ namespace Arcus.Messaging.Health.Tcp
         /// Triggered when the application host is performing a graceful shutdown.
         /// </summary>
         /// <param name="cancellationToken">Indicates that the shutdown process should no longer be graceful.</param>
-        public override Task StopAsync(CancellationToken cancellationToken)
+        public override async Task StopAsync(CancellationToken cancellationToken)
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return Task.FromCanceled(cancellationToken);
-            }
+            StopListeningForTcpConnections();
+            await base.StopAsync(cancellationToken);
+        }
 
-            try
-            {
-                _logger.LogTrace("Stopping TCP server on port {Port}...", Port);
-                _listener.Stop();
-                _logger.LogInformation("TCP server stopped on port {Port}", Port);
-
-                return base.StopAsync(cancellationToken);
-            }
-            catch (Exception exception)
-            {
-                return Task.FromException(exception);
-            }
+        /// <summary>
+        /// Rejects TCP client connections.
+        /// </summary>
+        public void StopListeningForTcpConnections()
+        {
+            _logger.LogTrace("Stopping TCP server on port {Port}...", Port);
+            _listener.Stop();
+            _logger.LogInformation("TCP server stopped on port {Port}", Port);
         }
     }
 }

--- a/src/Arcus.Messaging.Health/Tcp/TcpHealthListener.cs
+++ b/src/Arcus.Messaging.Health/Tcp/TcpHealthListener.cs
@@ -137,11 +137,8 @@ namespace Arcus.Messaging.Health.Tcp
         {
             while (!stoppingToken.IsCancellationRequested)
             {
-                if (IsListening)
-                {
-                    HealthReport report = await _healthService.CheckHealthAsync(stoppingToken);
-                    await AcceptConnectionAsync(report);
-                }
+                HealthReport report = await _healthService.CheckHealthAsync(stoppingToken);
+                await AcceptConnectionAsync(report);
             }
         }
 

--- a/src/Arcus.Messaging.Health/Tcp/TcpHealthListenerOptions.cs
+++ b/src/Arcus.Messaging.Health/Tcp/TcpHealthListenerOptions.cs
@@ -27,5 +27,10 @@ namespace Arcus.Messaging.Health.Tcp
                 _tcpHealthPort = value;
             }
         }
+
+        /// <summary>
+        /// Gets or sets the flag to indicating whether or not the TCP health port should accept or reject TCP connections when a health dependency reports an unhealthy status.
+        /// </summary>
+        public bool RejectTcpConnectionWhenUnhealthy { get; set; }
     }
 }

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/TcpConnectionRejectionProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/TcpConnectionRejectionProgram.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using Arcus.EventGrid.Publishing;
@@ -13,9 +13,9 @@ using Microsoft.Extensions.Logging;
 // ReSharper disable once CheckNamespace
 namespace Arcus.Messaging.Tests.Workers.ServiceBus
 {
-    public class Program
+    public class TcpConnectionRejectionProgram
     {
-        public static void Main(string[] args)
+        public static void main(string[] args)
         {
             CreateHostBuilder(args)
                 .Build()

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/TcpConnectionRejectionProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/TcpConnectionRejectionProgram.cs
@@ -15,6 +15,8 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus
 {
     public class TcpConnectionRejectionProgram
     {
+        private static int Index = -1;
+        
         public static void main(string[] args)
         {
             CreateHostBuilder(args)
@@ -35,7 +37,7 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus
                     services.AddTcpHealthProbes(
                         "ARCUS_HEALTH_PORT", 
                         builder => builder.AddCheck("toggle", 
-                            () => Environment.GetEnvironmentVariable("ARCUS_HEALTH_STATUS", EnvironmentVariableTarget.Machine) == "Healthy" 
+                            () => ++Index < 10
                                 ? HealthCheckResult.Healthy() 
                                 : HealthCheckResult.Unhealthy()),
                         options => options.RejectTcpConnectionWhenUnhealthy = true,

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/WorkerProject.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/WorkerProject.cs
@@ -143,7 +143,7 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
                       .WaitAndRetryForeverAsync(retryNumber => TimeSpan.FromSeconds(1));
 
             PolicyResult result = 
-                await Policy.TimeoutAsync(TimeSpan.FromSeconds(10))
+                await Policy.TimeoutAsync(TimeSpan.FromSeconds(15))
                             .WrapAsync(waitAndRetryForeverAsync)
                             .ExecuteAndCaptureAsync(() => TryToConnectToTcpListenerAsync(healthPort));
 

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/WorkerProject.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/WorkerProject.cs
@@ -175,7 +175,6 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
             }
         }
 
-
         private void RunDotNet(string command)
         {
             try

--- a/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthListenerDockerTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthListenerDockerTests.cs
@@ -23,7 +23,7 @@ namespace Arcus.Messaging.Tests.Integration.Health
         public async Task TcpHealthListener_ProbeForHealthReport_ResponseHealthy()
         {
             // Arrange
-            var service = new TcpHealthService(_healthTcpPort);
+            var service = new TcpHealthService(_healthTcpPort, Logger);
             
             // Act
             HealthReport report = await service.GetHealthReportAsync();

--- a/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthListenerDockerTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthListenerDockerTests.cs
@@ -1,0 +1,39 @@
+﻿using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Arcus.Messaging.Tests.Integration.Health
+{
+    [Trait("Category", "Docker")]
+    public class TcpHealthListenerDockerTests : IntegrationTest
+    {
+        private readonly int _healthTcpPort;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TcpHealthListenerDockerTests"/> class.
+        /// </summary>
+        public TcpHealthListenerDockerTests(ITestOutputHelper testOutput) : base(testOutput)
+        {
+            _healthTcpPort = Configuration.GetValue<int>("Arcus:Health:Port");
+        }
+
+        [Fact]
+        public async Task TcpHealthListener_ProbeForHealthReport_ResponseHealthy()
+        {
+            // Arrange
+            var service = new TcpHealthService(_healthTcpPort);
+            
+            // Act
+            HealthReport report = await service.GetHealthReportAsync();
+            
+            // Assert
+            Assert.NotNull(report);
+            Assert.Equal(HealthStatus.Healthy, report.Status);
+            (string entryName, HealthReportEntry entry) = Assert.Single(report.Entries);
+            Assert.Equal("sample", entryName);
+            Assert.Equal(HealthStatus.Healthy, entry.Status);
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthListenerTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthListenerTests.cs
@@ -29,7 +29,7 @@ namespace Arcus.Messaging.Tests.Integration.Health
             SetHealthStatus(HealthStatus.Healthy);
         }
         
-        [Fact]
+        [Fact(Skip = "Temp disable")]
         public async Task TcpHealthListenerWithRejectionActivated_RejectsTcpConnection_WhenHealthCheckIsUnhealthy()
         {
             // Arrange

--- a/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthListenerTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthListenerTests.cs
@@ -64,7 +64,6 @@ namespace Arcus.Messaging.Tests.Integration.Health
                                .WrapAsync(Policy.Handle<TException>()
                                                 .WaitAndRetryForeverAsync(index => TimeSpan.FromSeconds(1)))
                                .ExecuteAsync(assertion);
-
         }
 
         /// <summary>

--- a/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthListenerTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthListenerTests.cs
@@ -29,7 +29,7 @@ namespace Arcus.Messaging.Tests.Integration.Health
             SetHealthStatus(HealthStatus.Healthy);
         }
         
-        [Fact(Skip = "Temp disable")]
+        [Fact]
         public async Task TcpHealthListenerWithRejectionActivated_RejectsTcpConnection_WhenHealthCheckIsUnhealthy()
         {
             // Arrange

--- a/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthService.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthService.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using GuardNet;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Newtonsoft.Json;
+
+namespace Arcus.Messaging.Tests.Integration.Health
+{
+    /// <summary>
+    /// Represents a service to interact with the TCP health probe.
+    /// </summary>
+    public class TcpHealthService
+    {
+        private const string LocalAddress = "127.0.0.1";
+        
+        private readonly int _healthTcpPort;
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TcpHealthService"/> class.
+        /// </summary>
+        /// <param name="healthTcpPort">The local health TCP port to contact the TCP health probe.</param>
+        /// <param name="logger">The logger instance to write diagnostic trace messages while interacting with the TCP probe.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="healthTcpPort"/> is not a valid TCP port number.</exception>
+        public TcpHealthService(int healthTcpPort, ILogger logger)
+        {
+            Guard.NotLessThan(healthTcpPort, 0, nameof(healthTcpPort), "Requires a TCP health port number that's above zero");
+            _healthTcpPort = healthTcpPort;
+            _logger = logger ?? NullLogger.Instance;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="HealthReport"/> from the exposed TCP health probe.
+        /// </summary>
+        public async Task<HealthReport> GetHealthReportAsync()
+        {
+            using (var client = new TcpClient())
+            {
+                _logger.LogTrace("Connecting to the TCP {Address}:{Port}...", LocalAddress, _healthTcpPort);
+                await client.ConnectAsync(IPAddress.Parse(LocalAddress), _healthTcpPort);
+                _logger.LogTrace("Connected to the TCP {Address}:{Port}", LocalAddress, _healthTcpPort);
+                
+                _logger.LogTrace("Retrieving health report...");
+                using (NetworkStream clientStream = client.GetStream())
+                using (var reader = new StreamReader(clientStream))
+                {
+                    string healthReport = await reader.ReadToEndAsync();
+                    var report = JsonConvert.DeserializeObject<HealthReport>(healthReport, new HealthReportEntryConverter());
+
+                    _logger.LogTrace("Health report retrieved");
+                    return report;
+                }
+            }
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -59,7 +59,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                 CommandArgument.CreateSecret("ARCUS_SERVICEBUS_CONNECTIONSTRING", connectionString),
             };
 
-            using (var project = await ServiceBusWorkerProject.StartNewWithAsync(programType, config, _logger, commandArguments))
+            using (var project = await WorkerProject.StartNewWithAsync(programType, config, _logger, commandArguments))
             {
                 await using (var service = await TestMessagePumpService.StartNewAsync(config, _logger))
                 {
@@ -84,7 +84,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                 CommandArgument.CreateSecret("ARCUS_SERVICEBUS_CONNECTIONSTRING_WITH_TOPIC", config.GetServiceBusConnectionString(ServiceBusEntity.Topic)),
             };
 
-            using (var project = await ServiceBusWorkerProject.StartNewWithAsync<ServiceBusQueueAndTopicProgram>(config, _logger, commandArguments))
+            using (var project = await WorkerProject.StartNewWithAsync<ServiceBusQueueAndTopicProgram>(config, _logger, commandArguments))
             {
                 await using (var service = await TestMessagePumpService.StartNewAsync(config, _logger))
                 {
@@ -108,7 +108,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                 CommandArgument.CreateSecret("ARCUS_SERVICEBUS_CONNECTIONSTRING", connectionString),
             };
 
-            using (var project = await ServiceBusWorkerProject.StartNewWithAsync<ServiceBusQueueWithFallbackProgram>(config, _logger, commandArguments))
+            using (var project = await WorkerProject.StartNewWithAsync<ServiceBusQueueWithFallbackProgram>(config, _logger, commandArguments))
             {
                 await using (var service = await TestMessagePumpService.StartNewAsync(config, _logger))
                 {
@@ -132,7 +132,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                 CommandArgument.CreateSecret("ARCUS_SERVICEBUS_CONNECTIONSTRING", connectionString),
             };
 
-            using (var project = await ServiceBusWorkerProject.StartNewWithAsync<ServiceBusQueueWithServiceBusFallbackProgram>(config, _logger, commandArguments))
+            using (var project = await WorkerProject.StartNewWithAsync<ServiceBusQueueWithServiceBusFallbackProgram>(config, _logger, commandArguments))
             {
                 await using (var service = await TestMessagePumpService.StartNewAsync(config, _logger))
                 {
@@ -158,7 +158,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
 
             Order order = OrderGenerator.Generate();
 
-            using (var project = await ServiceBusWorkerProject.StartNewWithAsync(programType, config, _logger, commandArguments))
+            using (var project = await WorkerProject.StartNewWithAsync(programType, config, _logger, commandArguments))
             {
                 await using (var service = await TestMessagePumpService.StartNewAsync(config, _logger))
                 {
@@ -187,7 +187,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                 CommandArgument.CreateSecret("ARCUS_SERVICEBUS_CONNECTIONSTRING", connectionString)
             };
 
-            using (var project = await ServiceBusWorkerProject.StartNewWithAsync(programType, config, _logger, commandArguments))
+            using (var project = await WorkerProject.StartNewWithAsync(programType, config, _logger, commandArguments))
             {
                 await using (var service = await TestMessagePumpService.StartNewAsync(config, _logger))
                 {
@@ -212,7 +212,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                 CommandArgument.CreateSecret("ARCUS_SERVICEBUS_CONNECTIONSTRING", connectionString)
             };
 
-            using var project = await ServiceBusWorkerProject.StartNewWithAsync<ServiceBusQueueTrackCorrelationOnExceptionProgram>(config, _logger, commandArguments);
+            using var project = await WorkerProject.StartNewWithAsync<ServiceBusQueueTrackCorrelationOnExceptionProgram>(config, _logger, commandArguments);
             await using var service = await TestMessagePumpService.StartNewAsync(config, _logger);
             Message orderMessage = OrderGenerator.Generate().AsServiceBusMessage(operationId, transactionId);
                     
@@ -264,7 +264,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                 CommandArgument.CreateSecret("ARCUS_KEYVAULT_SERVICEPRINCIPAL_CLIENTSECRET", keyRotationConfig.ServicePrincipal.ClientSecret), 
             };
 
-            using (var project = await ServiceBusWorkerProject.StartNewWithAsync<ServiceBusQueueKeyVaultProgram>(config, _logger, commandArguments))
+            using (var project = await WorkerProject.StartNewWithAsync<ServiceBusQueueKeyVaultProgram>(config, _logger, commandArguments))
             {
                 string newSecondaryConnectionString = await client.RotateConnectionStringKeysForQueueAsync(KeyType.SecondaryKey);
                 await SetConnectionStringInKeyVaultAsync(keyVaultClient, keyRotationConfig, newSecondaryConnectionString);

--- a/src/Arcus.Messaging.Tests.Workers.ServiceBus.Queue/Program.cs
+++ b/src/Arcus.Messaging.Tests.Workers.ServiceBus.Queue/Program.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using Arcus.EventGrid.Publishing;
 using Arcus.Messaging.Tests.Core.Messages.v1;
 using Arcus.Messaging.Tests.Workers.MessageHandlers;
@@ -5,6 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace Arcus.Messaging.Tests.Workers.ServiceBus.Queue
 {
@@ -23,25 +26,38 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus.Queue
                 {
                     configuration.AddCommandLine(args);
                     configuration.AddEnvironmentVariables();
+                    configuration.AddInMemoryCollection(new List<KeyValuePair<string, string>>
+                    {
+                        new KeyValuePair<string, string>("ARCUS_HEALTH_PORT", 5000.ToString())
+                    });
                 })
                 .ConfigureServices((hostContext, services) =>
                 {
-                    services.AddLogging();
-                    services.AddTransient(svc =>
-                    {
-                        var configuration = svc.GetRequiredService<IConfiguration>();
-                        var eventGridTopic = configuration.GetValue<string>("EVENTGRID_TOPIC_URI");
-                        var eventGridKey = configuration.GetValue<string>("EVENTGRID_AUTH_KEY");
+                    services.AddLogging(logging => logging.SetMinimumLevel(LogLevel.Trace));
+                    //services.AddTransient(svc =>
+                    //{
+                    //    var configuration = svc.GetRequiredService<IConfiguration>();
+                    //    var eventGridTopic = configuration.GetValue<string>("EVENTGRID_TOPIC_URI");
+                    //    var eventGridKey = configuration.GetValue<string>("EVENTGRID_AUTH_KEY");
 
-                        return EventGridPublisherBuilder
-                            .ForTopic(eventGridTopic)
-                            .UsingAuthenticationKey(eventGridKey)
-                            .Build();
-                    });
-                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
-                            .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
+                    //    return EventGridPublisherBuilder
+                    //        .ForTopic(eventGridTopic)
+                    //        .UsingAuthenticationKey(eventGridKey)
+                    //        .Build();
+                    //});
+                    //services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
+                    //        .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 
-                    services.AddTcpHealthProbes("ARCUS_HEALTH_PORT", builder => builder.AddCheck("sample", () => HealthCheckResult.Healthy()));
+                    int index = -1;
+                    services.AddTcpHealthProbes(
+                        "ARCUS_HEALTH_PORT", 
+                        builder => builder.AddCheck("sample", () => ++index % 5 == 0 ? HealthCheckResult.Unhealthy() : HealthCheckResult.Healthy()),
+                        options => options.RejectTcpConnectionWhenUnhealthy = true,
+                        options =>
+                        {
+                            options.Delay = TimeSpan.Zero;
+                            options.Period = TimeSpan.FromSeconds(5);
+                        });
                 });
     }
 }

--- a/src/Arcus.Messaging.Tests.Workers.ServiceBus/Program.cs
+++ b/src/Arcus.Messaging.Tests.Workers.ServiceBus/Program.cs
@@ -47,7 +47,7 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus
                     services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
                             .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
                     
-                    services.AddTcpHealthProbes("ARCUS_HEALTH_PORT", builder => builder.AddCheck("sample", () => HealthCheckResult.Healthy());
+                    services.AddTcpHealthProbes("ARCUS_HEALTH_PORT", builder => builder.AddCheck("sample", () => HealthCheckResult.Healthy()));
                 });
     }
 }


### PR DESCRIPTION
Adds an `IHealthReportPublisher` that changes the TCP availability of the `TcpHealthListener` based on the health report status code.

Closes #131 