### PR TITLE
Fix - only register health publisher when required

### DIFF
--- a/src/Arcus.Messaging.Health/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Health/Extensions/IServiceCollectionExtensions.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             var listenerOptions = new TcpHealthListenerOptions { TcpPortConfigurationKey = tcpConfigurationKey };
             configureTcpListenerOptions?.Invoke(listenerOptions);
+            services.AddSingleton(listenerOptions);
             
             if (listenerOptions.RejectTcpConnectionWhenUnhealthy)
             {
@@ -56,8 +57,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
                 services.AddSingleton<IHealthCheckPublisher, TcpHealthCheckPublisher>();
             }
-
-            services.AddSingleton(listenerOptions);
+            
             services.AddSingleton<TcpHealthListener>();
             services.AddHostedService(serviceProvider => serviceProvider.GetRequiredService<TcpHealthListener>());
 

--- a/src/Arcus.Messaging.Health/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Health/Extensions/IServiceCollectionExtensions.cs
@@ -41,20 +41,23 @@ namespace Microsoft.Extensions.DependencyInjection
             Guard.NotNull(services, nameof(services), "Requires a set of services to add the TCP health probe to");
             Guard.NotNullOrWhitespace(tcpConfigurationKey, nameof(tcpConfigurationKey), "Requires a non-blank configuration key to retrieve the TCP port");
 
-            var healthCheckBuilder = services.AddHealthChecks();
+            IHealthChecksBuilder healthCheckBuilder = services.AddHealthChecks();
             configureHealthChecks?.Invoke(healthCheckBuilder);
 
-            services.Configure<TcpHealthListenerOptions>(options =>
+            var listenerOptions = new TcpHealthListenerOptions { TcpPortConfigurationKey = tcpConfigurationKey };
+            configureTcpListenerOptions?.Invoke(listenerOptions);
+            
+            if (listenerOptions.RejectTcpConnectionWhenUnhealthy)
             {
-                options.TcpPortConfigurationKey = tcpConfigurationKey;
-                configureTcpListenerOptions?.Invoke(options);
-            });
-            services.Configure<HealthCheckPublisherOptions>(options =>
-            {
-                configureHealthCheckPublisherOptions?.Invoke(options);
-            });
+                services.Configure<HealthCheckPublisherOptions>(options =>
+                {
+                    configureHealthCheckPublisherOptions?.Invoke(options);
+                });
 
-            services.AddSingleton<IHealthCheckPublisher, TcpHealthCheckPublisher>();
+                services.AddSingleton<IHealthCheckPublisher, TcpHealthCheckPublisher>();
+            }
+
+            services.AddSingleton(listenerOptions);
             services.AddSingleton<TcpHealthListener>();
             services.AddHostedService(serviceProvider => serviceProvider.GetRequiredService<TcpHealthListener>());
 

