### PR TITLE
chore: resolve code warnings

### DIFF
--- a/src/Arcus.Messaging.Abstractions/Arcus.Messaging.Abstractions.csproj
+++ b/src/Arcus.Messaging.Abstractions/Arcus.Messaging.Abstractions.csproj
@@ -17,6 +17,7 @@
     <PackageTags>Azure;Messaging</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageBody.IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageBody.IServiceCollectionExtensions.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
-        /// Adds a <see cref="IMessageHandler{TMessage,TMessageContext}" /> implementation to process the messages from an <see cref="MessagePump"/> implementation.
+        /// Adds a <see cref="IMessageHandler{TMessage,TMessageContext}" /> implementation to process the messages from an Azure Service Bus.
         /// resources.
         /// </summary>
         /// <typeparam name="TMessageHandler">The type of the implementation.</typeparam>

--- a/src/Arcus.Messaging.Abstractions/MessageCorrelationInfo.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageCorrelationInfo.cs
@@ -4,7 +4,7 @@ using Arcus.Observability.Correlation;
 namespace Arcus.Messaging.Abstractions
 {
     /// <summary>
-    ///     Information concerning correlation of telemetry & processes with main focus on messaging scenarios
+    ///     Information concerning correlation of telemetry &amp; processes with main focus on messaging scenarios
     /// </summary>
     public class MessageCorrelationInfo : CorrelationInfo
     {

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageHandler.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageHandler.cs
@@ -121,7 +121,6 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         ///     [true] if the registered <typeparamref name="TMessageContext"/> predicate holds; [false] otherwise.
         /// </returns>
         /// <typeparam name="TMessageContext">The type of the message context.</typeparam>
-        /// <param name="messageContext">The context in which the incoming message is processed.</param>
         [Obsolete("Use the " + nameof(CanProcessMessageBasedOnContext) + " specific message context overload instead")]
         public bool CanProcessMessage<TMessageContext>(TMessageContext messageContext)
             where TMessageContext : MessageContext
@@ -183,7 +182,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// Determines if the registered <see cref="IMessageHandler{TMessage,TMessageContext}"/> can process the incoming deserialized message based on the consumer-provided message predicate.
         /// </summary>
         /// <param name="message">The incoming deserialized message body.</param>
-        public bool CanProcessMessageBasedOnMessage(object? message)
+        public bool CanProcessMessageBasedOnMessage(object message)
         {
             if (_service.GetType().Name == typeof(MessageHandlerRegistration<,>).Name)
             {

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
@@ -226,7 +226,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
                 return result;
             }
 
-            if (TryDeserializeToMessageFormat(message, handlerMessageType, out object? deserializedByType) && deserializedByType != null)
+            if (TryDeserializeToMessageFormat(message, handlerMessageType, out object deserializedByType) && deserializedByType != null)
             {
                 return MessageResult.Success(deserializedByType);
             }
@@ -290,7 +290,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         ///     [true] if the <paramref name="message"/> conforms the <see cref="IMessageHandler{TMessage,TMessageContext}"/>'s contract; otherwise [false].
         /// </returns>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="messageType"/> is blank.</exception>
-        protected virtual bool TryDeserializeToMessageFormat(string message, Type messageType, out object? result)
+        protected virtual bool TryDeserializeToMessageFormat(string message, Type messageType, out object result)
         {
             Guard.NotNullOrWhitespace(message, nameof(message), "Can't parse a blank raw message against a message handler's contract");
 

--- a/src/Arcus.Messaging.Abstractions/PropertyNames.cs
+++ b/src/Arcus.Messaging.Abstractions/PropertyNames.cs
@@ -1,9 +1,23 @@
 ﻿namespace Arcus.Messaging.Abstractions
 {
+    /// <summary>
+    /// Represents general property names within contextual information of processing messages.
+    /// </summary>
     public static class PropertyNames
     {
+        /// <summary>
+        /// Gets the context property name to get the correlation transaction ID.
+        /// </summary>
         public const string TransactionId = "Transaction-Id";
+        
+        /// <summary>
+        /// Gets the context property name to get the encoding that was used on the message.
+        /// </summary>
         public const string Encoding = "Message-Encoding";
+        
+        /// <summary>
+        /// Gets the context property to get the content type of the message.
+        /// </summary>
         public const string ContentType = "Content-Type";
     }
 }


### PR DESCRIPTION
* Deprecated 'packageUrl' of the NuGet that's being ignored for now
* Nullable reference types removed to be more compatible
* Add public XML code docs