### PR TITLE
Feature - make message correlation transaction ID configurable

### DIFF
--- a/docs/preview/features/message-pumps/service-bus.md
+++ b/docs/preview/features/message-pumps/service-bus.md
@@ -167,6 +167,10 @@ public class Startup
                 // this job instance in a multi-instance deployment (default: guid).
                 options.JobId = Guid.NewGuid().ToString();
 
+                // The name of the Azure Service Bus message property that has the transaction ID.
+                // (default: Transaction-Id).
+                options.TransactionIdPropertyName = "X-Transaction-ID";
+
                 // Indicate whether or not a new Azure Service Bus Topic subscription should be created/deleted
                 // when the message pump starts/stops (default: CreateOnStart & DeleteOnStop).
                 options.TopicSubscription = TopicSubscription.CreateOnStart | TopicSubscription.DeleteOnStop;

--- a/docs/preview/features/message-pumps/service-bus.md
+++ b/docs/preview/features/message-pumps/service-bus.md
@@ -169,7 +169,7 @@ public class Startup
 
                 // The name of the Azure Service Bus message property that has the transaction ID.
                 // (default: Transaction-Id).
-                options.TransactionIdPropertyName = "X-Transaction-ID";
+                options.Correlation.TransactionIdPropertyName = "X-Transaction-ID";
 
                 // Indicate whether or not a new Azure Service Bus Topic subscription should be created/deleted
                 // when the message pump starts/stops (default: CreateOnStart & DeleteOnStop).

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -468,7 +468,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
                 Logger.LogTrace("No operation ID was found on the message");
             }
 
-            MessageCorrelationInfo correlationInfo = message.GetCorrelationInfo(Settings.Options.TransactionIdPropertyName);
+            MessageCorrelationInfo correlationInfo = message.GetCorrelationInfo(Settings.Options.Correlation.TransactionIdPropertyName);
             using (IServiceScope serviceScope = ServiceProvider.CreateScope())
             {
                 var correlationInfoAccessor = serviceScope.ServiceProvider.GetService<ICorrelationInfoAccessor<MessageCorrelationInfo>>();

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -468,7 +468,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
                 Logger.LogTrace("No operation ID was found on the message");
             }
 
-            MessageCorrelationInfo correlationInfo = message.GetCorrelationInfo();
+            MessageCorrelationInfo correlationInfo = message.GetCorrelationInfo(Settings.Options.TransactionIdPropertyName);
             using (IServiceScope serviceScope = ServiceProvider.CreateScope())
             {
                 var correlationInfoAccessor = serviceScope.ServiceProvider.GetService<ICorrelationInfoAccessor<MessageCorrelationInfo>>();

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -468,7 +468,8 @@ namespace Arcus.Messaging.Pumps.ServiceBus
                 Logger.LogTrace("No operation ID was found on the message");
             }
 
-            MessageCorrelationInfo correlationInfo = message.GetCorrelationInfo(Settings.Options.Correlation.TransactionIdPropertyName);
+            string transactionIdPropertyName = Settings.Options.Correlation?.TransactionIdPropertyName ?? PropertyNames.TransactionId;
+            MessageCorrelationInfo correlationInfo = message.GetCorrelationInfo(transactionIdPropertyName);
             using (IServiceScope serviceScope = ServiceProvider.CreateScope())
             {
                 var correlationInfoAccessor = serviceScope.ServiceProvider.GetService<ICorrelationInfoAccessor<MessageCorrelationInfo>>();

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusCorrelationOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusCorrelationOptions.cs
@@ -1,0 +1,26 @@
+﻿using Arcus.Messaging.Abstractions;
+using GuardNet;
+
+namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
+{
+    /// <summary>
+    /// Represents the user-configurable options to control the correlation information tracking during the receiving of the Azure Service Bus messages in the <see cref="AzureServiceBusMessagePump"/>.
+    /// </summary>
+    public class AzureServiceBusCorrelationOptions
+    {
+        private string _transactionIdProperty = PropertyNames.TransactionId;
+        
+        /// <summary>
+        /// Gets or sets the name of the Azure Service Bus message property to determine the transaction ID.
+        /// </summary>
+        public string TransactionIdPropertyName
+        {
+            get => _transactionIdProperty;
+            set
+            {
+                Guard.NotNullOrWhitespace(value, nameof(value), "Transaction ID message property name for Azure Service Bus Message cannot be blank");
+                _transactionIdProperty = value;
+            }
+        }
+    }
+}

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpConfiguration.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpConfiguration.cs
@@ -37,6 +37,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
             EmitSecurityEvents = options.EmitSecurityEvents;
             JobId = options.JobId;
             KeyRotationTimeout = options.KeyRotationTimeout;
+            TransactionIdPropertyName = options.TransactionIdPropertyName;
         }
 
         /// <summary>