--- a/src/Arcus.Messaging.Health/Publishing/TcpHealthCheckPublisher.cs
+++ b/src/Arcus.Messaging.Health/Publishing/TcpHealthCheckPublisher.cs
@@ -6,7 +6,6 @@ using GuardNet;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 
 namespace Arcus.Messaging.Health.Publishing
 {

--- a/src/Arcus.Messaging.Health/Publishing/TcpHealthCheckPublisher.cs
+++ b/src/Arcus.Messaging.Health/Publishing/TcpHealthCheckPublisher.cs
@@ -26,7 +26,7 @@ namespace Arcus.Messaging.Health.Publishing
         /// <param name="options">The registered options to configure the <see cref="TcpHealthListener"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="healthListener"/>, or <paramref name="options"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="options"/> doesn't have a filled-out value.</exception>
-        public TcpHealthCheckPublisher(TcpHealthListener healthListener, IOptions<TcpHealthListenerOptions> options)
+        public TcpHealthCheckPublisher(TcpHealthListener healthListener, TcpHealthListenerOptions options)
             : this(healthListener, options, NullLogger<TcpHealthCheckPublisher>.Instance)
         {
         }
@@ -39,15 +39,14 @@ namespace Arcus.Messaging.Health.Publishing
         /// <param name="logger">The logger to write diagnostic trace messages during accepting or rejecting TCP connections.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="healthListener"/>, <paramref name="options"/>, or <paramref name="logger"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="options"/> doesn't have a filled-out value.</exception>
-        public TcpHealthCheckPublisher(TcpHealthListener healthListener, IOptions<TcpHealthListenerOptions> options, ILogger<TcpHealthCheckPublisher> logger)
+        public TcpHealthCheckPublisher(TcpHealthListener healthListener, TcpHealthListenerOptions options, ILogger<TcpHealthCheckPublisher> logger)
         {
             Guard.NotNull(healthListener, nameof(healthListener), "Requires a TCP health listener to accept or reject TCP connections");
             Guard.NotNull(options, nameof(options), "Requires a set of registered options to determine if the TCP connections should be accepted or rejected based on the health report");
             Guard.NotNull(logger, nameof(logger), "Requires a logger instance to write diagnostic trace messages when TCP connections are accepted or rejected");
-            Guard.For(() => options.Value is null, new ArgumentException("Requires a filled-out value for the registered options to determine if the TCP connections should be accepted or rejected based on the health report", nameof(options)));
             
             _healthListener = healthListener;
-            _options = options.Value;
+            _options = options;
             _logger = logger;
         }
         

--- a/src/Arcus.Messaging.Health/Tcp/TcpHealthListener.cs
+++ b/src/Arcus.Messaging.Health/Tcp/TcpHealthListener.cs
@@ -38,40 +38,6 @@ namespace Arcus.Messaging.Health.Tcp
         /// <exception cref="ArgumentException">Thrown when the <paramref name="tcpListenerOptions"/> doesn't have a filled-out value.</exception>
         public TcpHealthListener(
             IConfiguration configuration,
-            IOptions<TcpHealthListenerOptions> tcpListenerOptions,
-            HealthCheckService healthService)
-            : this(configuration, tcpListenerOptions, healthService, NullLogger<TcpHealthListener>.Instance)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TcpHealthListener"/> class.
-        /// </summary>
-        /// <param name="configuration">The key-value application configuration properties.</param>
-        /// <param name="tcpListenerOptions">The additional options to configure the TCP listener.</param>
-        /// <param name="healthService">The service to retrieve the current health of the application.</param>
-        /// <param name="logger">The logging implementation to write diagnostic messages during the running of the TCP listener.</param>
-        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="configuration"/>, <paramref name="tcpListenerOptions"/>, <paramref name="healthService"/>, or <paramref name="logger"/> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentException">Thrown when the <paramref name="tcpListenerOptions"/> doesn't have a filled-out value.</exception>
-        public TcpHealthListener(
-            IConfiguration configuration,
-            IOptions<TcpHealthListenerOptions> tcpListenerOptions,
-            HealthCheckService healthService, 
-            ILogger<TcpHealthListener> logger)
-            : this(configuration, tcpListenerOptions?.Value, healthService, logger)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TcpHealthListener"/> class.
-        /// </summary>
-        /// <param name="configuration">The key-value application configuration properties.</param>
-        /// <param name="tcpListenerOptions">The additional options to configure the TCP listener.</param>
-        /// <param name="healthService">The service to retrieve the current health of the application.</param>
-        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="configuration"/>, <paramref name="tcpListenerOptions"/>, or <paramref name="healthService"/> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentException">Thrown when the <paramref name="tcpListenerOptions"/> doesn't have a filled-out value.</exception>
-        public TcpHealthListener(
-            IConfiguration configuration,
             TcpHealthListenerOptions tcpListenerOptions,
             HealthCheckService healthService)
             : this(configuration, tcpListenerOptions, healthService, NullLogger<TcpHealthListener>.Instance)

--- a/src/Arcus.Messaging.Health/Tcp/TcpHealthListener.cs
+++ b/src/Arcus.Messaging.Health/Tcp/TcpHealthListener.cs
@@ -43,7 +43,7 @@ namespace Arcus.Messaging.Health.Tcp
             : this(configuration, tcpListenerOptions, healthService, NullLogger<TcpHealthListener>.Instance)
         {
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TcpHealthListener"/> class.
         /// </summary>
@@ -58,13 +58,46 @@ namespace Arcus.Messaging.Health.Tcp
             IOptions<TcpHealthListenerOptions> tcpListenerOptions,
             HealthCheckService healthService, 
             ILogger<TcpHealthListener> logger)
+            : this(configuration, tcpListenerOptions?.Value, healthService, logger)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TcpHealthListener"/> class.
+        /// </summary>
+        /// <param name="configuration">The key-value application configuration properties.</param>
+        /// <param name="tcpListenerOptions">The additional options to configure the TCP listener.</param>
+        /// <param name="healthService">The service to retrieve the current health of the application.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="configuration"/>, <paramref name="tcpListenerOptions"/>, or <paramref name="healthService"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="tcpListenerOptions"/> doesn't have a filled-out value.</exception>
+        public TcpHealthListener(
+            IConfiguration configuration,
+            TcpHealthListenerOptions tcpListenerOptions,
+            HealthCheckService healthService)
+            : this(configuration, tcpListenerOptions, healthService, NullLogger<TcpHealthListener>.Instance)
+        {
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TcpHealthListener"/> class.
+        /// </summary>
+        /// <param name="configuration">The key-value application configuration properties.</param>
+        /// <param name="tcpListenerOptions">The additional options to configure the TCP listener.</param>
+        /// <param name="healthService">The service to retrieve the current health of the application.</param>
+        /// <param name="logger">The logging implementation to write diagnostic messages during the running of the TCP listener.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="configuration"/>, <paramref name="tcpListenerOptions"/>, <paramref name="healthService"/>, or <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="tcpListenerOptions"/> doesn't have a filled-out value.</exception>
+        public TcpHealthListener(
+            IConfiguration configuration,
+            TcpHealthListenerOptions tcpListenerOptions,
+            HealthCheckService healthService, 
+            ILogger<TcpHealthListener> logger)
         {
             Guard.NotNull(tcpListenerOptions, nameof(tcpListenerOptions), "Requires a set of TCP listener options to correctly run the TCP listener");
             Guard.NotNull(healthService, nameof(healthService), "Requires a health service to retrieve the current health status of the application");
             Guard.NotNull(logger, nameof(logger), "Requires a logger implementation to write diagnostic messages during the running of the TCP listener");
-            Guard.For(() => tcpListenerOptions.Value is null, new ArgumentException("Requires a set of TCP listener options to correctly run the TCP listener", nameof(tcpListenerOptions)));
 
-            _tcpListenerOptions = tcpListenerOptions.Value;
+            _tcpListenerOptions = tcpListenerOptions;
             _healthService = healthService;
             _logger = logger;
 

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueAndTopicProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueAndTopicProgram.cs
@@ -44,8 +44,8 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus
                                .Build();
                     });
 
-                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING_WITH_QUEUE"])
-                            .AddServiceBusTopicMessagePump("Test-Receive-All-Topic-And-Queue", configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING_WITH_TOPIC"])
+                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING_WITH_QUEUE"], options => options.AutoComplete = true)
+                            .AddServiceBusTopicMessagePump("Test-Receive-All-Topic-And-Queue", configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING_WITH_TOPIC"], options => options.AutoComplete = true)
                             .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 
                     services.AddTcpHealthProbes("ARCUS_HEALTH_PORT", builder => builder.AddCheck("sample", () => HealthCheckResult.Healthy()));

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueContextAndBodyFilterSelectionProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueContextAndBodyFilterSelectionProgram.cs
@@ -42,7 +42,7 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
                                .UsingAuthenticationKey(eventGridKey)
                                .Build();
                     });
-                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
+                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"], options => options.AutoComplete = true)
                             .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>(context => context.Properties.ContainsKey("NotExisting"), body => false)
                             .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>(
                                 context => context.Properties["Topic"].ToString() == "Orders", 

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueContextTypeSelectionProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueContextTypeSelectionProgram.cs
@@ -42,7 +42,7 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
                                .UsingAuthenticationKey(eventGridKey)
                                .Build();
                     });
