### PR TITLE
Feature - initialize the transaction ID (like the operation ID) with default guid

### DIFF
--- a/src/Arcus.Messaging.ServiceBus.Core/Extensions/MessageExtensions.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/Extensions/MessageExtensions.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.ServiceBus
                 return transactionId.ToString();
             }
 
-            return string.Empty;
+            return null;
         }
     }
 }

--- a/src/Arcus.Messaging.Tests.Unit/ServiceBus/MessageExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/ServiceBus/MessageExtensionsTests.cs
@@ -116,7 +116,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
         }
 
         [Fact]
-        public void GetMessageCorrelationInfo_WithCorrelationId_ReturnsCorrelationInfoWithEmptyTransactionId()
+        public void GetMessageCorrelationInfo_WithCorrelationId_ReturnsCorrelationInfoWithNonEmptyTransactionId()
         {
             // Arrange
             string expectedOperationId = $"operation-{Guid.NewGuid()}";
@@ -129,7 +129,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             Assert.NotNull(correlationInfo);
             Assert.NotEmpty(correlationInfo.CycleId);
             Assert.Equal(expectedOperationId, correlationInfo.OperationId);
-            Assert.Empty(correlationInfo.TransactionId);
+            Assert.NotEmpty(correlationInfo.TransactionId);
         }
 
         [Fact]


### PR DESCRIPTION
Update the message correlation extraction to initialize like the operation ID the transaction ID with a default guid when none is found.

Closes #158 