### PR TITLE
Fix - unit test to verify that non-existing transaction ID is 'null'

### DIFF
--- a/src/Arcus.Messaging.Tests.Unit/ServiceBus/MessageExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/ServiceBus/MessageExtensionsTests.cs
@@ -136,18 +136,16 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
         public void GetTransactionId_WithoutTransactionIdAsUserProperty_ReturnsEmptyString()
         {
             // Arrange
-            string expectedTransactionId = string.Empty;
             var message = new Message
             {
                 UserProperties = {  }
             };
 
             // Act
-            var transactionId = message.GetTransactionId();
+            string transactionId = message.GetTransactionId();
 
             // Assert
-            Assert.NotNull(transactionId);
-            Assert.Equal(expectedTransactionId, transactionId);
+            Assert.Null(transactionId);
         }
 
         [Fact]


### PR DESCRIPTION
Not sure how it happened, but the unit test about the transaction ID failed on `master`.