-                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
+                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"], options => options.AutoComplete = true)
                             .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>()
                             .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueKeyVaultProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueKeyVaultProgram.cs
@@ -54,7 +54,7 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus
                             .UsingAuthenticationKey(eventGridKey)
                             .Build();
                     });
-                    services.AddServiceBusQueueMessagePump(hostContext.Configuration["ARCUS_KEYVAULT_CONNECTIONSTRINGSECRETNAME"])
+                    services.AddServiceBusQueueMessagePump(hostContext.Configuration["ARCUS_KEYVAULT_CONNECTIONSTRINGSECRETNAME"], options => options.AutoComplete = true)
                             .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 
                     services.AddTcpHealthProbes("ARCUS_HEALTH_PORT", builder => builder.AddCheck("sample", () => HealthCheckResult.Healthy()));

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueProgram.cs
@@ -40,7 +40,7 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus
                                .UsingAuthenticationKey(eventGridKey)
                                .Build();
                     });
-                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
+                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"], options => options.AutoComplete = true)
                             .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 
                     services.AddTcpHealthProbes("ARCUS_HEALTH_PORT", builder => builder.AddCheck("sample", () => HealthCheckResult.Healthy()));

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueTrackCorrelationOnExceptionProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueTrackCorrelationOnExceptionProgram.cs
@@ -49,7 +49,7 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus
                 .UseSerilog(UpdateLoggerConfiguration)
                 .ConfigureServices((hostContext, services) =>
                 {
-                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
+                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"], options => options.AutoComplete = true)
                             .WithServiceBusMessageHandler<OrdersSabotageAzureServiceBusMessageHandler, Order>();
 
                     services.AddTcpHealthProbes("ARCUS_HEALTH_PORT", builder => builder.AddCheck("sample", () => HealthCheckResult.Healthy()));

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueWithContextAndBodyFilterAndBodySerializerProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueWithContextAndBodyFilterAndBodySerializerProgram.cs
@@ -40,7 +40,7 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus
                             .UsingAuthenticationKey(eventGridKey)
                             .Build();
                     });
