### PR TITLE
test: remove app insights connection in integration tests

### DIFF
--- a/src/Arcus.Messaging.Tests.Integration/Fixture/InMemoryLogSink.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/InMemoryLogSink.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Arcus.Messaging.Tests.Integration.Fixture
+{
+    /// <summary>
+    /// Represents a logging sink that collects the emitted log events in-memory.
+    /// </summary>
+    public class InMemoryLogSink : ILogEventSink
+    {
+        private readonly ConcurrentQueue<LogEvent> _logEmits = new ConcurrentQueue<LogEvent>();
+
+        /// <summary>
+        /// Gets the current log emits available on the sink.
+        /// </summary>
+        public IEnumerable<LogEvent> CurrentLogEmits => _logEmits.ToArray();
+
+        /// <summary>
+        /// Emit the provided log event to the sink.
+        /// </summary>
+        /// <param name="logEvent">The log event to write.</param>
+        public void Emit(LogEvent logEvent)
+        {
+            _logEmits.Enqueue(logEvent);
+        }
+    }
+}


### PR DESCRIPTION
We don't need the Azure Application Insights connection anymore with the new approach of testing the message pumps in the integration test suite.