@@ -74,5 +75,10 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// Gets or sets the timeout when the message pump tries to restart and re-authenticate during key rotation.
         /// </summary>
         internal TimeSpan KeyRotationTimeout { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the name of the Azure Service Bus message property to determine the transaction ID.
+        /// </summary>
+        internal string TransactionIdPropertyName { get; set; }
     }
 }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpConfiguration.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpConfiguration.cs
@@ -31,7 +31,8 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         private AzureServiceBusMessagePumpConfiguration(AzureServiceBusMessagePumpOptions options)
         {
             Guard.NotNull(options, nameof(options));
-
+            Guard.NotNull(options.Correlation, nameof(options), "Requires correlation options to configure the Azure Service Bus configuration for the message pump");
+            
             MaxConcurrentCalls = options.MaxConcurrentCalls;
             AutoComplete = options.AutoComplete;
             EmitSecurityEvents = options.EmitSecurityEvents;

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpConfiguration.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpConfiguration.cs
@@ -37,7 +37,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
             EmitSecurityEvents = options.EmitSecurityEvents;
             JobId = options.JobId;
             KeyRotationTimeout = options.KeyRotationTimeout;
-            TransactionIdPropertyName = options.TransactionIdPropertyName;
+            Correlation = options.Correlation;
         }
 
         /// <summary>
@@ -77,8 +77,8 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         internal TimeSpan KeyRotationTimeout { get; set; }
         
         /// <summary>
-        /// Gets or sets the name of the Azure Service Bus message property to determine the transaction ID.
+        /// Gets or sets the options to control the correlation information during the receiving of Azure Service Bus messages.
         /// </summary>
-        internal string TransactionIdPropertyName { get; set; }
+        internal AzureServiceBusCorrelationOptions Correlation { get; }
     }
 }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Arcus.Messaging.Abstractions;
 using GuardNet;
 
 namespace Arcus.Messaging.Pumps.ServiceBus.Configuration 
@@ -11,6 +12,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         private int? _maxConcurrentCalls;
         private string _jobId;
         private TimeSpan _keyRotationTimeout = TimeSpan.FromSeconds(5);
+        private string _transactionIdProperty = PropertyNames.TransactionId;
 
         /// <summary>
         ///     Maximum concurrent calls to process messages
@@ -64,6 +66,19 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
             {
                 Guard.NotLessThan(value, TimeSpan.Zero, nameof(value), "Key rotation timeout cannot be less than a zero time range");
                 _keyRotationTimeout = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the Azure Service Bus message property to determine the transaction ID.
+        /// </summary>
+        public string TransactionIdPropertyName
+        {
+            get => _transactionIdProperty;
+            set
+            {
+                Guard.NotNullOrWhitespace(value, nameof(value), "Transaction ID message property name for Azure Service Bus Message cannot be blank");
+                _transactionIdProperty = value;
             }
         }
     }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
@@ -12,7 +12,6 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         private int? _maxConcurrentCalls;
         private string _jobId;
         private TimeSpan _keyRotationTimeout = TimeSpan.FromSeconds(5);