-                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
+                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"], options => options.AutoComplete = true)
                             .WithServiceBusMessageHandler<PassThruOrderMessageHandler, Order>(messageContextFilter: context => false)
                             .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>(messageBodyFilter: message => false)
                             .WithServiceBusMessageHandler<OrderBatchMessageHandler, OrderBatch>(

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueWithFallbackProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueWithFallbackProgram.cs
@@ -41,7 +41,7 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus
                                .UsingAuthenticationKey(eventGridKey)
                                .Build();
                     });
-                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
+                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"], options => options.AutoComplete = true)
                             .WithServiceBusMessageHandler<PassThruOrderMessageHandler, Order>((AzureServiceBusMessageContext context) => false)
                             .WithFallbackMessageHandler<OrdersFallbackMessageHandler>();
 

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueWithServiceBusFallbackProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusQueueWithServiceBusFallbackProgram.cs
@@ -42,7 +42,7 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus
                                .UsingAuthenticationKey(eventGridKey)
                                .Build();
                     });
-                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
+                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"], options => options.AutoComplete = true)
                             .WithServiceBusMessageHandler<PassThruOrderMessageHandler, Order>((AzureServiceBusMessageContext context) => false)
                             .WithServiceBusFallbackMessageHandler<OrdersServiceBusFallbackMessageHandler>();
 

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusTopicBodyPredicateSelectionProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusTopicBodyPredicateSelectionProgram.cs
@@ -43,7 +43,7 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
                                .UsingAuthenticationKey(eventGridKey)
                                .Build();
                     });
-                    services.AddServiceBusTopicMessagePump("Test-Receive-All-Topic-Only", configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
+                    services.AddServiceBusTopicMessagePump("Test-Receive-All-Topic-Only", configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"], options => options.AutoComplete = true)
                             .WithMessageHandler<PassThruOrderMessageHandler, Order, AzureServiceBusMessageContext>((Order body) => false)
                             .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>((Customer body) => body is null)
                             .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>((Order body) => body.Id != null);

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusTopicContextPredicateSelectionProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusTopicContextPredicateSelectionProgram.cs
@@ -42,7 +42,7 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
                                .UsingAuthenticationKey(eventGridKey)
                                .Build();
                     });
