### PR TITLE
test: add az servicebus namespace-scoped integration tests

### DIFF
--- a/src/Arcus.Messaging.Tests.Integration/Extensions/ServiceBusConnectionStringPropertiesExtensions.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Extensions/ServiceBusConnectionStringPropertiesExtensions.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Reflection;
+using GuardNet;
+
+// ReSharper disable once CheckNamespace
+namespace Azure.Messaging.ServiceBus
+{
+    /// <summary>
+    /// Extensions on the <see cref="ServiceBusConnectionStringProperties"/> to extract internal data.
+    /// </summary>
+    public static class ServiceBusConnectionStringPropertiesExtensions
+    {
+        /// <summary>
+        /// Gets the namespace-scoped Azure Service Bus connection string representation of the current set of <paramref name="properties"/>.
+        /// </summary>
+        /// <param name="properties">The Azure Service Bus property set of the separate connection string parts.</param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="properties"/> is <c>null</c>
+        ///     or doesn't contain the necessary properties or methods to determine the namespace-scoped connection string.
+        /// </exception>
+        public static string GetNamespaceConnectionString(this ServiceBusConnectionStringProperties properties)
+        {
+            Guard.NotNull(properties, nameof(properties), "Requires an Azure Service Bus properties instance to determine the namespace-scoped connection string");
+            
+            string originalEntityPath = properties.EntityPath;
+            SetEntityPath(properties, entityPath: null);
+
+            string connectionString = GetConnectionString(properties);
+            SetEntityPath(properties, originalEntityPath);
+
+            return connectionString;
+        }
+
+        private static void SetEntityPath(ServiceBusConnectionStringProperties properties, string entityPath)
+        {
+            const BindingFlags internalScope = BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.SetProperty;
+            Type propertiesType = properties.GetType();
+            PropertyInfo entityPathProperty = propertiesType.GetProperty(nameof(properties.EntityPath));
+
+            Guard.NotNull(entityPathProperty, nameof(entityPathProperty), 
+                $"Requires a '{nameof(properties)}' property on the '{nameof(ServiceBusConnectionStringProperties)}' type");
+            
+            entityPathProperty?.SetValue(properties, entityPath, internalScope, binder: null, index: null, culture: null);
+        }
+
+        private static string GetConnectionString(ServiceBusConnectionStringProperties properties)
+        {
+            const BindingFlags internalScope = BindingFlags.NonPublic | BindingFlags.Instance;
+            Type propertiesType = properties.GetType();
+            
+            const string connectionStringMethodName = "ToConnectionString";
+            MethodInfo connectionStringMethod = propertiesType.GetMethod(connectionStringMethodName, internalScope);
+            Guard.NotNull(connectionStringMethod, nameof(properties), 
+                $"Requires a '{connectionStringMethodName}' method on the '{nameof(ServiceBusConnectionStringProperties)}'");
+
+            var connectionString = connectionStringMethod?.Invoke(properties, new object[0]) as string;
+            return connectionString;
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/Extensions/ServiceBusConnectionStringPropertiesExtensions.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Extensions/ServiceBusConnectionStringPropertiesExtensions.cs
@@ -54,6 +54,12 @@ namespace Azure.Messaging.ServiceBus
                 $"Requires a '{connectionStringMethodName}' method on the '{nameof(ServiceBusConnectionStringProperties)}'");
 
             var connectionString = connectionStringMethod?.Invoke(properties, new object[0]) as string;
+            if (string.IsNullOrWhiteSpace(connectionStringMethodName))
+            {
+                throw new InvalidOperationException(
+                    "Could not determine the Azure Service Bus namespace-scoped connection string from the given connection string properties");
+            }
+            
             return connectionString;
         }
     }

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -55,7 +55,6 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = config.GetServiceBusConnectionString(ServiceBusEntityType.Queue);
             var options = new WorkerOptions();
             options.AddEventGridPublisher(config)
-                   .ConfigureLogging(_logger)
                    .AddServiceBusQueueMessagePump(configuration => connectionString, opt => opt.AutoComplete = true)
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -5,7 +5,6 @@ using Arcus.Messaging.Abstractions.ServiceBus;
 using Arcus.Messaging.Pumps.ServiceBus.KeyRotation.Extensions;
 using Arcus.Messaging.Tests.Core.Generators;
 using Arcus.Messaging.Tests.Core.Messages.v1;
-using Arcus.Messaging.Tests.Integration.Extensions;
 using Arcus.Messaging.Tests.Integration.Fixture;
 using Arcus.Messaging.Tests.Integration.ServiceBus;
 using Arcus.Messaging.Tests.Workers.MessageBodyHandlers;

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -53,14 +53,10 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             // Arrange
             var config = TestConfig.Create();
             string connectionString = config.GetServiceBusConnectionString(ServiceBusEntityType.Queue);
-            string[] connectionStringParts = connectionString.Split(';');
-            string namespaceConnectionString = String.Join(";", connectionStringParts.Take(3));
-            string entityPath = connectionStringParts[3].Split('=')[1];
-            
             var options = new WorkerOptions();
             options.AddEventGridPublisher(config)
                    .ConfigureLogging(_logger)
-                   .AddServiceBusQueueMessagePump(entityPath, configuration => namespaceConnectionString, opt => opt.AutoComplete = true)
+                   .AddServiceBusQueueMessagePump(configuration => connectionString, opt => opt.AutoComplete = true)
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 
             // Act


### PR DESCRIPTION
Add Azure Service Bus namespace-scoped integration tests that pass in the entity path separately so we can verify that the bug (#187) is indeed solved by the revisiting of the settings and the use of the new Azure SDK.

Closes #187 
Relates to #179 
Relates to #175 