### PR TITLE
test: add unit tests for az servicebus sys props assignments

### DIFF
--- a/src/Arcus.Messaging.Abstractions.ServiceBus/AzureServiceBusSystemProperties.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/AzureServiceBusSystemProperties.cs
@@ -11,6 +11,8 @@ namespace Arcus.Messaging.Abstractions.ServiceBus
     {
         private AzureServiceBusSystemProperties(ServiceBusReceivedMessage message)
         {
+            Guard.NotNull(message, nameof(message), "Requires an Azure Service Bus received message to construct a set of Azure Service Bus system properties");
+
             DeadLetterSource = message.DeadLetterSource;
             DeliveryCount = message.DeliveryCount;
             EnqueuedSequenceNumber = message.EnqueuedSequenceNumber;
@@ -122,6 +124,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus
         /// <summary>
         /// Gets the content type descriptor.
         /// </summary>
+        /// <value>RFC2045 Content-Type descriptor.</value>
         /// <remarks>
         /// Optionally describes the payload of the message,
         /// with a descriptor following the format of RFC2045, Section 5, for example "application/json".

--- a/src/Arcus.Messaging.Tests.Unit/ServiceBus/AzureServiceBusSystemPropertiesTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/ServiceBus/AzureServiceBusSystemPropertiesTests.cs
@@ -1,5 +1,13 @@
 ﻿using System;
+using System.Reflection;
+using System.Text;
 using Arcus.Messaging.Abstractions.ServiceBus;
+using Arcus.Messaging.Tests.Unit.Fixture;
+using Azure.Core.Amqp;
+using Azure.Messaging.ServiceBus;
+using Bogus;
+using Bogus.Extensions;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Arcus.Messaging.Tests.Unit.ServiceBus
@@ -7,11 +15,200 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
     [Trait("Category", "Unit")]
     public class AzureServiceBusSystemPropertiesTests
     {
+        private static readonly Faker BogusGenerator = new Faker();
+        
         [Fact]
         public void CreateProperties_WithoutServiceBusMessage_Fails()
         {
             Assert.ThrowsAny<ArgumentException>(
                 () => AzureServiceBusSystemProperties.CreateFrom(message: null));
+        }
+
+        [Fact]
+        public void CreateProperties_FromMessage_AssignsDeliveryCountCorrectly()
+        {
+            // Arrange
+            uint expected = BogusGenerator.Random.UInt();
+
+            AmqpAnnotatedMessage amqpMessage = CreateAmqpMessage();
+            amqpMessage.Header.DeliveryCount = expected;
+            ServiceBusReceivedMessage message = CreateServiceBusReceivedMessage(amqpMessage);
+            
+            // Act
+            var systemProperties = AzureServiceBusSystemProperties.CreateFrom(message);
+            
+            // Assert
+            Assert.Equal((int) expected, systemProperties.DeliveryCount);
+        }
+        
+        [Fact]
+        public void CreateProperties_FromMessage_AssignsContentTypeCorrectly()
+        {
+            // Arrange
+            string expected = BogusGenerator.Random.String();
+
+            AmqpAnnotatedMessage amqpMessage = CreateAmqpMessage();
+            amqpMessage.Properties.ContentType = expected;
+            ServiceBusReceivedMessage message = CreateServiceBusReceivedMessage(amqpMessage);
+            
+            // Act
+            var systemProperties = AzureServiceBusSystemProperties.CreateFrom(message);
+            
+            // Assert
+            Assert.Equal(expected, systemProperties.ContentType);
+        }
+        
+        [Fact]
+        public void CreateProperties_FromMessage_AssignsDeadLetterSourceCorrectly()
+        {
+            // Arrange
+            string expected = BogusGenerator.Random.String();
+
+            AmqpAnnotatedMessage amqpMessage = CreateAmqpMessage();
+            amqpMessage.MessageAnnotations["x-opt-deadletter-source"] = expected;
+            ServiceBusReceivedMessage message = CreateServiceBusReceivedMessage(amqpMessage);
+            
+            // Act
+            var systemProperties = AzureServiceBusSystemProperties.CreateFrom(message);
+            
+            // Assert
+            Assert.Equal(expected, systemProperties.DeadLetterSource);
+        }
+        
+        [Fact]
+        public void CreateProperties_FromMessage_AssignsEnqueuedSequenceNumberCorrectly()
+        {
+            // Arrange
+            long expected = BogusGenerator.Random.Long();
+
+            AmqpAnnotatedMessage amqpMessage = CreateAmqpMessage();
+            amqpMessage.MessageAnnotations["x-opt-enqueue-sequence-number"] = expected;
+            ServiceBusReceivedMessage message = CreateServiceBusReceivedMessage(amqpMessage);
+            
+            // Act
+            var systemProperties = AzureServiceBusSystemProperties.CreateFrom(message);
+            
+            // Assert
+            Assert.Equal(expected, systemProperties.EnqueuedSequenceNumber);
+        }
+        
+        [Fact]
+        public void CreateProperties_FromMessage_AssignsIsReceivedCorrectly()
+        {
+            // Arrange
+            long expected = BogusGenerator.Random.Long(min: 0);
+
+            AmqpAnnotatedMessage amqpMessage = CreateAmqpMessage();
+            amqpMessage.MessageAnnotations["x-opt-enqueue-sequence-number"] = expected;
+            ServiceBusReceivedMessage message = CreateServiceBusReceivedMessage(amqpMessage);
+            
+            // Act
+            var systemProperties = AzureServiceBusSystemProperties.CreateFrom(message);
+            
+            // Assert
+            Assert.True(systemProperties.IsReceived);
+        }
+        
+        [Fact]
+        public void CreateProperties_FromMessage_AssignsEnqueuedTimeCorrectly()
+        {
+            // Arrange
+            DateTime expected = BogusGenerator.Date.Recent();
+
+            AmqpAnnotatedMessage amqpMessage = CreateAmqpMessage();
+            amqpMessage.MessageAnnotations["x-opt-enqueued-time"] = expected;
+            ServiceBusReceivedMessage message = CreateServiceBusReceivedMessage(amqpMessage);
+            
+            // Act
+            var systemProperties = AzureServiceBusSystemProperties.CreateFrom(message);
+            
+            // Assert
+            Assert.Equal(expected, systemProperties.EnqueuedTime);
+        }
+        
+        [Fact]
+        public void CreateProperties_FromMessage_AssignsLockTokenCorrectly()
+        {
+            // Arrange
+            Guid? expected = Guid.NewGuid().OrNull(BogusGenerator);
+
+            AmqpAnnotatedMessage amqpMessage = CreateAmqpMessage();
+            ServiceBusReceivedMessage message = CreateServiceBusReceivedMessage(amqpMessage);
+            SetLockToken(message, expected);
+
+            // Act
+            var systemProperties = AzureServiceBusSystemProperties.CreateFrom(message);
+            
+            // Assert
+            Assert.Equal((expected ?? Guid.Empty).ToString(), systemProperties.LockToken);
+            Assert.Equal(expected != null, systemProperties.IsLockTokenSet);
+        }
+        
+        [Fact]
+        public void CreateProperties_FromMessage_AssignsLockedUntilCorrectly()
+        {
+            // Arrange
+            DateTime expected = BogusGenerator.Date.Past();
+
+            AmqpAnnotatedMessage amqpMessage = CreateAmqpMessage();
+            amqpMessage.MessageAnnotations["x-opt-locked-until"] = expected;
+            ServiceBusReceivedMessage message = CreateServiceBusReceivedMessage(amqpMessage);
+            
+            // Act
+            var systemProperties = AzureServiceBusSystemProperties.CreateFrom(message);
+            
+            // Assert
+            Assert.Equal(expected, systemProperties.LockedUntil);
+        }
+        
+        [Fact]
+        public void CreateProperties_FromMessage_AssignsSequenceNumberCorrectly()
+        {
+            // Arrange
+            long expected = BogusGenerator.Random.Long();
+
+            AmqpAnnotatedMessage amqpMessage = CreateAmqpMessage();
+            amqpMessage.MessageAnnotations["x-opt-sequence-number"] = expected;
+            ServiceBusReceivedMessage message = CreateServiceBusReceivedMessage(amqpMessage);
+            
+            // Act
+            var systemProperties = AzureServiceBusSystemProperties.CreateFrom(message);
+            
+            // Assert
+            Assert.Equal(expected, systemProperties.SequenceNumber);
+            Assert.Equal(expected > -1, systemProperties.IsReceived);
+        }
+
+        private static void SetLockToken(ServiceBusReceivedMessage message, Guid? expected)
+        {
+            PropertyInfo lockTokenGuid = message.GetType().GetProperty("LockTokenGuid", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(lockTokenGuid);
+            lockTokenGuid.SetValue(message, expected);
+        }
+
+        private static AmqpAnnotatedMessage CreateAmqpMessage()
+        {
+            var order = new Order();
+            string json = JsonConvert.SerializeObject(order);
+            byte[] bytes = Encoding.UTF8.GetBytes(json);
+
+            var message = new AmqpAnnotatedMessage(new AmqpMessageBody(new[] {new ReadOnlyMemory<byte>(bytes)}));
+            message.Header.DeliveryCount = BogusGenerator.Random.UInt();
+            
+            return message;
+        }
+
+        private static ServiceBusReceivedMessage CreateServiceBusReceivedMessage(AmqpAnnotatedMessage amqpMessage)
+        {
+            var serviceBusMessage = (ServiceBusReceivedMessage) Activator.CreateInstance(
+                type: typeof(ServiceBusReceivedMessage),
+                bindingAttr: BindingFlags.NonPublic | BindingFlags.Instance,
+                binder: null,
+                args: new object[] {amqpMessage},
+                culture: null,
+                activationAttributes: null);
+            
+            return serviceBusMessage;
         }
     }
 }


### PR DESCRIPTION
Adds the necessary unit tests to verify a correct assignment to our system properties type.

Closes #185 