-                    services.AddServiceBusTopicMessagePump("Test-Receive-All-Topic-Only", configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
+                    services.AddServiceBusTopicMessagePump("Test-Receive-All-Topic-Only", configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"], options => options.AutoComplete = true)
                             .WithMessageHandler<PassThruOrderMessageHandler, Order, AzureServiceBusMessageContext>((AzureServiceBusMessageContext context) => false)
                             .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>(context => context.Properties["Topic"].ToString() == "Customers")
                             .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>(context => context.Properties["Topic"].ToString() == "Orders");

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusTopicProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusTopicProgram.cs
@@ -39,7 +39,7 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus
                             .UsingAuthenticationKey(eventGridKey)
                             .Build();
                     });
-                    services.AddServiceBusTopicMessagePump("Test-Receive-All-Topic-Only", configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
+                    services.AddServiceBusTopicMessagePump("Test-Receive-All-Topic-Only", configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"], options => options.AutoComplete = true)
                             .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 
                     services.AddTcpHealthProbes("ARCUS_HEALTH_PORT");

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusTopicWithOrderBatchProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/ServiceBusTopicWithOrderBatchProgram.cs
@@ -40,7 +40,7 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus
                             .UsingAuthenticationKey(eventGridKey)
                             .Build();
                     });