-        private string _transactionIdProperty = PropertyNames.TransactionId;
 
         /// <summary>
         ///     Maximum concurrent calls to process messages
@@ -70,16 +69,8 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         }
 
         /// <summary>
-        /// Gets or sets the name of the Azure Service Bus message property to determine the transaction ID.
+        /// Gets the options to control the correlation information upon the receiving of Azure Service Bus messages in the <see cref="AzureServiceBusMessagePump"/>.
         /// </summary>
-        public string TransactionIdPropertyName
-        {
-            get => _transactionIdProperty;
-            set
-            {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Transaction ID message property name for Azure Service Bus Message cannot be blank");
-                _transactionIdProperty = value;
-            }
-        }
+        public AzureServiceBusCorrelationOptions Correlation { get; } = new AzureServiceBusCorrelationOptions();
     }
 }

--- a/src/Arcus.Messaging.Tests.Unit/Blanks.cs
+++ b/src/Arcus.Messaging.Tests.Unit/Blanks.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace Arcus.Messaging.Tests.Unit
+{
+    /// <summary>
+    /// Represents a sequence of blank inputs used for data-driven tests.
+    /// </summary>
+    public class Blanks : IEnumerable<object[]>
+    {
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection.
+        /// </summary>
+        /// <returns>An enumerator that can be used to iterate through the collection.</returns>
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            yield return new object[] {null};
+            yield return new object[] {""};
+            yield return new object[] {" "};
+            yield return new object[] {"    "};
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through a collection.
+        /// </summary>
+        /// <returns>An <see cref="T:System.Collections.IEnumerator" /> object that can be used to iterate through the collection.</returns>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Unit/ServiceBus/AzureServiceBusMessagePumpOptionsTest.cs
+++ b/src/Arcus.Messaging.Tests.Unit/ServiceBus/AzureServiceBusMessagePumpOptionsTest.cs
@@ -49,5 +49,30 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             // Act & Assert
             Assert.Throws<ArgumentException>(() => createOptions(invalidConcurrentCalls));
         }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void TransactionIdPropertyName_ValueIsBlank_Throws(string transactionIdPropertyName)
+        {
+            // Arrange
+            var options = new AzureServiceBusMessagePumpOptions();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => options.TransactionIdPropertyName = transactionIdPropertyName);
+        }
+
+        [Fact]
+        public void TransactionIdPropertyName_ValueNotBlank_Succeeds()
+        {
+            // Arrange
+            var options = new AzureServiceBusMessagePumpOptions();
+            const string expected = "Transaction-ID";
+            
+            // Act
+            options.TransactionIdPropertyName = expected;
+            
+            // Assert
+            Assert.Equal(expected, options.TransactionIdPropertyName);
+        }
     }
 }

--- a/src/Arcus.Messaging.Tests.Unit/ServiceBus/AzureServiceBusMessagePumpOptionsTest.cs
+++ b/src/Arcus.Messaging.Tests.Unit/ServiceBus/AzureServiceBusMessagePumpOptionsTest.cs
@@ -58,7 +58,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var options = new AzureServiceBusMessagePumpOptions();
 
             // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(() => options.TransactionIdPropertyName = transactionIdPropertyName);
+            Assert.ThrowsAny<ArgumentException>(() => options.Correlation.TransactionIdPropertyName = transactionIdPropertyName);
         }
 
         [Fact]
@@ -69,10 +69,10 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             const string expected = "Transaction-ID";
             
             // Act
-            options.TransactionIdPropertyName = expected;
+            options.Correlation.TransactionIdPropertyName = expected;
             
             // Assert
-            Assert.Equal(expected, options.TransactionIdPropertyName);
+            Assert.Equal(expected, options.Correlation.TransactionIdPropertyName);
         }
     }
 }


### PR DESCRIPTION
Introduces a new property in the settings which can control the name of correlation transaction ID of the Azure Service Bus message during receival of Azure Service Bus messages in the message pump.

Closes #156  