-                    services.AddServiceBusTopicMessagePump("Test-Receive-All-Topic-Only", configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
+                    services.AddServiceBusTopicMessagePump("Test-Receive-All-Topic-Only", configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"], options => options.AutoComplete = true)
                             .WithServiceBusMessageHandler<OrderBatchMessageHandler, OrderBatch>(messageBodySerializerImplementationFactory: serviceProvider =>
                             {
                                 var logger = serviceProvider.GetService<ILogger<OrderBatchMessageBodySerializer>>();

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/TcpConnectionRejectionProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/TcpConnectionRejectionProgram.cs
@@ -37,7 +37,7 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus
                     services.AddTcpHealthProbes(
                         "ARCUS_HEALTH_PORT", 
                         builder => builder.AddCheck("toggle", 
-                            () => ++Index < 10
+                            () => ++Index < 5
                                 ? HealthCheckResult.Healthy() 
                                 : HealthCheckResult.Unhealthy()),
                         options => options.RejectTcpConnectionWhenUnhealthy = true,

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/TcpConnectionRejectionProgram.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/TcpConnectionRejectionProgram.cs
@@ -37,14 +37,14 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus
                     services.AddTcpHealthProbes(
                         "ARCUS_HEALTH_PORT", 
                         builder => builder.AddCheck("toggle", 
-                            () => ++Index < 5
+                            () => ++Index < 10
                                 ? HealthCheckResult.Healthy() 
                                 : HealthCheckResult.Unhealthy()),
                         options => options.RejectTcpConnectionWhenUnhealthy = true,
                         options =>
                         {
-                            options.Delay = TimeSpan.Zero;
-                            options.Period = TimeSpan.FromSeconds(1);
+                            options.Delay = TimeSpan.FromSeconds(3);
+                            options.Period = TimeSpan.FromSeconds(2);
                         });
                 });
     }

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/WorkerProject.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/WorkerProject.cs
@@ -116,7 +116,7 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
 
         private void Start(IEnumerable<CommandArgument> commandArguments)
         {
-            RunDotNet($"build -c Release {_projectDirectory.FullName}");
+            RunDotNet($"build --nologo --no-incremental -c Release {_projectDirectory.FullName}");
             
             string targetAssembly = Path.Combine(_projectDirectory.FullName, $"bin/Release/netcoreapp3.1/Arcus.Messaging.Tests.Workers.ServiceBus.dll");
             string exposedSecretsCommands = String.Join(" ", commandArguments.Select(arg => arg.ToExposedString()));

--- a/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthListenerTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthListenerTests.cs
@@ -25,7 +25,7 @@ namespace Arcus.Messaging.Tests.Integration.Health
             _logger = new XunitTestLogger(outputWriter);
         }
         
-        [Fact(Skip = "temp skip health test")]
+        [Fact]
         public async Task TcpHealthListenerWithRejectionActivated_RejectsTcpConnection_WhenHealthCheckIsUnhealthy()
         {
             // Arrange

--- a/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthListenerTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthListenerTests.cs
@@ -32,7 +32,7 @@ namespace Arcus.Messaging.Tests.Integration.Health
             var config = TestConfig.Create();
             var service = new TcpHealthService(WorkerProject.HealthPort, _logger);
             
-            using (var project = await WorkerProject.StartNewWithAsync<TcpConnectionRejectionProgram>(config, _logger))
+            using (var project = await WorkerProject.StartNewWithAsync<TcpConnectionRejectionProgram>(config, _logger, startupTcpVerification: false))
             {
                 HealthReport afterReport = await RetryAssert<SocketException, HealthReport>(
                     () => service.GetHealthReportAsync());

--- a/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthListenerTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthListenerTests.cs
@@ -25,7 +25,7 @@ namespace Arcus.Messaging.Tests.Integration.Health
             _logger = new XunitTestLogger(outputWriter);
         }
         
-        [Fact]
+        [Fact(Skip = "temp skip health test")]
         public async Task TcpHealthListenerWithRejectionActivated_RejectsTcpConnection_WhenHealthCheckIsUnhealthy()
         {
             // Arrange

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -50,6 +50,8 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
         public async Task ServiceBusMessagePump_PublishServiceBusMessage_MessageSuccessfullyProcessed(ServiceBusEntity entity, Type programType)
         {
             // Arrange
+            _logger.LogTrace("Start test '{MethodName}({EntityType}, {ProgramType})'", nameof(ServiceBusMessagePump_PublishServiceBusMessage_MessageSuccessfullyProcessed), entity, programType.Name);
+            
             var config = TestConfig.Create();
             string connectionString = config.GetServiceBusConnectionString(entity);
             var commandArguments = new[]
@@ -67,6 +69,8 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                     await service.SimulateMessageProcessingAsync(connectionString);
                 }
             }
+            
+            _logger.LogTrace("Stop test '{MethodName}({EntityType}, {ProgramType})'", nameof(ServiceBusMessagePump_PublishServiceBusMessage_MessageSuccessfullyProcessed), entity, programType.Name);
         }
 
         [Fact]

--- a/src/Arcus.Messaging.Tests.Workers.ServiceBus/Program.cs
+++ b/src/Arcus.Messaging.Tests.Workers.ServiceBus/Program.cs
@@ -1,53 +1,14 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using Arcus.EventGrid.Publishing;
-using Arcus.Messaging.Tests.Core.Messages.v1;
-using Arcus.Messaging.Tests.Workers.MessageHandlers;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
-// ReSharper disable once CheckNamespace
 namespace Arcus.Messaging.Tests.Workers.ServiceBus
 {
-    public class Program
+    public static class Program
     {
         public static void Main(string[] args)
         {
-            CreateHostBuilder(args)
-                .Build()
-                .Run();
-        }
 
-        public static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureAppConfiguration(configuration =>
-                {
-                    configuration.AddCommandLine(args);
-                    configuration.AddEnvironmentVariables();
-                })
-                .ConfigureLogging(loggingBuilder => loggingBuilder.AddConsole(options => options.IncludeScopes = true))
-                .ConfigureServices((hostContext, services) =>
-                {
-                    services.AddTransient(svc =>
-                    {
-                        var configuration = svc.GetRequiredService<IConfiguration>();
-                        var eventGridTopic = configuration.GetValue<string>("EVENTGRID_TOPIC_URI");
-                        var eventGridKey = configuration.GetValue<string>("EVENTGRID_AUTH_KEY");
-                        
-                        return EventGridPublisherBuilder
-                            .ForTopic(eventGridTopic)
-                            .UsingAuthenticationKey(eventGridKey)
-                            .Build();
-                    });
-                    
-                    services.AddServiceBusQueueMessagePump(configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
-                            .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
-                    
-                    services.AddTcpHealthProbes("ARCUS_HEALTH_PORT", builder => builder.AddCheck("sample", () => HealthCheckResult.Healthy()));
-                });
+        }
     }
 }


### PR DESCRIPTION
Some small improvement that makes sure that we don't register a unnecessary resource which will be called regularly when publishing health, when we don't need it. 