### PR TITLE
feat: add messaging option for more flexible json parsing

### DIFF
--- a/docs/preview/features/message-pumps/service-bus.md
+++ b/docs/preview/features/message-pumps/service-bus.md
@@ -185,9 +185,9 @@ public class Startup
                 // (default: Transaction-Id).
                 options.Correlation.TransactionIdPropertyName = "X-Transaction-ID";
 
-                // Indicate whether or not the default built-in JSON deserialization should ignore missing members 
-                // when deserializing the incoming message (default: false).
-                options.Deserialization.IgnoreMissingMembers = true;
+                // Indicate whether or not the default built-in JSON deserialization should ignore additional members 
+                // when deserializing the incoming message (default: AdditionalMemberHandling.Error).
+                options.Deserialization.AdditionalMembers = AdditionalMembersHandling.Ignore;
 
                 // Indicate whether or not a new Azure Service Bus Topic subscription should be created/deleted
                 // when the message pump starts/stops (default: CreateOnStart & DeleteOnStop).
@@ -217,9 +217,9 @@ public class Startup
                 // (default: Transaction-Id).
                 options.Correlation.TransactionIdPropertyName = "X-Transaction-ID";
 
-                // Indicate whether or not the default built-in JSON deserialization should ignore missing members 
-                // when deserializing the incoming message (default: false).
-                options.Deserialization.IgnoreMissingMembers = true;
+                // Indicate whether or not the default built-in JSON deserialization should ignore additional members 
+                // when deserializing the incoming message (default: AdditionalMemberHandling.Error).
+                options.Deserialization.AdditionalMembers = AdditionalMembersHandling.Ignore;
             });
 
         // Uses managed identity to authenticate with the Service Bus Topic:

--- a/docs/preview/features/message-pumps/service-bus.md
+++ b/docs/preview/features/message-pumps/service-bus.md
@@ -185,6 +185,10 @@ public class Startup
                 // (default: Transaction-Id).
                 options.Correlation.TransactionIdPropertyName = "X-Transaction-ID";
 
+                // Indicate whether or not the default built-in JSON deserialization should ignore missing members 
+                // when deserializing the incoming message (default: false).
+                options.Deserialization.IgnoreMissingMembers = true;
+
                 // Indicate whether or not a new Azure Service Bus Topic subscription should be created/deleted
                 // when the message pump starts/stops (default: CreateOnStart & DeleteOnStop).
                 options.TopicSubscription = TopicSubscription.CreateOnStart | TopicSubscription.DeleteOnStop;
@@ -208,6 +212,14 @@ public class Startup
                 // The unique identifier for this background job to distinguish 
                 // this job instance in a multi-instance deployment (default: guid).
                 options.JobId = Guid.NewGuid().ToString();
+
+                // The name of the Azure Service Bus message property that has the transaction ID.
+                // (default: Transaction-Id).
+                options.Correlation.TransactionIdPropertyName = "X-Transaction-ID";
+
+                // Indicate whether or not the default built-in JSON deserialization should ignore missing members 
+                // when deserializing the incoming message (default: false).
+                options.Deserialization.IgnoreMissingMembers = true;
             });
 
         // Uses managed identity to authenticate with the Service Bus Topic:

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/IServiceCollectionExtensions.cs
@@ -14,7 +14,8 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class IServiceCollectionExtensions
     {
         /// <summary>
-        /// Adds an <see cref="IAzureServiceBusMessageRouter"/> implementation to route the incoming messages through registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/> instances.
+        ///     Adds an <see cref="IAzureServiceBusMessageRouter"/> implementation
+        ///     to route the incoming messages through registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/> instances.
         /// </summary>
         /// <param name="services">The collection of services to add the router to.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
@@ -22,15 +23,35 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             Guard.NotNull(services, nameof(services), "Requires a set of services to register the Azure Service Bus message routing");
 
-            return services.AddServiceBusMessageRouting(serviceProvider =>
+            return AddServiceBusMessageRouting(services, configureOptions: null);
+        }
+
+        /// <summary>
+        ///     Adds an <see cref="IAzureServiceBusMessageRouter"/> implementation
+        ///     to route the incoming messages through registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/> instances.
+        /// </summary>
+        /// <param name="services">The collection of services to add the router to.</param>
+        /// <param name="configureOptions">The function to configure the options that change the behavior of the router.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
+        public static ServiceBusMessageHandlerCollection AddServiceBusMessageRouting(
+            this IServiceCollection services,
+            Action<AzureServiceBusMessageRouterOptions> configureOptions)
+        {
+            Guard.NotNull(services, nameof(services), "Requires a set of services to register the Azure Service Bus message routing");
+            
+            return AddServiceBusMessageRouting(services, serviceProvider =>
             {
+                var options = new AzureServiceBusMessageRouterOptions();
+                configureOptions?.Invoke(options);
                 var logger = serviceProvider.GetService<ILogger<AzureServiceBusMessageRouter>>();
-                return new AzureServiceBusMessageRouter(serviceProvider, logger);
+
+                return new AzureServiceBusMessageRouter(serviceProvider, options, logger);
             });
         }
 
         /// <summary>
-        /// Adds an <see cref="IAzureServiceBusMessageRouter"/> implementation to route the incoming messages through registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/> instances.
+        ///     Adds an <see cref="IAzureServiceBusMessageRouter"/> implementation
+        ///     to route the incoming messages through registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/> instances.
         /// </summary>
         /// <param name="services">The collection of services to add the router to.</param>
         /// <param name="implementationFactory">The function to create the <typeparamref name="TMessageRouter"/> implementation.</param>

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
@@ -23,11 +23,25 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         /// Initializes a new instance of the <see cref="AzureServiceBusMessageRouter"/> class.
         /// </summary>
         /// <param name="serviceProvider">The service provider instance to retrieve all the <see cref="IMessageHandler{TMessage,TMessageContext}"/> instances.</param>
+        /// <param name="options">The consumer-configurable options to change the behavior of the router.</param>
         /// <param name="logger">The logger instance to write diagnostic trace messages during the routing of the message.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
-        public AzureServiceBusMessageRouter(IServiceProvider serviceProvider, ILogger<AzureServiceBusMessageRouter> logger)
-            : this(serviceProvider, (ILogger) logger)
+        public AzureServiceBusMessageRouter(IServiceProvider serviceProvider, AzureServiceBusMessageRouterOptions options, ILogger<AzureServiceBusMessageRouter> logger)
+            : this(serviceProvider, options, (ILogger) logger)
         {
+            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires an service provider to retrieve the registered message handlers");
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureServiceBusMessageRouter"/> class.
+        /// </summary>
+        /// <param name="serviceProvider">The service provider instance to retrieve all the <see cref="IMessageHandler{TMessage,TMessageContext}"/> instances.</param>
+        /// <param name="options">The consumer-configurable options to change the behavior of the router.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
+        public AzureServiceBusMessageRouter(IServiceProvider serviceProvider, AzureServiceBusMessageRouterOptions options)
+            : this(serviceProvider, options, NullLogger.Instance)
+        {
+            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires an service provider to retrieve the registered message handlers");
         }
         
         /// <summary>
@@ -36,14 +50,57 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         /// <param name="serviceProvider">The service provider instance to retrieve all the <see cref="IMessageHandler{TMessage,TMessageContext}"/> instances.</param>
         /// <param name="logger">The logger instance to write diagnostic trace messages during the routing of the message.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
+        public AzureServiceBusMessageRouter(IServiceProvider serviceProvider, ILogger<AzureServiceBusMessageRouter> logger)
+            : this(serviceProvider, new AzureServiceBusMessageRouterOptions(), (ILogger) logger)
+        {
+            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires an service provider to retrieve the registered message handlers");
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureServiceBusMessageRouter"/> class.
+        /// </summary>
+        /// <param name="serviceProvider">The service provider instance to retrieve all the <see cref="IMessageHandler{TMessage,TMessageContext}"/> instances.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
+        public AzureServiceBusMessageRouter(IServiceProvider serviceProvider)
+            : this(serviceProvider, new AzureServiceBusMessageRouterOptions(), NullLogger.Instance)
+        {
+            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires an service provider to retrieve the registered message handlers");
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureServiceBusMessageRouter"/> class.
+        /// </summary>
+        /// <param name="serviceProvider">The service provider instance to retrieve all the <see cref="IMessageHandler{TMessage,TMessageContext}"/> instances.</param>
+        /// <param name="logger">The logger instance to write diagnostic trace messages during the routing of the message.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
         protected AzureServiceBusMessageRouter(IServiceProvider serviceProvider, ILogger logger)
-            : base(serviceProvider, logger ?? NullLogger<AzureServiceBusMessageRouter>.Instance)
+            : this(serviceProvider, new AzureServiceBusMessageRouterOptions(), logger)
+        {
+            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires an service provider to retrieve the registered message handlers");
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureServiceBusMessageRouter"/> class.
+        /// </summary>
+        /// <param name="serviceProvider">The service provider instance to retrieve all the <see cref="IMessageHandler{TMessage,TMessageContext}"/> instances.</param>
+        /// <param name="options">The consumer-configurable options to change the behavior of the router.</param>
+        /// <param name="logger">The logger instance to write diagnostic trace messages during the routing of the message.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
+        protected AzureServiceBusMessageRouter(IServiceProvider serviceProvider, AzureServiceBusMessageRouterOptions options, ILogger logger)
+            : base(serviceProvider, options, logger ?? NullLogger<AzureServiceBusMessageRouter>.Instance)
         {
             Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires an service provider to retrieve the registered message handlers");
 
             _fallbackMessageHandler = new Lazy<IAzureServiceBusFallbackMessageHandler>(() => serviceProvider.GetService<IAzureServiceBusFallbackMessageHandler>());
+
+            ServiceBusOptions = options;
         }
 
+        /// <summary>
+        /// Gets the consumer-configurable options to change the behavior of the Azure Service Bus router.
+        /// </summary>
+        protected AzureServiceBusMessageRouterOptions ServiceBusOptions { get; }
+        
         /// <summary>
         /// Gets the flag indicating whether or not the router has an registered <see cref="IAzureServiceBusFallbackMessageHandler"/> instance.
         /// </summary>

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouterOptions.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouterOptions.cs
@@ -1,0 +1,11 @@
+﻿using Arcus.Messaging.Abstractions.MessageHandling;
+
+namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
+{
+    /// <summary>
+    /// Represents the consumer-configurable options to change the behavior of the <see cref="AzureServiceBusMessageRouter"/>.
+    /// </summary>
+    public class AzureServiceBusMessageRouterOptions : MessageRouterOptions
+    {
+    }
+}

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/AdditionalMemberHandling.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/AdditionalMemberHandling.cs
@@ -1,0 +1,19 @@
+﻿namespace Arcus.Messaging.Abstractions.MessageHandling
+{
+    /// <summary>
+    /// Represents a model to determine what to do with additional members in an incoming message payload
+    /// during the build-in JSON deserialization in the <see cref="MessageRouter"/>.
+    /// </summary>
+    public enum AdditionalMemberHandling
+    {
+        /// <summary>
+        /// Makes the built-in JSON deserialization result in an error when any additional members are encountered.
+        /// </summary>
+        Error = 0,
+        
+        /// <summary>
+        /// Makes the built-in JSON deserialization ignore any additional members that are encountered.
+        /// </summary>
+        Ignore = 1
+    }
+}

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageDeserializationOptions.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageDeserializationOptions.cs
@@ -9,6 +9,6 @@
         /// Gets or sets the flag indicating whether or not the default JSON deserialization should ignore missing members
         /// when trying to match a incoming message with a message handler's message type.
         /// </summary>
-        public bool IgnoreMissingMembers { get; set; } = false;
+        public AdditionalMemberHandling AdditionalMembers { get; set; } = AdditionalMemberHandling.Error;
     }
 }

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageDeserializationOptions.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageDeserializationOptions.cs
@@ -1,0 +1,14 @@
+﻿namespace Arcus.Messaging.Abstractions.MessageHandling
+{
+    /// <summary>
+    /// Represents the consumer-configurable options, as part of the <see cref="MessageRouterOptions"/>, to change the behavior of the <see cref="MessageRouter"/>.
+    /// </summary>
+    public class MessageDeserializationOptions
+    {
+        /// <summary>
+        /// Gets or sets the flag indicating whether or not the default JSON deserialization should ignore missing members
+        /// when trying to match a incoming message with a message handler's message type.
+        /// </summary>
+        public bool IgnoreMissingMembers { get; set; } = false;
+    }
+}

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
@@ -385,7 +385,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         private JsonSerializer CreateJsonSerializer()
         {
             var jsonSerializer = new JsonSerializer();
-            if (Options.Deserialization.IgnoreMissingMembers)
+            if (Options.Deserialization.AdditionalMembers is AdditionalMemberHandling.Ignore)
             {
                 jsonSerializer.MissingMemberHandling = MissingMemberHandling.Ignore;
             }

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
@@ -388,12 +388,15 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             switch (Options.Deserialization?.AdditionalMembers)
             {
                 case AdditionalMemberHandling.Error:
+                    Logger.LogTrace("JSON deserialization uses 'Error' result when encountering additional members");
                     jsonSerializer.MissingMemberHandling = MissingMemberHandling.Error;
                     break;
                 case AdditionalMemberHandling.Ignore:
+                    Logger.LogTrace("JSON deserialization uses 'Ignore' result when encountering additional members");
                     jsonSerializer.MissingMemberHandling = MissingMemberHandling.Ignore;
                     break;
                 default:
+                    Logger.LogTrace("JSON deserialization uses 'Error' result when encountering additional members");
                     jsonSerializer.MissingMemberHandling = MissingMemberHandling.Error;
                     break;
             }

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
@@ -385,22 +385,28 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         private JsonSerializer CreateJsonSerializer()
         {
             var jsonSerializer = new JsonSerializer();
-            switch (Options.Deserialization?.AdditionalMembers)
+            
+            if (Options.Deserialization is null)
             {
-                case AdditionalMemberHandling.Error:
-                    Logger.LogTrace("JSON deserialization uses 'Error' result when encountering additional members");
-                    jsonSerializer.MissingMemberHandling = MissingMemberHandling.Error;
-                    break;
-                case AdditionalMemberHandling.Ignore:
-                    Logger.LogTrace("JSON deserialization uses 'Ignore' result when encountering additional members");
-                    jsonSerializer.MissingMemberHandling = MissingMemberHandling.Ignore;
-                    break;
-                default:
-                    Logger.LogTrace("JSON deserialization uses 'Error' result when encountering additional members");
-                    jsonSerializer.MissingMemberHandling = MissingMemberHandling.Error;
-                    break;
+                jsonSerializer.MissingMemberHandling = MissingMemberHandling.Error;
+            }
+            else
+            {
+                switch (Options.Deserialization.AdditionalMembers)
+                {
+                    case AdditionalMemberHandling.Error:
+                        jsonSerializer.MissingMemberHandling = MissingMemberHandling.Error;
+                        break;
+                    case AdditionalMemberHandling.Ignore:
+                        jsonSerializer.MissingMemberHandling = MissingMemberHandling.Ignore;
+                        break;
+                    default:
+                        jsonSerializer.MissingMemberHandling = MissingMemberHandling.Error;
+                        break;
+                }
             }
 
+            Logger.LogTrace($"JSON deserialization uses '{jsonSerializer.MissingMemberHandling}' result when encountering additional members");
             return jsonSerializer;
         }
     }

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
@@ -385,13 +385,17 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         private JsonSerializer CreateJsonSerializer()
         {
             var jsonSerializer = new JsonSerializer();
-            if (Options.Deserialization.AdditionalMembers is AdditionalMemberHandling.Ignore)
+            switch (Options.Deserialization?.AdditionalMembers)
             {
-                jsonSerializer.MissingMemberHandling = MissingMemberHandling.Ignore;
-            }
-            else
-            {
-                jsonSerializer.MissingMemberHandling = MissingMemberHandling.Error;
+                case AdditionalMemberHandling.Error:
+                    jsonSerializer.MissingMemberHandling = MissingMemberHandling.Error;
+                    break;
+                case AdditionalMemberHandling.Ignore:
+                    jsonSerializer.MissingMemberHandling = MissingMemberHandling.Ignore;
+                    break;
+                default:
+                    jsonSerializer.MissingMemberHandling = MissingMemberHandling.Error;
+                    break;
             }
 
             return jsonSerializer;

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouterOptions.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouterOptions.cs
@@ -1,0 +1,13 @@
+﻿namespace Arcus.Messaging.Abstractions.MessageHandling
+{
+    /// <summary>
+    /// Represents the consumer-configurable options to change the behavior of the <see cref="MessageRouter"/>.
+    /// </summary>
+    public class MessageRouterOptions
+    {
+        /// <summary>
+        /// Gets the consumer-configurable options to change the deserialization behavior of the message router.
+        /// </summary>
+        public MessageDeserializationOptions Deserialization { get; } = new MessageDeserializationOptions();
+    }
+}

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using Arcus.Messaging.Abstractions.MessageHandling;
+using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 using GuardNet;
 
 namespace Arcus.Messaging.Pumps.ServiceBus.Configuration 
@@ -98,6 +100,16 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// Gets the options to control the correlation information upon the receiving of Azure Service Bus messages in the <see cref="AzureServiceBusMessagePump"/>.
         /// </summary>
         public AzureServiceBusCorrelationOptions Correlation { get; } = new AzureServiceBusCorrelationOptions();
+
+        /// <summary>
+        /// Gets the consumer-configurable options to change the deserialization behavior.
+        /// </summary>
+        public MessageDeserializationOptions Deserialization => MessageRouterOptions.Deserialization;
+
+        /// <summary>
+        /// Gets the consumer-configurable options to change the behavior of the message router.
+        /// </summary>
+        internal AzureServiceBusMessageRouterOptions MessageRouterOptions { get; } = new AzureServiceBusMessageRouterOptions();
 
         /// <summary>
         /// Gets the default consumer-configurable options for Azure Service Bus Queue message pumps.

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
@@ -114,7 +114,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// <summary>
         /// Gets the default consumer-configurable options for Azure Service Bus Queue message pumps.
         /// </summary>
-        internal static AzureServiceBusMessagePumpOptions DefaultQueueOptions { get; } = new AzureServiceBusMessagePumpOptions()
+        internal static AzureServiceBusMessagePumpOptions DefaultQueueOptions => new AzureServiceBusMessagePumpOptions()
         {
             TopicSubscription = null
         };
@@ -122,7 +122,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// <summary>
         /// Gets the default consumer-configurable options for Azure Service Bus Topic message pumps.
         /// </summary>
-        internal static AzureServiceBusMessagePumpOptions DefaultTopicOptions { get; } = new AzureServiceBusMessagePumpOptions()
+        internal static AzureServiceBusMessagePumpOptions DefaultTopicOptions => new AzureServiceBusMessagePumpOptions()
         {
             TopicSubscription = ServiceBus.TopicSubscription.CreateOnStart | ServiceBus.TopicSubscription.DeleteOnStop
         };

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusQueueMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusQueueMessagePumpOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Arcus.Messaging.Abstractions.MessageHandling;
 
 namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
 {
@@ -47,5 +48,10 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// Gets the options to control the correlation information upon the receiving of Azure Service Bus messages in the <see cref="AzureServiceBusMessagePump"/>.
         /// </summary>
         AzureServiceBusCorrelationOptions Correlation { get; }
+        
+        /// <summary>
+        /// Gets the consumer-configurable options to change the deserialization behavior.
+        /// </summary>
+         MessageDeserializationOptions Deserialization { get; }
     }
 }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusTopicMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusTopicMessagePumpOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Arcus.Messaging.Abstractions.MessageHandling;
 
 namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
 {
@@ -56,5 +57,10 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// Gets the options to control the correlation information upon the receiving of Azure Service Bus messages in the <see cref="AzureServiceBusMessagePump"/>.
         /// </summary>
         AzureServiceBusCorrelationOptions Correlation { get; }
+        
+        /// <summary>
+        /// Gets the consumer-configurable options to change the deserialization behavior.
+        /// </summary>
+        MessageDeserializationOptions Deserialization { get; }
     }
 }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
@@ -827,7 +827,12 @@ namespace Microsoft.Extensions.DependencyInjection
             AzureServiceBusMessagePumpOptions options = 
                 DetermineAzureServiceBusMessagePumpOptions(serviceBusEntity, configureQueueMessagePump, configureTopicMessagePump);
 
-            ServiceBusMessageHandlerCollection collection = services.AddServiceBusMessageRouting();
+            ServiceBusMessageHandlerCollection collection = services.AddServiceBusMessageRouting(provider =>
+            {
+                var logger = provider.GetService<ILogger<AzureServiceBusMessageRouter>>();
+                return new AzureServiceBusMessageRouter(provider, options.MessageRouterOptions, logger);
+            });
+            
             services.AddHostedService(serviceProvider =>
             {
                 var logger = serviceProvider.GetRequiredService<ILogger<AzureServiceBusMessagePump>>();

--- a/src/Arcus.Messaging.Tests.Core/Generators/OrderV2Generator.cs
+++ b/src/Arcus.Messaging.Tests.Core/Generators/OrderV2Generator.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Arcus.Messaging.Tests.Core.Messages.v1;
+using Arcus.Messaging.Tests.Core.Messages.v2;
+using Bogus;
+
+namespace Arcus.Messaging.Tests.Core.Generators
+{
+    public static class OrderV2Generator
+    {
+        public static OrderV2 Generate()
+        {
+            Faker<Customer> customerGenerator = new Faker<Customer>()
+                .RuleFor(u => u.FirstName, (f, u) => f.Name.FirstName())
+                .RuleFor(u => u.LastName, (f, u) => f.Name.LastName());
+
+            Faker<OrderV2> orderGenerator = new Faker<OrderV2>()
+                .RuleFor(u => u.Customer, () => customerGenerator)
+                .RuleFor(u => u.Id, f => Guid.NewGuid().ToString())
+                .RuleFor(u => u.Amount, f => f.Random.Int())
+                .RuleFor(u => u.ArticleNumber, f => f.Commerce.Product())
+                .RuleFor(u => u.Status, f => f.Random.Int());
+
+            return orderGenerator.Generate();
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Core/Messages/v1/Shipment.cs
+++ b/src/Arcus.Messaging.Tests.Core/Messages/v1/Shipment.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Arcus.Messaging.Tests.Core.Messages.v1
+{
+    public class Shipment
+    {
+        [JsonProperty]
+        public int Code { get; set; }
+        
+        [JsonProperty]
+        public DateTimeOffset Date { get; set; }
+        
+        [JsonProperty]
+        public string Description { get; set; }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Core/Messages/v2/OrderV2.cs
+++ b/src/Arcus.Messaging.Tests.Core/Messages/v2/OrderV2.cs
@@ -1,0 +1,23 @@
+﻿using Arcus.Messaging.Tests.Core.Messages.v1;
+using Newtonsoft.Json;
+
+namespace Arcus.Messaging.Tests.Core.Messages.v2
+{
+    public class OrderV2
+    {
+        [JsonProperty]
+        public string Id { get; set; }
+
+        [JsonProperty]
+        public int Amount { get; set; }
+
+        [JsonProperty]
+        public string ArticleNumber { get; set; }
+
+        [JsonProperty]
+        public Customer Customer { get; set; }
+        
+        [JsonProperty]
+        public int Status { get; set; }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/Arcus.Messaging.Tests.Integration.csproj
+++ b/src/Arcus.Messaging.Tests.Integration/Arcus.Messaging.Tests.Integration.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="0.4.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="0.4.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.3.0" />
-    <PackageReference Include="Arcus.Testing.Logging" Version="0.2.0-preview-2" />
+    <PackageReference Include="Arcus.Testing.Logging" Version="0.2.0" />
     <PackageReference Include="Guard.Net" Version="1.2.0" />
     <PackageReference Include="Microsoft.Azure.ApplicationInsights.Query" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="2.1.0" />

--- a/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthListenerTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthListenerTests.cs
@@ -58,7 +58,7 @@ namespace Arcus.Messaging.Tests.Integration.Health
             options.Services.AddTcpHealthProbes(HealthPortConfigurationName, 
                 configureHealthChecks: builder => builder.AddCheck("unhealhty", () => HealthCheckResult.Unhealthy()),
                 configureTcpListenerOptions: opt => opt.RejectTcpConnectionWhenUnhealthy = true,
-                configureHealthCheckPublisherOptions: opt => opt.Delay = TimeSpan.Zero);
+                configureHealthCheckPublisherOptions: opt => opt.Period = TimeSpan.FromSeconds(3));
             
             // Act
             await using (var worker = await Worker.StartNewAsync(options))

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -254,7 +254,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                    .AddServiceBusQueueMessagePump(
                        configuration => connectionString, 
                        opt => opt.AutoComplete = false)
-                   .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>()
+                   .WithServiceBusMessageHandler<ShipmentAzureServiceBusMessageHandler, Shipment>()
                    .WithServiceBusFallbackMessageHandler<OrdersFallbackCompleteMessageHandler>();
             
             // Act
@@ -313,7 +313,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                    .AddServiceBusQueueMessagePump(
                         configuration => connectionString, 
                         opt => opt.AutoComplete = false)
-                   .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>()
+                   .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>((AzureServiceBusMessageContext context) => false)
                    .WithServiceBusFallbackMessageHandler<OrdersFallbackCompleteMessageHandler>();
             
             // Act
@@ -333,7 +333,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = config.GetServiceBusConnectionString(ServiceBusEntityType.Queue);
             var options = new WorkerOptions();
             options.AddEventGridPublisher(config)
-                   .AddServiceBusQueueMessagePump(configuration => connectionString, options => options.AutoComplete = true)
+                   .AddServiceBusQueueMessagePump(configuration => connectionString, opt => opt.AutoComplete = true)
                     .WithServiceBusMessageHandler<OrderBatchMessageHandler, OrderBatch>(messageBodySerializerImplementationFactory: serviceProvider =>
                     {
                         var logger = serviceProvider.GetService<ILogger<OrderBatchMessageBodySerializer>>();
@@ -358,7 +358,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             var options = new WorkerOptions();
             options.AddEventGridPublisher(config)
                    .AddServiceBusQueueMessagePump(configuration => connectionString, opt => opt.AutoComplete = true)
-                   .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>()
+                   .WithServiceBusMessageHandler<ShipmentAzureServiceBusMessageHandler, Shipment>()
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 
             // Act
@@ -498,7 +498,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = config.GetServiceBusConnectionString(ServiceBusEntityType.Queue);
             var options = new WorkerOptions();
             options.AddEventGridPublisher(config)
-                   .AddServiceBusQueueMessagePump(configuration => connectionString, options => options.AutoComplete = true)
+                   .AddServiceBusQueueMessagePump(configuration => connectionString, opt => opt.AutoComplete = true)
                    .WithServiceBusMessageHandler<PassThruOrderMessageHandler, Order>((AzureServiceBusMessageContext context) => false)
                    .WithFallbackMessageHandler<OrdersFallbackMessageHandler>();
             
@@ -518,7 +518,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = config.GetServiceBusConnectionString(ServiceBusEntityType.Queue);
             var options = new WorkerOptions();
             options.AddEventGridPublisher(config)
-                   .AddServiceBusQueueMessagePump(configuration => connectionString, options => options.AutoComplete = true)
+                   .AddServiceBusQueueMessagePump(configuration => connectionString, opt => opt.AutoComplete = true)
                    .WithServiceBusMessageHandler<PassThruOrderMessageHandler, Order>((AzureServiceBusMessageContext context) => false)
                    .WithServiceBusFallbackMessageHandler<OrdersServiceBusFallbackMessageHandler>();
 
@@ -560,10 +560,11 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             var config = TestConfig.Create();
             string connectionString = config.GetServiceBusConnectionString(ServiceBusEntityType.Queue);
             var options = new WorkerOptions();
-            options.AddServiceBusQueueMessagePump(
+            options.ConfigureLogging(_logger)
+                   .AddServiceBusQueueMessagePump(
                        configuration => connectionString, 
-                       options => options.AutoComplete = false)
-                   .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>()
+                       opt => opt.AutoComplete = false)
+                   .WithServiceBusMessageHandler<ShipmentAzureServiceBusMessageHandler, Shipment>()
                    .WithServiceBusFallbackMessageHandler<OrdersAzureServiceBusDeadLetterFallbackMessageHandler>();
             
             Order order = OrderGenerator.Generate();
@@ -637,7 +638,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                        "Test-Receive-All-Topic-Only", 
                        configuration => connectionString, 
                        opt => opt.AutoComplete = false)
-                   .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>()
+                   .WithServiceBusMessageHandler<ShipmentAzureServiceBusMessageHandler, Shipment>()
                    .WithServiceBusFallbackMessageHandler<OrdersAzureServiceBusAbandonFallbackMessageHandler>();
             
             await using (var worker = await Worker.StartNewAsync(options))

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions.MessageHandling;
 using Arcus.Messaging.Abstractions.ServiceBus;
 using Arcus.Messaging.Tests.Core.Generators;
 using Arcus.Messaging.Tests.Core.Messages.v1;
@@ -171,7 +172,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
 
             var options = new WorkerOptions();
             options.AddEventGridPublisher(config)
-                   .AddServiceBusQueueMessagePump(configuration => connectionString, opt => opt.Deserialization.IgnoreMissingMembers = true)
+                   .AddServiceBusQueueMessagePump(configuration => connectionString, opt => opt.Deserialization.AdditionalMembers = AdditionalMemberHandling.Ignore)
                    .WithServiceBusMessageHandler<OrderV2AzureServiceBusMessageHandler, OrderV2>();
 
             // Act
@@ -559,10 +560,10 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = config.GetServiceBusConnectionString(ServiceBusEntityType.Queue);
             var options = new WorkerOptions();
             options.AddServiceBusQueueMessagePump(
-                        configuration => connectionString, 
-                        options => options.AutoComplete = false)
-                    .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>()
-                    .WithServiceBusFallbackMessageHandler<OrdersAzureServiceBusDeadLetterFallbackMessageHandler>();
+                       configuration => connectionString, 
+                       options => options.AutoComplete = false)
+                   .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>()
+                   .WithServiceBusFallbackMessageHandler<OrdersAzureServiceBusDeadLetterFallbackMessageHandler>();
             
             Order order = OrderGenerator.Generate();
 

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -309,6 +309,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = config.GetServiceBusConnectionString(ServiceBusEntityType.Queue);
             var options = new WorkerOptions();
             options.AddEventGridPublisher(config)
+                   .ConfigureLogging(_logger)
                    .AddServiceBusQueueMessagePump(
                         configuration => connectionString, 
                         opt => opt.AutoComplete = false)

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -250,11 +250,12 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             var config = TestConfig.Create();
             string connectionString = config.GetServiceBusConnectionString(ServiceBusEntityType.Queue);
             var options = new WorkerOptions();
-            options.AddEventGridPublisher(config)
+            options.ConfigureLogging(_logger)
+                   .AddEventGridPublisher(config)
                    .AddServiceBusQueueMessagePump(
                        configuration => connectionString, 
                        opt => opt.AutoComplete = false)
-                   .WithServiceBusMessageHandler<ShipmentAzureServiceBusMessageHandler, Shipment>()
+                   .WithServiceBusMessageHandler<ShipmentAzureServiceBusMessageHandler, Shipment>((AzureServiceBusMessageContext context) => false)
                    .WithServiceBusFallbackMessageHandler<OrdersFallbackCompleteMessageHandler>();
             
             // Act

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -201,7 +201,6 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             {
                 var options = new WorkerOptions();
                 options.AddEventGridPublisher(config)
-                       .ConfigureLogging(_logger)
                        .AddServiceBusTopicMessagePumpUsingManagedIdentity(
                            topicName: properties.EntityPath,
                            subscriptionName: "Test-Receive-All-Topic-Only", 
@@ -250,12 +249,11 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             var config = TestConfig.Create();
             string connectionString = config.GetServiceBusConnectionString(ServiceBusEntityType.Queue);
             var options = new WorkerOptions();
-            options.ConfigureLogging(_logger)
-                   .AddEventGridPublisher(config)
+            options.AddEventGridPublisher(config)
                    .AddServiceBusQueueMessagePump(
                        configuration => connectionString, 
                        opt => opt.AutoComplete = false)
-                   .WithServiceBusMessageHandler<ShipmentAzureServiceBusMessageHandler, Shipment>((AzureServiceBusMessageContext context) => false)
+                   .WithServiceBusMessageHandler<ShipmentAzureServiceBusMessageHandler, Shipment>()
                    .WithServiceBusFallbackMessageHandler<OrdersFallbackCompleteMessageHandler>();
             
             // Act
@@ -284,7 +282,6 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             {
                 var options = new WorkerOptions();
                 options.AddEventGridPublisher(config)
-                       .ConfigureLogging(_logger)
                        .AddServiceBusQueueMessagePumpUsingManagedIdentity(
                            queueName: properties.EntityPath,
                            serviceBusNamespace: properties.FullyQualifiedNamespace,
@@ -310,11 +307,10 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = config.GetServiceBusConnectionString(ServiceBusEntityType.Queue);
             var options = new WorkerOptions();
             options.AddEventGridPublisher(config)
-                   .ConfigureLogging(_logger)
                    .AddServiceBusQueueMessagePump(
                         configuration => connectionString, 
                         opt => opt.AutoComplete = false)
-                   .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>((AzureServiceBusMessageContext context) => false)
+                   .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>()
                    .WithServiceBusFallbackMessageHandler<OrdersFallbackCompleteMessageHandler>();
             
             // Act
@@ -446,10 +442,9 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = config.GetServiceBusConnectionString(ServiceBusEntityType.Queue);
             var options = new WorkerOptions();
             options.AddEventGridPublisher(config)
-                   .ConfigureLogging(_logger)
                    .AddServiceBusQueueMessagePump(configuration => connectionString, opt => opt.AutoComplete = true)
                    .WithServiceBusMessageHandler<PassThruOrderMessageHandler, Order>(messageContextFilter: context => false)
-                   .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>(messageBodyFilter: message => false)
+                   .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>(messageBodyFilter: message => true)
                    .WithServiceBusMessageHandler<OrderBatchMessageHandler, OrderBatch>(
                        messageContextFilter: context => context != null,
                        messageBodySerializerImplementationFactory: serviceProvider =>
@@ -561,11 +556,10 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             var config = TestConfig.Create();
             string connectionString = config.GetServiceBusConnectionString(ServiceBusEntityType.Queue);
             var options = new WorkerOptions();
-            options.ConfigureLogging(_logger)
-                   .AddServiceBusQueueMessagePump(
+            options.AddServiceBusQueueMessagePump(
                        configuration => connectionString, 
                        opt => opt.AutoComplete = false)
-                   .WithServiceBusMessageHandler<ShipmentAzureServiceBusMessageHandler, Shipment>()
+                   .WithServiceBusMessageHandler<ShipmentAzureServiceBusMessageHandler, Shipment>((AzureServiceBusMessageContext context) => true)
                    .WithServiceBusFallbackMessageHandler<OrdersAzureServiceBusDeadLetterFallbackMessageHandler>();
             
             Order order = OrderGenerator.Generate();

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/TestMessagePumpService.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/TestMessagePumpService.cs
@@ -190,6 +190,10 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                                     _logger.LogInformation("Received dead lettered message in test suite");
                                     await receiver.CompleteMessageAsync(message);
                                 }
+                                else
+                                {
+                                    _logger.LogInformation("No dead lettered message received in test suite, retrying...");
+                                }
 
                                 return message;
                             });

--- a/src/Arcus.Messaging.Tests.Unit/Fixture/OrderV1AzureServiceBusMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Unit/Fixture/OrderV1AzureServiceBusMessageHandler.cs
@@ -1,0 +1,39 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Abstractions.ServiceBus;
+using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
+
+namespace Arcus.Messaging.Tests.Unit.Fixture
+{
+    /// <summary>
+    /// Represents a test Azure Service Bus message handler to process <see cref="Core.Messages.v1.Order"/> messages.
+    /// </summary>
+    public class OrderV1AzureServiceBusMessageHandler : IAzureServiceBusMessageHandler<Core.Messages.v1.Order>
+    {
+        /// <summary>
+        /// Gets the flag indicating whether or not this message handler was being used to process a message.
+        /// </summary>
+        public bool IsProcessed { get; private set; }
+
+        /// <summary>
+        ///     Process a new message that was received
+        /// </summary>
+        /// <param name="message">Message that was received</param>
+        /// <param name="messageContext">Context providing more information concerning the processing</param>
+        /// <param name="correlationInfo">
+        ///     Information concerning correlation of telemetry and processes by using a variety of unique
+        ///     identifiers
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        public Task ProcessMessageAsync(
+            Core.Messages.v1.Order message,
+            AzureServiceBusMessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            IsProcessed = true;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Unit/Fixture/OrderV1MessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Unit/Fixture/OrderV1MessageHandler.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Abstractions.MessageHandling;
+
+namespace Arcus.Messaging.Tests.Unit.Fixture
+{
+    public class OrderV1MessageHandler : IMessageHandler<Core.Messages.v1.Order>
+    {
+        /// <summary>
+        /// Gets the flag indicating whether or not this message handler was being used to process a message.
+        /// </summary>
+        public bool IsProcessed { get; private set; }
+
+        /// <summary>
+        ///     Process a new message that was received
+        /// </summary>
+        /// <param name="message">Message that was received</param>
+        /// <param name="messageContext">Context providing more information concerning the processing</param>
+        /// <param name="correlationInfo">
+        ///     Information concerning correlation of telemetry and processes by using a variety of unique
+        ///     identifiers
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        public Task ProcessMessageAsync(
+            Core.Messages.v1.Order message,
+            MessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            IsProcessed = true;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Unit/Fixture/OrderV2AzureServiceBusMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Unit/Fixture/OrderV2AzureServiceBusMessageHandler.cs
@@ -1,0 +1,40 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Abstractions.ServiceBus;
+using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
+using Arcus.Messaging.Tests.Core.Messages.v2;
+
+namespace Arcus.Messaging.Tests.Unit.Fixture
+{
+    /// <summary>
+    /// Represents a test Azure Service Bus message handler to process <see cref="OrderV2"/> messages.
+    /// </summary>
+    public class OrderV2AzureServiceBusMessageHandler : IAzureServiceBusMessageHandler<OrderV2>
+    {
+        /// <summary>
+        /// Gets the flag indicating whether or not this message handler was being used to process a message.
+        /// </summary>
+        public bool IsProcessed { get; private set; }
+
+        /// <summary>
+        ///     Process a new message that was received
+        /// </summary>
+        /// <param name="message">Message that was received</param>
+        /// <param name="messageContext">Context providing more information concerning the processing</param>
+        /// <param name="correlationInfo">
+        ///     Information concerning correlation of telemetry and processes by using a variety of unique
+        ///     identifiers
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        public Task ProcessMessageAsync(
+            OrderV2 message,
+            AzureServiceBusMessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            IsProcessed = true;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Unit/Fixture/OrderV2MessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Unit/Fixture/OrderV2MessageHandler.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Abstractions.MessageHandling;
+using Arcus.Messaging.Tests.Core.Messages.v2;
+
+namespace Arcus.Messaging.Tests.Unit.Fixture
+{
+    public class OrderV2MessageHandler : IMessageHandler<OrderV2>
+    {
+        /// <summary>
+        /// Gets the flag indicating whether or not this message handler was being used to process a message.
+        /// </summary>
+        public bool IsProcessed { get; private set; }
+
+        /// <summary>
+        ///     Process a new message that was received
+        /// </summary>
+        /// <param name="message">Message that was received</param>
+        /// <param name="messageContext">Context providing more information concerning the processing</param>
+        /// <param name="correlationInfo">
+        ///     Information concerning correlation of telemetry and processes by using a variety of unique
+        ///     identifiers
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        public Task ProcessMessageAsync(
+            OrderV2 message,
+            MessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            IsProcessed = true;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/Extensions/IServiceCollectionExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/Extensions/IServiceCollectionExtensionsTests.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
-namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
+namespace Arcus.Messaging.Tests.Unit.MessageHandling.Extensions
 {
     public class IServiceCollectionExtensionsTests
     {

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/Extensions/MessageBody.MessageHandlerCollectionExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/Extensions/MessageBody.MessageHandlerCollectionExtensionsTests.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
-namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
+namespace Arcus.Messaging.Tests.Unit.MessageHandling.Extensions
 {
     public partial class MessageHandlerCollectionExtensionsTests
     {

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/Extensions/MessageContext.MessageBody.MessageHandlerCollectionExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/Extensions/MessageContext.MessageBody.MessageHandlerCollectionExtensionsTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
-namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
+namespace Arcus.Messaging.Tests.Unit.MessageHandling.Extensions
 {
     public partial class MessageHandlerCollectionExtensionsTests
     {

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/Extensions/MessageContext.MessageHandlerCollectionExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/Extensions/MessageContext.MessageHandlerCollectionExtensionsTests.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
-namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
+namespace Arcus.Messaging.Tests.Unit.MessageHandling.Extensions
 {
     public partial class MessageHandlerCollectionExtensionsTests
     {

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/Extensions/MessageContext.MessageSerializer.MessageHandlerCollectionExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/Extensions/MessageContext.MessageSerializer.MessageHandlerCollectionExtensionsTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 using ArgumentException = System.ArgumentException;
 
-namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
+namespace Arcus.Messaging.Tests.Unit.MessageHandling.Extensions
 {
     public partial class MessageHandlerCollectionExtensionsTests
     {

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/Extensions/MessageHandlerCollectionExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/Extensions/MessageHandlerCollectionExtensionsTests.cs
@@ -4,7 +4,7 @@ using Arcus.Messaging.Tests.Unit.Fixture;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
-namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
+namespace Arcus.Messaging.Tests.Unit.MessageHandling.Extensions
 {
     public partial class MessageHandlerCollectionExtensionsTests
     {

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/Extensions/MessageSerializer.MessageBody.MessageHandlerCollectionExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/Extensions/MessageSerializer.MessageBody.MessageHandlerCollectionExtensionsTests.cs
@@ -1,59 +1,51 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.MessageHandling;
 using Arcus.Messaging.Tests.Unit.Fixture;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
-namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
+namespace Arcus.Messaging.Tests.Unit.MessageHandling.Extensions
 {
     public partial class MessageHandlerCollectionExtensionsTests
     {
         [Theory]
-        [InlineData(false, false)]
-        [InlineData(false, true)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
-        public async Task WithMessageHandlerDefaultContext_WithContextFilterWithMessageBodySerializerMessageBodyFilter_UsesFilter(bool matchesContext, bool matchesBody)
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task WithMessageHandlerWithDefaultContext_WithMessageBodySerializerWithMessageBodyFilter_UsesSerializer(bool matches)
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
             var expectedBody = $"test-message-body-{Guid.NewGuid()}";
             var expectedMessage = new TestMessage();
-            var expectedContext = new MessageContext("message-id", new Dictionary<string, object>());
             var serializer = new TestMessageBodySerializer(expectedBody, expectedMessage);
 
             // Act
             services.WithMessageHandler<DefaultTestMessageHandler, TestMessage>(
-                messageContextFilter: context =>
-                {
-                    Assert.Same(expectedContext, context);
-                    return matchesContext;
-                },
                 messageBodySerializer: serializer,
                 messageBodyFilter: body =>
                 {
                     Assert.Same(expectedMessage, body);
-                    return matchesBody;
+                    return matches;
                 });
 
             // Assert
             IServiceProvider provider = services.Services.BuildServiceProvider();
             IEnumerable<MessageHandler> handlers = MessageHandler.SubtractFrom(provider, NullLogger.Instance);
+            Assert.NotNull(handlers);
             MessageHandler handler = Assert.Single(handlers);
             Assert.NotNull(handler);
-            Assert.Equal(matchesBody, handler.CanProcessMessageBasedOnMessage(expectedMessage));
-            Assert.Equal(matchesContext, handler.CanProcessMessageBasedOnContext(expectedContext));
+            bool actual = handler.CanProcessMessageBasedOnMessage(expectedMessage);
+            Assert.Equal(matches, actual);
             MessageResult result = await handler.TryCustomDeserializeMessageAsync(expectedBody);
             Assert.NotNull(result);
             Assert.Same(expectedMessage, result.DeserializedMessage);
         }
 
         [Fact]
-        public void WithMessageHandlerDefaultContext_WithoutContextFilterWithMessageBodySerializerWithMessageBodyFilter_Fails()
+        public void WithMessageHandlerWithDefaultContext_WithoutMessageBodySerializerWithMessageBodyFilter_Fails()
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
@@ -61,27 +53,12 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => services.WithMessageHandler<DefaultTestMessageHandler, TestMessage>(
-                    messageContextFilter: null,
-                    messageBodySerializer: new TestMessageBodySerializer(),
-                    messageBodyFilter: body => true));
-        }
-
-        [Fact]
-        public void WithMessageHandlerDefaultContext_WithContextFilterWithoutMessageBodySerializerWithMessageBodyFilter_Fails()
-        {
-            // Arrange
-            var services = new MessageHandlerCollection(new ServiceCollection());
-
-            // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(
-                () => services.WithMessageHandler<DefaultTestMessageHandler, TestMessage>(
-                    messageContextFilter: context => true,
                     messageBodySerializer: null,
                     messageBodyFilter: body => true));
         }
 
         [Fact]
-        public void WithMessageHandlerDefaultContext_WithContextFilterWithMessageBodySerializerWithoutMessageBodyFilter_Fails()
+        public void WithMessageHandlerWithDefaultContext_WithMessageBodySerializerWithoutMessageBodyFilter_Fails()
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
@@ -89,53 +66,45 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => services.WithMessageHandler<DefaultTestMessageHandler, TestMessage>(
-                    messageContextFilter: context => false,
                     messageBodySerializer: new TestMessageBodySerializer(),
                     messageBodyFilter: null));
         }
 
         [Theory]
-        [InlineData(false, false)]
-        [InlineData(false, true)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
-        public async Task WithMessageHandlerDefaultContext_WithContextFilterWithMessageBodySerializerImplementationFactoryMessageBodyFilter_UsesFilter(bool matchesContext, bool matchesBody)
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task WithMessageHandlerWithDefaultContext_WithMessageBodySerializerImplementationFactoryWithMessageBodyFilter_UsesSerializer(bool matches)
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
             var expectedBody = $"test-message-body-{Guid.NewGuid()}";
             var expectedMessage = new TestMessage();
-            var expectedContext = new MessageContext("message-id", new Dictionary<string, object>());
             var serializer = new TestMessageBodySerializer(expectedBody, expectedMessage);
 
             // Act
             services.WithMessageHandler<DefaultTestMessageHandler, TestMessage>(
-                messageContextFilter: context =>
-                {
-                    Assert.Same(expectedContext, context);
-                    return matchesContext;
-                },
                 messageBodySerializerImplementationFactory: serviceProvider => serializer,
                 messageBodyFilter: body =>
                 {
                     Assert.Same(expectedMessage, body);
-                    return matchesBody;
+                    return matches;
                 });
 
             // Assert
             IServiceProvider provider = services.Services.BuildServiceProvider();
             IEnumerable<MessageHandler> handlers = MessageHandler.SubtractFrom(provider, NullLogger.Instance);
+            Assert.NotNull(handlers);
             MessageHandler handler = Assert.Single(handlers);
             Assert.NotNull(handler);
-            Assert.Equal(matchesBody, handler.CanProcessMessageBasedOnMessage(expectedMessage));
-            Assert.Equal(matchesContext, handler.CanProcessMessageBasedOnContext(expectedContext));
+            bool actual = handler.CanProcessMessageBasedOnMessage(expectedMessage);
+            Assert.Equal(matches, actual);
             MessageResult result = await handler.TryCustomDeserializeMessageAsync(expectedBody);
             Assert.NotNull(result);
             Assert.Same(expectedMessage, result.DeserializedMessage);
         }
 
         [Fact]
-        public void WithMessageHandlerDefaultContext_WithoutContextFilterWithMessageBodySerializerImplementationFactoryWithMessageBodyFilter_Fails()
+        public void WithMessageHandlerWithDefaultContext_WithoutMessageBodySerializerImplementationFactoryWithMessageBodyFilter_Fails()
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
@@ -143,27 +112,12 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => services.WithMessageHandler<DefaultTestMessageHandler, TestMessage>(
-                    messageContextFilter: null,
-                    messageBodySerializerImplementationFactory: serviceProvider => new TestMessageBodySerializer(),
-                    messageBodyFilter: body => true));
-        }
-
-        [Fact]
-        public void WithMessageHandlerDefaultContext_WithContextFilterWithoutMessageBodySerializerImplementationFactoryWithMessageBodyFilter_Fails()
-        {
-            // Arrange
-            var services = new MessageHandlerCollection(new ServiceCollection());
-
-            // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(
-                () => services.WithMessageHandler<DefaultTestMessageHandler, TestMessage>(
-                    messageContextFilter: context => true,
                     messageBodySerializerImplementationFactory: null,
                     messageBodyFilter: body => true));
         }
 
         [Fact]
-        public void WithMessageHandlerDefaultContext_WithContextFilterWithMessageBodySerializerImplementationFactoryWithoutMessageBodyFilter_Fails()
+        public void WithMessageHandlerWithDefaultContext_WithMessageBodySerializerImplementationFactoryWithoutMessageBodyFilter_Fails()
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
@@ -171,53 +125,45 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => services.WithMessageHandler<DefaultTestMessageHandler, TestMessage>(
-                    messageContextFilter: context => false,
                     messageBodySerializerImplementationFactory: serviceProvider => new TestMessageBodySerializer(),
                     messageBodyFilter: null));
         }
 
         [Theory]
-        [InlineData(false, false)]
-        [InlineData(false, true)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
-        public async Task WithMessageHandlerCustomContext_WithContextFilterWithMessageBodySerializerWithMessageBodyFilter_UsesFilter(bool matchesContext, bool matchesBody)
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task WithMessageHandlerWithCustomContext_WithMessageBodySerializerWithMessageBodyFilter_UsesSerializer(bool matches)
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
             var expectedBody = $"test-message-body-{Guid.NewGuid()}";
             var expectedMessage = new TestMessage();
-            var expectedContext = TestMessageContext.Generate();
             var serializer = new TestMessageBodySerializer(expectedBody, expectedMessage);
 
             // Act
             services.WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(
-                messageContextFilter: context =>
-                {
-                    Assert.Same(expectedContext, context);
-                    return matchesContext;
-                },
                 messageBodySerializer: serializer,
                 messageBodyFilter: body =>
                 {
                     Assert.Same(expectedMessage, body);
-                    return matchesBody;
+                    return matches;
                 });
 
             // Assert
             IServiceProvider provider = services.Services.BuildServiceProvider();
             IEnumerable<MessageHandler> handlers = MessageHandler.SubtractFrom(provider, NullLogger.Instance);
+            Assert.NotNull(handlers);
             MessageHandler handler = Assert.Single(handlers);
             Assert.NotNull(handler);
-            Assert.Equal(matchesBody, handler.CanProcessMessageBasedOnMessage(expectedMessage));
-            Assert.Equal(matchesContext, handler.CanProcessMessageBasedOnContext(expectedContext));
+            bool actual = handler.CanProcessMessageBasedOnMessage(expectedMessage);
+            Assert.Equal(matches, actual);
             MessageResult result = await handler.TryCustomDeserializeMessageAsync(expectedBody);
             Assert.NotNull(result);
             Assert.Same(expectedMessage, result.DeserializedMessage);
         }
 
         [Fact]
-        public void WithMessageHandlerCustomContext_WithoutContextFilterWithMessageBodySerializerWithMessageBodyFilter_Fails()
+        public void WithMessageHandlerWithCustomContext_WithoutMessageBodySerializerWithMessageBodyFilter_Fails()
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
@@ -225,27 +171,12 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => services.WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(
-                    messageContextFilter: null,
-                    messageBodySerializer: new TestMessageBodySerializer(),
-                    messageBodyFilter: body => true));
-        }
-
-        [Fact]
-        public void WithMessageHandlerCustomContext_WithContextFilterWithoutMessageBodySerializerWithMessageBodyFilter_Fails()
-        {
-            // Arrange
-            var services = new MessageHandlerCollection(new ServiceCollection());
-
-            // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(
-                () => services.WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(
-                    messageContextFilter: context => true,
                     messageBodySerializer: null,
                     messageBodyFilter: body => true));
         }
 
         [Fact]
-        public void WithMessageHandlerCustomContext_WithContextFilterWithMessageBodySerializerWithoutMessageBodyFilter_Fails()
+        public void WithMessageHandlerWithCustomContext_WithMessageBodySerializerWithoutMessageBodyFilter_Fails()
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
@@ -253,53 +184,45 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => services.WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(
-                    messageContextFilter: context => false,
                     messageBodySerializer: new TestMessageBodySerializer(),
                     messageBodyFilter: null));
         }
 
-        [Theory]
-        [InlineData(false, false)]
-        [InlineData(false, true)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
-        public async Task WithMessageHandlerCustomContext_WithContextFilterWithMessageBodySerializerImplementationFactoryWithMessageBodyFilter_UsesFilter(bool matchesContext, bool matchesBody)
+         [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task WithMessageHandlerWithCustomContext_WithMessageBodySerializerImplementationFactoryWithMessageBodyFilter_UsesSerializer(bool matches)
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
             var expectedBody = $"test-message-body-{Guid.NewGuid()}";
             var expectedMessage = new TestMessage();
-            var expectedContext = TestMessageContext.Generate();
             var serializer = new TestMessageBodySerializer(expectedBody, expectedMessage);
 
             // Act
             services.WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(
-                messageContextFilter: context =>
-                {
-                    Assert.Same(expectedContext, context);
-                    return matchesContext;
-                },
                 messageBodySerializerImplementationFactory: serviceProvider => serializer,
                 messageBodyFilter: body =>
                 {
                     Assert.Same(expectedMessage, body);
-                    return matchesBody;
+                    return matches;
                 });
 
             // Assert
             IServiceProvider provider = services.Services.BuildServiceProvider();
             IEnumerable<MessageHandler> handlers = MessageHandler.SubtractFrom(provider, NullLogger.Instance);
+            Assert.NotNull(handlers);
             MessageHandler handler = Assert.Single(handlers);
             Assert.NotNull(handler);
-            Assert.Equal(matchesBody, handler.CanProcessMessageBasedOnMessage(expectedMessage));
-            Assert.Equal(matchesContext, handler.CanProcessMessageBasedOnContext(expectedContext));
+            bool actual = handler.CanProcessMessageBasedOnMessage(expectedMessage);
+            Assert.Equal(matches, actual);
             MessageResult result = await handler.TryCustomDeserializeMessageAsync(expectedBody);
             Assert.NotNull(result);
             Assert.Same(expectedMessage, result.DeserializedMessage);
         }
 
         [Fact]
-        public void WithMessageHandlerCustomContext_WithoutContextFilterWithMessageBodySerializerImplementationFactoryWithMessageBodyFilter_Fails()
+        public void WithMessageHandlerWithCustomContext_WithoutMessageBodySerializerImplementationFactoryWithMessageBodyFilter_Fails()
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
@@ -307,27 +230,12 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => services.WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(
-                    messageContextFilter: null,
-                    messageBodySerializerImplementationFactory: serviceProvider => new TestMessageBodySerializer(),
-                    messageBodyFilter: body => true));
-        }
-
-        [Fact]
-        public void WithMessageHandlerCustomContext_WithContextFilterWithoutMessageBodySerializerImplementationFactoryWithMessageBodyFilter_Fails()
-        {
-            // Arrange
-            var services = new MessageHandlerCollection(new ServiceCollection());
-
-            // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(
-                () => services.WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(
-                    messageContextFilter: context => true,
                     messageBodySerializerImplementationFactory: null,
                     messageBodyFilter: body => true));
         }
 
         [Fact]
-        public void WithMessageHandlerCustomContext_WithContextFilterWithMessageBodySerializerImplementationFactoryWithoutMessageBodyFilter_Fails()
+        public void WithMessageHandlerWithCustomContext_WithMessageBodySerializerImplementationFactoryWithoutMessageBodyFilter_Fails()
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
@@ -335,56 +243,48 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => services.WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(
-                    messageContextFilter: context => false,
                     messageBodySerializerImplementationFactory: serviceProvider => new TestMessageBodySerializer(),
                     messageBodyFilter: null));
         }
 
         [Theory]
-        [InlineData(false, false)]
-        [InlineData(false, true)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
-        public async Task WithMessageHandlerDefaultContext_WithContextFilterWithMessageBodySerializerWithMessageBodyFilterWithMessageHandlerImplementationFactory_UsesFilter(bool matchesContext, bool matchesBody)
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task WithMessageHandlerWithDefaultContext_WithMessageBodySerializerWithMessageBodyFilterWithMessageHandlerImplementationFactory_UsesSerializer(bool matches)
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
             var expectedBody = $"test-message-body-{Guid.NewGuid()}";
             var expectedMessage = new TestMessage();
-            var expectedContext = new MessageContext("message-id", new Dictionary<string, object>());
             var serializer = new TestMessageBodySerializer(expectedBody, expectedMessage);
             var expectedHandler = new DefaultTestMessageHandler();
 
             // Act
             services.WithMessageHandler<DefaultTestMessageHandler, TestMessage>(
-                messageContextFilter: context =>
-                {
-                    Assert.Same(expectedContext, context);
-                    return matchesContext;
-                },
                 messageBodySerializer: serializer,
                 messageBodyFilter: body =>
                 {
                     Assert.Same(expectedMessage, body);
-                    return matchesBody;
+                    return matches;
                 },
                 implementationFactory: serviceProvider => expectedHandler);
 
             // Assert
             IServiceProvider provider = services.Services.BuildServiceProvider();
             IEnumerable<MessageHandler> handlers = MessageHandler.SubtractFrom(provider, NullLogger.Instance);
+            Assert.NotNull(handlers);
             MessageHandler handler = Assert.Single(handlers);
             Assert.NotNull(handler);
             Assert.Same(expectedHandler, handler.GetMessageHandlerInstance());
-            Assert.Equal(matchesBody, handler.CanProcessMessageBasedOnMessage(expectedMessage));
-            Assert.Equal(matchesContext, handler.CanProcessMessageBasedOnContext(expectedContext));
+            bool actual = handler.CanProcessMessageBasedOnMessage(expectedMessage);
+            Assert.Equal(matches, actual);
             MessageResult result = await handler.TryCustomDeserializeMessageAsync(expectedBody);
             Assert.NotNull(result);
             Assert.Same(expectedMessage, result.DeserializedMessage);
         }
 
         [Fact]
-        public void WithMessageHandlerDefaultContext_WithoutContextFilterWithMessageBodySerializerWithMessageBodyFilterWithMessageHandlerImplementationFactory_Fails()
+        public void WithMessageHandlerWithDefaultContext_WithoutMessageBodySerializerWithMessageBodyFilterWithMessageHandlerImplementationFactory_Fails()
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
@@ -392,29 +292,13 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => services.WithMessageHandler<DefaultTestMessageHandler, TestMessage>(
-                    messageContextFilter: null,
-                    messageBodySerializer: new TestMessageBodySerializer(),
-                    messageBodyFilter: body => true,
-                    implementationFactory: serviceProvider => new DefaultTestMessageHandler()));
-        }
-
-        [Fact]
-        public void WithMessageHandlerDefaultContext_WithContextFilterWithoutMessageBodySerializerWithMessageBodyFilterWithMessageHandlerImplementationFactory_Fails()
-        {
-            // Arrange
-            var services = new MessageHandlerCollection(new ServiceCollection());
-
-            // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(
-                () => services.WithMessageHandler<DefaultTestMessageHandler, TestMessage>(
-                    messageContextFilter: context => true,
                     messageBodySerializer: null,
                     messageBodyFilter: body => true,
                     implementationFactory: serviceProvider => new DefaultTestMessageHandler()));
         }
 
         [Fact]
-        public void WithMessageHandlerDefaultContext_WithContextFilterWithMessageBodySerializerWithoutMessageBodyFilterWithMessageHandlerImplementationFactory_Fails()
+        public void WithMessageHandlerWithDefaultContext_WithMessageBodySerializerWithoutMessageBodyFilterWithMessageHandlerImplementationFactory_Fails()
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
@@ -422,14 +306,13 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => services.WithMessageHandler<DefaultTestMessageHandler, TestMessage>(
-                    messageContextFilter: context => true,
                     messageBodySerializer: new TestMessageBodySerializer(),
                     messageBodyFilter: null,
                     implementationFactory: serviceProvider => new DefaultTestMessageHandler()));
         }
 
         [Fact]
-        public void WithMessageHandlerDefaultContext_WithoutContextFilterWithMessageBodySerializerWithMessageBodyFilterWithoutMessageHandlerImplementationFactory_Fails()
+        public void WithMessageHandlerWithDefaultContext_WithMessageBodySerializerWithMessageBodyFilterWithoutMessageHandlerImplementationFactory_Fails()
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
@@ -437,57 +320,49 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => services.WithMessageHandler<DefaultTestMessageHandler, TestMessage>(
-                    messageContextFilter: context => false,
                     messageBodySerializer: new TestMessageBodySerializer(),
-                    messageBodyFilter: body => true,
+                    messageBodyFilter: body => false,
                     implementationFactory: null));
         }
 
         [Theory]
-        [InlineData(false, false)]
-        [InlineData(false, true)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
-        public async Task WithMessageHandlerDefaultContext_WithContextFilterWithMessageBodySerializerImplementationFactoryWithMessageBodyFilterWithMessageHandlerImplementationFactory_UsesFilter(bool matchesContext, bool matchesBody)
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task WithMessageHandlerWithDefaultContext_WithMessageBodySerializerImplementationFactoryWithMessageBodyFilterWithMessageHandlerImplementationFactory_UsesSerializer(bool matches)
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
             var expectedBody = $"test-message-body-{Guid.NewGuid()}";
             var expectedMessage = new TestMessage();
-            var expectedContext = new MessageContext("message-id", new Dictionary<string, object>());
             var serializer = new TestMessageBodySerializer(expectedBody, expectedMessage);
-            var expectedHandler = new DefaultTestMessageHandler();
+            var expectedHanlder = new DefaultTestMessageHandler();
 
             // Act
             services.WithMessageHandler<DefaultTestMessageHandler, TestMessage>(
-                messageContextFilter: context =>
-                {
-                    Assert.Same(expectedContext, context);
-                    return matchesContext;
-                },
                 messageBodySerializerImplementationFactory: serviceProvider => serializer,
                 messageBodyFilter: body =>
                 {
                     Assert.Same(expectedMessage, body);
-                    return matchesBody;
+                    return matches;
                 },
-                messageHandlerImplementationFactory: serviceProvider => expectedHandler);
+                messageHandlerImplementationFactory: serviceProvider => expectedHanlder);
 
             // Assert
             IServiceProvider provider = services.Services.BuildServiceProvider();
             IEnumerable<MessageHandler> handlers = MessageHandler.SubtractFrom(provider, NullLogger.Instance);
+            Assert.NotNull(handlers);
             MessageHandler handler = Assert.Single(handlers);
             Assert.NotNull(handler);
-            Assert.Same(expectedHandler, handler.GetMessageHandlerInstance());
-            Assert.Equal(matchesBody, handler.CanProcessMessageBasedOnMessage(expectedMessage));
-            Assert.Equal(matchesContext, handler.CanProcessMessageBasedOnContext(expectedContext));
+            Assert.Same(expectedHanlder, handler.GetMessageHandlerInstance());
+            bool actual = handler.CanProcessMessageBasedOnMessage(expectedMessage);
+            Assert.Equal(matches, actual);
             MessageResult result = await handler.TryCustomDeserializeMessageAsync(expectedBody);
             Assert.NotNull(result);
             Assert.Same(expectedMessage, result.DeserializedMessage);
         }
 
         [Fact]
-        public void WithMessageHandlerDefaultContext_WithoutContextFilterWithMessageBodySerializerImplementationFactoryWithMessageBodyFilterWithMessageHandlerImplementationFactory_Fails()
+        public void WithMessageHandlerWithDefaultContext_WithoutMessageBodySerializerImplementationFactoryWithMessageBodyFilterWithMessageHandlerImplementationFactory_Fails()
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
@@ -495,29 +370,13 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => services.WithMessageHandler<DefaultTestMessageHandler, TestMessage>(
-                    messageContextFilter: null,
-                    messageBodySerializerImplementationFactory: serviceProvider => new TestMessageBodySerializer(),
-                    messageBodyFilter: body => true,
-                    messageHandlerImplementationFactory: serviceProvider => new DefaultTestMessageHandler()));
-        }
-
-        [Fact]
-        public void WithMessageHandlerDefaultContext_WithContextFilterWithoutMessageBodySerializerImplementationFactoryWithMessageBodyFilterWithMessageHandlerImplementationFactory_Fails()
-        {
-            // Arrange
-            var services = new MessageHandlerCollection(new ServiceCollection());
-
-            // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(
-                () => services.WithMessageHandler<DefaultTestMessageHandler, TestMessage>(
-                    messageContextFilter: context => false,
                     messageBodySerializerImplementationFactory: null,
                     messageBodyFilter: body => true,
                     messageHandlerImplementationFactory: serviceProvider => new DefaultTestMessageHandler()));
         }
 
         [Fact]
-        public void WithMessageHandlerDefaultContext_WithContextFilterWithMessageBodySerializerImplementationFactoryWithoutMessageBodyFilterWithMessageHandlerImplementationFactory_Fails()
+        public void WithMessageHandlerWithDefaultContext_WithMessageBodySerializerImplementationFactoryWithoutMessageBodyFilterWithMessageHandlerImplementationFactory_Fails()
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
@@ -525,14 +384,13 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => services.WithMessageHandler<DefaultTestMessageHandler, TestMessage>(
-                    messageContextFilter: context => false,
                     messageBodySerializerImplementationFactory: serviceProvider => new TestMessageBodySerializer(),
                     messageBodyFilter: null,
                     messageHandlerImplementationFactory: serviceProvider => new DefaultTestMessageHandler()));
         }
 
         [Fact]
-        public void WithMessageHandlerDefaultContext_WithContextFilterWithMessageBodySerializerImplementationFactoryWithMessageBodyFilterWithoutMessageHandlerImplementationFactory_Fails()
+        public void WithMessageHandlerWithDefaultContext_WithMessageBodySerializerImplementationFactoryWithMessageBodyFilterWithoutMessageHandlerImplementationFactory_Fails()
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
@@ -540,57 +398,49 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => services.WithMessageHandler<DefaultTestMessageHandler, TestMessage>(
-                    messageContextFilter: context => false,
                     messageBodySerializerImplementationFactory: serviceProvider => new TestMessageBodySerializer(),
-                    messageBodyFilter: body => true,
+                    messageBodyFilter: body => false,
                     messageHandlerImplementationFactory: null));
         }
 
         [Theory]
-        [InlineData(false, false)]
-        [InlineData(false, true)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
-        public async Task WithMessageHandlerCustomContext_WithContextFilterWithMessageBodySerializerWithMessageBodyFilterWithMessageHandlerImplementationFactory_UsesFilter(bool matchesContext, bool matchesBody)
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task WithMessageHandlerWithCustomContext_WithMessageBodySerializerWithMessageBodyFilterWithMessageHandlerImplementationFactory_UsesSerializer(bool matches)
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
             var expectedBody = $"test-message-body-{Guid.NewGuid()}";
             var expectedMessage = new TestMessage();
-            var expectedContext = TestMessageContext.Generate();
             var serializer = new TestMessageBodySerializer(expectedBody, expectedMessage);
             var expectedHandler = new TestMessageHandler();
 
             // Act
             services.WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(
-                messageContextFilter: context =>
-                {
-                    Assert.Same(expectedContext, context);
-                    return matchesContext;
-                },
                 messageBodySerializer: serializer,
                 messageBodyFilter: body =>
                 {
                     Assert.Same(expectedMessage, body);
-                    return matchesBody;
+                    return matches;
                 },
                 implementationFactory: serviceProvider => expectedHandler);
 
             // Assert
             IServiceProvider provider = services.Services.BuildServiceProvider();
             IEnumerable<MessageHandler> handlers = MessageHandler.SubtractFrom(provider, NullLogger.Instance);
+            Assert.NotNull(handlers);
             MessageHandler handler = Assert.Single(handlers);
             Assert.NotNull(handler);
             Assert.Same(expectedHandler, handler.GetMessageHandlerInstance());
-            Assert.Equal(matchesBody, handler.CanProcessMessageBasedOnMessage(expectedMessage));
-            Assert.Equal(matchesContext, handler.CanProcessMessageBasedOnContext(expectedContext));
+            bool actual = handler.CanProcessMessageBasedOnMessage(expectedMessage);
+            Assert.Equal(matches, actual);
             MessageResult result = await handler.TryCustomDeserializeMessageAsync(expectedBody);
             Assert.NotNull(result);
             Assert.Same(expectedMessage, result.DeserializedMessage);
         }
 
         [Fact]
-        public void WithMessageHandlerCustomContext_WithoutContextFilterWithMessageBodySerializerWithMessageBodyFilterWithMessageHandlerImplementationFactory_Fails()
+        public void WithMessageHandlerWithCustomContext_WithoutMessageBodySerializerWithMessageBodyFilterWithMessageHandlerImplementationFactory_Fails()
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
@@ -598,29 +448,13 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => services.WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(
-                    messageContextFilter: null,
-                    messageBodySerializer:new TestMessageBodySerializer(),
-                    messageBodyFilter: body => true,
-                    implementationFactory: serviceProvider => new TestMessageHandler()));
-        }
-
-        [Fact]
-        public void WithMessageHandlerCustomContext_WithContextFilterWithoutMessageBodySerializerWithMessageBodyFilterWithMessageHandlerImplementationFactory_Fails()
-        {
-            // Arrange
-            var services = new MessageHandlerCollection(new ServiceCollection());
-
-            // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(
-                () => services.WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(
-                    messageContextFilter: context => false,
                     messageBodySerializer: null,
                     messageBodyFilter: body => true,
                     implementationFactory: serviceProvider => new TestMessageHandler()));
         }
 
         [Fact]
-        public void WithMessageHandlerCustomContext_WithContextFilterWithMessageBodySerializerWithoutMessageBodyFilterWithMessageHandlerImplementationFactory_Fails()
+        public void WithMessageHandlerWithCustomContext_WithMessageBodySerializerWithoutMessageBodyFilterWithMessageHandlerImplementationFactory_Fails()
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
@@ -628,14 +462,13 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => services.WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(
-                    messageContextFilter: context => false,
-                    messageBodySerializer:new TestMessageBodySerializer(),
+                    messageBodySerializer: new TestMessageBodySerializer(),
                     messageBodyFilter: null,
                     implementationFactory: serviceProvider => new TestMessageHandler()));
         }
 
         [Fact]
-        public void WithMessageHandlerCustomContext_WithContextFilterWithMessageBodySerializerWithMessageBodyFilterWithoutMessageHandlerImplementationFactory_Fails()
+        public void WithMessageHandlerWithCustomContext_WithMessageBodySerializerWithMessageBodyFilterWithoutMessageHandlerImplementationFactory_Fails()
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
@@ -643,57 +476,49 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => services.WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(
-                    messageContextFilter: context => false,
-                    messageBodySerializer:new TestMessageBodySerializer(),
-                    messageBodyFilter: body => true,
+                    messageBodySerializer: new TestMessageBodySerializer(),
+                    messageBodyFilter: body => false,
                     implementationFactory: null));
         }
 
-        [Theory]
-        [InlineData(false, false)]
-        [InlineData(false, true)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
-        public async Task WithMessageHandlerCustomContext_WithContextFilterWithMessageBodySerializerImplementationFactoryWithMessageBodyFilterWithMessageHandlerImplementationFactory_UsesFilter(bool matchesContext, bool matchesBody)
+         [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task WithMessageHandlerWithCustomContext_WithMessageBodySerializerImplementationFactoryWithMessageBodyFilterWithMessageHandlerImplementationFactory_UsesSerializer(bool matches)
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
             var expectedBody = $"test-message-body-{Guid.NewGuid()}";
             var expectedMessage = new TestMessage();
-            var expectedContext = TestMessageContext.Generate();
             var serializer = new TestMessageBodySerializer(expectedBody, expectedMessage);
             var expectedHandler = new TestMessageHandler();
 
             // Act
             services.WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(
-                messageContextFilter: context =>
-                {
-                    Assert.Same(expectedContext, context);
-                    return matchesContext;
-                },
                 messageBodySerializerImplementationFactory: serviceProvider => serializer,
                 messageBodyFilter: body =>
                 {
                     Assert.Same(expectedMessage, body);
-                    return matchesBody;
+                    return matches;
                 },
                 messageHandlerImplementationFactory: serviceProvider => expectedHandler);
 
             // Assert
             IServiceProvider provider = services.Services.BuildServiceProvider();
             IEnumerable<MessageHandler> handlers = MessageHandler.SubtractFrom(provider, NullLogger.Instance);
+            Assert.NotNull(handlers);
             MessageHandler handler = Assert.Single(handlers);
             Assert.NotNull(handler);
             Assert.Same(expectedHandler, handler.GetMessageHandlerInstance());
-            Assert.Equal(matchesBody, handler.CanProcessMessageBasedOnMessage(expectedMessage));
-            Assert.Equal(matchesContext, handler.CanProcessMessageBasedOnContext(expectedContext));
+            bool actual = handler.CanProcessMessageBasedOnMessage(expectedMessage);
+            Assert.Equal(matches, actual);
             MessageResult result = await handler.TryCustomDeserializeMessageAsync(expectedBody);
             Assert.NotNull(result);
             Assert.Same(expectedMessage, result.DeserializedMessage);
         }
 
         [Fact]
-        public void WithMessageHandlerCustomContext_WithoutContextFilterWithMessageBodySerializerImplementationFactoryWithMessageBodyFilterWithMessageHandlerImplementationFactory_Fails()
+        public void WithMessageHandlerWithCustomContext_WithoutMessageBodySerializerImplementationFactoryWithMessageBodyFilterWithMessageHandlerImplementationFactory_Fails()
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
@@ -701,29 +526,13 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => services.WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(
-                    messageContextFilter: null,
-                    messageBodySerializerImplementationFactory: serviceProvider => new TestMessageBodySerializer(),
-                    messageBodyFilter: body => true,
-                    messageHandlerImplementationFactory: serviceProvider => new TestMessageHandler()));
-        }
-
-        [Fact]
-        public void WithMessageHandlerCustomContext_WithContextFilterWithoutMessageBodySerializerImplementationFactoryWithMessageBodyFilterWithMessageHandlerImplementationFactory_Fails()
-        {
-            // Arrange
-            var services = new MessageHandlerCollection(new ServiceCollection());
-
-            // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(
-                () => services.WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(
-                    messageContextFilter: context => false,
                     messageBodySerializerImplementationFactory: null,
                     messageBodyFilter: body => true,
                     messageHandlerImplementationFactory: serviceProvider => new TestMessageHandler()));
         }
 
         [Fact]
-        public void WithMessageHandlerCustomContext_WithContextFilterWithMessageBodySerializerImplementationFactoryWithoutMessageBodyFilterWithMessageHandlerImplementationFactory_Fails()
+        public void WithMessageHandlerWithCustomContext_WithMessageBodySerializerImplementationFactoryWithoutMessageBodyFilterWithMessageHandlerImplementationFactory_Fails()
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
@@ -731,14 +540,13 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => services.WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(
-                    messageContextFilter: context => false,
                     messageBodySerializerImplementationFactory: serviceProvider => new TestMessageBodySerializer(),
                     messageBodyFilter: null,
                     messageHandlerImplementationFactory: serviceProvider => new TestMessageHandler()));
         }
 
         [Fact]
-        public void WithMessageHandlerCustomContext_WithContextFilterWithMessageBodySerializerImplementationFactoryWithMessageBodyFilterWithoutMessageHandlerImplementationFactory_Fails()
+        public void WithMessageHandlerWithCustomContext_WithMessageBodySerializerImplementationFactoryWithMessageBodyFilterWithoutMessageHandlerImplementationFactory_Fails()
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
@@ -746,7 +554,6 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => services.WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(
-                    messageContextFilter: context => false,
                     messageBodySerializerImplementationFactory: serviceProvider => new TestMessageBodySerializer(),
                     messageBodyFilter: body => true,
                     messageHandlerImplementationFactory: null));

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/Extensions/MessageSerializer.MessageHandlerCollectionExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/Extensions/MessageSerializer.MessageHandlerCollectionExtensionsTests.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
-namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions.Extensions
+namespace Arcus.Messaging.Tests.Unit.MessageHandling.Extensions
 {
     public partial class MessageHandlerCollectionExtensionsTests
     {

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/MessageRouterTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/MessageRouterTests.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.MessageHandling;
+using Arcus.Messaging.Tests.Core.Generators;
 using Arcus.Messaging.Tests.Core.Messages.v1;
+using Arcus.Messaging.Tests.Core.Messages.v2;
 using Arcus.Messaging.Tests.Unit.Fixture;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -13,7 +14,7 @@ using Newtonsoft.Json;
 using Xunit;
 using Order = Arcus.Messaging.Tests.Core.Messages.v1.Order;
 
-namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions
+namespace Arcus.Messaging.Tests.Unit.MessageHandling
 {
     public class MessageRouterTests
     {
@@ -28,8 +29,8 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions
             var ignoredDefaultHandler = new DefaultTestMessageHandler();
             var ignoredHandler = new TestMessageHandler();
             collection.WithMessageHandler<DefaultTestMessageHandler, TestMessage>(serviceProvider => ignoredDefaultHandler)
-                    .WithMessageHandler<StubTestMessageHandler<TestMessage, TestMessageContext>, TestMessage, TestMessageContext>(serviceProvider => spyHandler)
-                    .WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(serviceProvider => ignoredHandler);
+                      .WithMessageHandler<StubTestMessageHandler<TestMessage, TestMessageContext>, TestMessage, TestMessageContext>(serviceProvider => spyHandler)
+                      .WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(serviceProvider => ignoredHandler);
 
             // Act
             services.AddMessageRouting();
@@ -91,10 +92,10 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions
             var ignoredDefaultHandler = new DefaultTestMessageHandler();
             var ignoredHandler = new TestMessageHandler();
             collection.WithMessageHandler<DefaultTestMessageHandler, TestMessage>(serviceProvider => ignoredDefaultHandler)
-                    .WithMessageHandler<StubTestMessageHandler<TestMessage, TestMessageContext>, TestMessage, TestMessageContext>(
-                        messageContextFilter: ctx => false, implementationFactory: serviceProvider => ignoredSameTypeHandler)
-                    .WithMessageHandler<StubTestMessageHandler<TestMessage, TestMessageContext>, TestMessage, TestMessageContext>(serviceProvider => spyHandler)
-                    .WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(serviceProvider => ignoredHandler);
+                      .WithMessageHandler<StubTestMessageHandler<TestMessage, TestMessageContext>, TestMessage, TestMessageContext>(
+                          messageContextFilter: ctx => false, implementationFactory: serviceProvider => ignoredSameTypeHandler)
+                      .WithMessageHandler<StubTestMessageHandler<TestMessage, TestMessageContext>, TestMessage, TestMessageContext>(serviceProvider => spyHandler)
+                      .WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(serviceProvider => ignoredHandler);
 
             // Act
             services.AddMessageRouting();
@@ -126,10 +127,10 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions
             var ignoredDefaultHandler = new DefaultTestMessageHandler();
             var ignoredHandler = new TestMessageHandler();
             collection.WithMessageHandler<DefaultTestMessageHandler, TestMessage>(serviceProvider => ignoredDefaultHandler)
-                    .WithMessageHandler<StubTestMessageHandler<TestMessage, TestMessageContext>, TestMessage, TestMessageContext>(
-                        messageBodyFilter: body => false, implementationFactory: serviceProvider => ignoredSameTypeHandler)
-                    .WithMessageHandler<StubTestMessageHandler<TestMessage, TestMessageContext>, TestMessage, TestMessageContext>(serviceProvider => spyHandler)
-                    .WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(serviceProvider => ignoredHandler);
+                      .WithMessageHandler<StubTestMessageHandler<TestMessage, TestMessageContext>, TestMessage, TestMessageContext>(
+                          messageBodyFilter: body => false, implementationFactory: serviceProvider => ignoredSameTypeHandler)
+                      .WithMessageHandler<StubTestMessageHandler<TestMessage, TestMessageContext>, TestMessage, TestMessageContext>(serviceProvider => spyHandler)
+                      .WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(serviceProvider => ignoredHandler);
 
             // Act
             services.AddMessageRouting();
@@ -157,7 +158,7 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions
             var collection = new MessageHandlerCollection(services);
             var spyHandler = new StubTestMessageHandler<TestMessage, TestMessageContext>();
             var ignoredSameTypeHandler = new StubTestMessageHandler<TestMessage, TestMessageContext>();
-            var ignoredWrongDeserializedTypeHandler = new StubTestMessageHandler<Order, TestMessageContext>();
+            var ignoredWrongDeserializedTypeHandler = new StubTestMessageHandler<Core.Messages.v1.Order, TestMessageContext>();
             var ignoredDefaultHandler = new DefaultTestMessageHandler();
             var ignoredHandler = new TestMessageHandler();
             
@@ -166,15 +167,15 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions
             var serializer = new TestMessageBodySerializer(expectedBody, expectedMessage);
 
             collection.WithMessageHandler<DefaultTestMessageHandler, TestMessage>(serviceProvider => ignoredDefaultHandler)
-                    .WithMessageHandler<StubTestMessageHandler<Order, TestMessageContext>, Order, TestMessageContext>(
-                        messageBodySerializer: new TestMessageBodySerializer(expectedBody, new Customer()),
-                        implementationFactory: serviceProvider => ignoredWrongDeserializedTypeHandler)
-                    .WithMessageHandler<StubTestMessageHandler<TestMessage, TestMessageContext>, TestMessage, TestMessageContext>(
-                        messageContextFilter: ctx => false, implementationFactory: serviceProvider => ignoredSameTypeHandler)
-                    .WithMessageHandler<StubTestMessageHandler<TestMessage, TestMessageContext>, TestMessage, TestMessageContext>(
-                        messageBodySerializer: serializer, 
-                        implementationFactory: serviceProvider => spyHandler)
-                    .WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(serviceProvider => ignoredHandler);
+                      .WithMessageHandler<StubTestMessageHandler<Core.Messages.v1.Order, TestMessageContext>, Order, TestMessageContext>(
+                          messageBodySerializer: new TestMessageBodySerializer(expectedBody, new Customer()),
+                          implementationFactory: serviceProvider => ignoredWrongDeserializedTypeHandler)
+                      .WithMessageHandler<StubTestMessageHandler<TestMessage, TestMessageContext>, TestMessage, TestMessageContext>(
+                          messageContextFilter: ctx => false, implementationFactory: serviceProvider => ignoredSameTypeHandler)
+                      .WithMessageHandler<StubTestMessageHandler<TestMessage, TestMessageContext>, TestMessage, TestMessageContext>(
+                          messageBodySerializer: serializer, 
+                          implementationFactory: serviceProvider => spyHandler)
+                      .WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(serviceProvider => ignoredHandler);
 
             // Act
             services.AddMessageRouting();
@@ -192,6 +193,64 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.Abstractions
             Assert.False(ignoredDefaultHandler.IsProcessed);
             Assert.False(ignoredWrongDeserializedTypeHandler.IsProcessed);
             Assert.False(ignoredHandler.IsProcessed);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task WithMessageRouting_WithIgnoreMissingMembers_GoesThroughDifferentMessageHandler(bool ignoreMissingMembers)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var collection = new MessageHandlerCollection(services);
+            var messageHandlerV1 = new OrderV1MessageHandler();
+            var messageHandlerV2 = new OrderV2MessageHandler();
+
+            collection.WithMessageHandler<OrderV1MessageHandler, Order>(provider => messageHandlerV1)
+                      .WithMessageHandler<OrderV2MessageHandler, OrderV2>(provider => messageHandlerV2);
+            
+            // Act
+            services.AddMessageRouting(options => options.Deserialization.IgnoreMissingMembers = ignoreMissingMembers);
+            
+            // Assert
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+            var router = serviceProvider.GetRequiredService<IMessageRouter>();
+
+            OrderV2 order = OrderV2Generator.Generate();
+            var context = new MessageContext("message-id", new Dictionary<string, object>());
+            var correlationInfo = new MessageCorrelationInfo("operation-id", "transaction-id");
+            string json = JsonConvert.SerializeObject(order);
+
+            await router.RouteMessageAsync(json, context, correlationInfo, CancellationToken.None);
+            Assert.Equal(ignoreMissingMembers, messageHandlerV1.IsProcessed);
+            Assert.NotEqual(ignoreMissingMembers, messageHandlerV2.IsProcessed);
+        }
+        
+        [Fact]
+        public void CreateWithoutOptionsAndLogger_WithoutServiceProvider_Fails()
+        {
+            Assert.ThrowsAny<ArgumentException>(() => new MessageRouter(serviceProvider: null));
+        }
+
+        [Fact]
+        public void CreateWithoutOptions_WithoutServiceProvider_Fails()
+        {
+            Assert.ThrowsAny<ArgumentException>(() =>
+                new MessageRouter(serviceProvider: null, logger: NullLogger<MessageRouter>.Instance));
+        }
+
+        [Fact]
+        public void CreateWithoutLogger_WithoutServiceProvider_Fails()
+        {
+            Assert.ThrowsAny<ArgumentException>(
+                () => new MessageRouter(serviceProvider: null, options: new MessageRouterOptions()));
+        }
+
+        [Fact]
+        public void Create_WithoutServiceProvider_Fails()
+        {
+            Assert.ThrowsAny<ArgumentException>(
+                () => new MessageRouter(serviceProvider: null, options: new MessageRouterOptions(), logger: NullLogger<MessageRouter>.Instance));
         }
     }
 }

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/MessageRouterTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/MessageRouterTests.cs
@@ -196,9 +196,9 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task WithMessageRouting_WithIgnoreMissingMembers_GoesThroughDifferentMessageHandler(bool ignoreMissingMembers)
+        [InlineData(AdditionalMemberHandling.Ignore)]
+        [InlineData(AdditionalMemberHandling.Error)]
+        public async Task WithMessageRouting_WithIgnoreMissingMembers_GoesThroughDifferentMessageHandler(AdditionalMemberHandling additionalMemberHandling)
         {
             // Arrange
             var services = new ServiceCollection();
@@ -210,7 +210,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling
                       .WithMessageHandler<OrderV2MessageHandler, OrderV2>(provider => messageHandlerV2);
             
             // Act
-            services.AddMessageRouting(options => options.Deserialization.IgnoreMissingMembers = ignoreMissingMembers);
+            services.AddMessageRouting(options => options.Deserialization.AdditionalMembers = additionalMemberHandling);
             
             // Assert
             IServiceProvider serviceProvider = services.BuildServiceProvider();
@@ -222,8 +222,8 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling
             string json = JsonConvert.SerializeObject(order);
 
             await router.RouteMessageAsync(json, context, correlationInfo, CancellationToken.None);
-            Assert.Equal(ignoreMissingMembers, messageHandlerV1.IsProcessed);
-            Assert.NotEqual(ignoreMissingMembers, messageHandlerV2.IsProcessed);
+            Assert.Equal(additionalMemberHandling is AdditionalMemberHandling.Ignore, messageHandlerV1.IsProcessed);
+            Assert.Equal(additionalMemberHandling is AdditionalMemberHandling.Error, messageHandlerV2.IsProcessed);
         }
         
         [Fact]

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/AzureServiceBusMessageRouterTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/AzureServiceBusMessageRouterTests.cs
@@ -294,8 +294,8 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
             var correlationInfo = new MessageCorrelationInfo("operation-id", "transaction-id");
             await router.RouteMessageAsync(message, context, correlationInfo, CancellationToken.None);
             
-            Assert.Equal(additionalMemberHandling is AdditionalMemberHandling.Ignore, messageHandlerV2.IsProcessed);
-            Assert.Equal(additionalMemberHandling is AdditionalMemberHandling.Error, messageHandlerV1.IsProcessed);
+            Assert.Equal(additionalMemberHandling is AdditionalMemberHandling.Error, messageHandlerV2.IsProcessed);
+            Assert.Equal(additionalMemberHandling is AdditionalMemberHandling.Ignore, messageHandlerV1.IsProcessed);
         }
 
         [Fact]

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/AzureServiceBusMessageRouterTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/AzureServiceBusMessageRouterTests.cs
@@ -269,9 +269,9 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public async Task WithServiceBusRouting_IgnoreMissingMembers_ResultsInDifferentMessageHandler(bool ignoreMissingMembers)
+        [InlineData(AdditionalMemberHandling.Ignore)]
+        [InlineData(AdditionalMemberHandling.Error)]
+        public async Task WithServiceBusRouting_IgnoreMissingMembers_ResultsInDifferentMessageHandler(AdditionalMemberHandling additionalMemberHandling)
         {
             // Arrange
             var services = new ServiceCollection();
@@ -282,7 +282,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
                       .WithServiceBusMessageHandler<OrderV2AzureServiceBusMessageHandler, OrderV2>(provider => messageHandlerV2);
             
             // Act
-            services.AddServiceBusMessageRouting(options => options.Deserialization.IgnoreMissingMembers = ignoreMissingMembers);
+            services.AddServiceBusMessageRouting(options => options.Deserialization.AdditionalMembers = additionalMemberHandling);
             
             // Assert
             IServiceProvider serviceProvider = services.BuildServiceProvider();
@@ -294,8 +294,8 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
             var correlationInfo = new MessageCorrelationInfo("operation-id", "transaction-id");
             await router.RouteMessageAsync(message, context, correlationInfo, CancellationToken.None);
             
-            Assert.NotEqual(ignoreMissingMembers, messageHandlerV2.IsProcessed);
-            Assert.Equal(ignoreMissingMembers, messageHandlerV1.IsProcessed);
+            Assert.Equal(additionalMemberHandling is AdditionalMemberHandling.Ignore, messageHandlerV2.IsProcessed);
+            Assert.Equal(additionalMemberHandling is AdditionalMemberHandling.Error, messageHandlerV1.IsProcessed);
         }
 
         [Fact]

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/AzureServiceBusMessageRouterTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/AzureServiceBusMessageRouterTests.cs
@@ -7,8 +7,9 @@ using Arcus.Messaging.Abstractions.ServiceBus;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 using Arcus.Messaging.Tests.Core.Generators;
 using Arcus.Messaging.Tests.Core.Messages.v1;
+using Arcus.Messaging.Tests.Core.Messages.v2;
 using Arcus.Messaging.Tests.Unit.Fixture;
-using Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Stubs;
+using Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus.Stubs;
 using Azure.Messaging.ServiceBus;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -16,7 +17,7 @@ using Newtonsoft.Json;
 using Xunit;
 using Order = Arcus.Messaging.Tests.Core.Messages.v1.Order;
 
-namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus
+namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
 {
     public class AzureServiceBusMessageRouterTests
     {
@@ -29,7 +30,7 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus
             var ignoredHandler = new TestServiceBusMessageHandler();
             var spyHandler = new StubServiceBusMessageHandler<Order>();
             collection.WithServiceBusMessageHandler<StubServiceBusMessageHandler<Order>, Order>(serviceProvider => spyHandler)
-                    .WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(serviceProvider => ignoredHandler);
+                      .WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(serviceProvider => ignoredHandler);
 
             // Act
             services.AddServiceBusMessageRouting();
@@ -58,9 +59,9 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus
             var ignoredHandler = new StubServiceBusMessageHandler<Order>();
             var spyHandler = new StubServiceBusMessageHandler<Order>();
             collection.WithServiceBusMessageHandler<StubServiceBusMessageHandler<Order>, Order>(
-                        messageContextFilter: ctx => true, implementationFactory: serviceProvider => spyHandler)
-                    .WithServiceBusMessageHandler<StubServiceBusMessageHandler<Order>, Order>(
-                        messageContextFilter: ctx => false, implementationFactory: serviceProvider => ignoredHandler);
+                          messageContextFilter: ctx => true, implementationFactory: serviceProvider => spyHandler)
+                      .WithServiceBusMessageHandler<StubServiceBusMessageHandler<Order>, Order>(
+                          messageContextFilter: ctx => false, implementationFactory: serviceProvider => ignoredHandler);
 
             // Act
             services.AddServiceBusMessageRouting();
@@ -88,9 +89,9 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus
             var ignoredHandler = new StubServiceBusMessageHandler<Order>();
             var spyHandler = new StubServiceBusMessageHandler<Order>();
             collection.WithServiceBusMessageHandler<StubServiceBusMessageHandler<Order>, Order>(
-                        messageBodyFilter: body => true, implementationFactory: serviceProvider => spyHandler)
-                    .WithServiceBusMessageHandler<StubServiceBusMessageHandler<Order>, Order>(
-                        messageBodyFilter: body => false, implementationFactory: serviceProvider => ignoredHandler);
+                          messageBodyFilter: body => true, implementationFactory: serviceProvider => spyHandler)
+                      .WithServiceBusMessageHandler<StubServiceBusMessageHandler<Order>, Order>(
+                          messageBodyFilter: body => false, implementationFactory: serviceProvider => ignoredHandler);
 
             // Act
             services.AddServiceBusMessageRouting();
@@ -118,7 +119,7 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus
             var ignoredHandler = new StubServiceBusMessageHandler<Order>();
             var spyHandler = new StubServiceBusMessageHandler<Order>();
             collection.WithServiceBusMessageHandler<StubServiceBusMessageHandler<Order>, Order>(implementationFactory: serviceProvider => spyHandler)
-                    .WithServiceBusMessageHandler<StubServiceBusMessageHandler<Order>, Order>(messageBodyFilter: body => true, implementationFactory: serviceProvider => ignoredHandler);
+                      .WithServiceBusMessageHandler<StubServiceBusMessageHandler<Order>, Order>(messageBodyFilter: body => true, implementationFactory: serviceProvider => ignoredHandler);
 
             // Act
             services.AddServiceBusMessageRouting();
@@ -150,7 +151,7 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus
             string expectedBody = JsonConvert.SerializeObject(expectedMessage);
             var serializer = new TestMessageBodySerializer(expectedBody, OrderGenerator.Generate());
             collection.WithServiceBusMessageHandler<StubServiceBusMessageHandler<Order>, Order>(messageBodySerializer: serializer, implementationFactory: serviceProvider => spyHandler)
-                    .WithServiceBusMessageHandler<StubServiceBusMessageHandler<TestMessage>, TestMessage>(implementationFactory: serviceProvider => ignoredHandler);
+                      .WithServiceBusMessageHandler<StubServiceBusMessageHandler<TestMessage>, TestMessage>(implementationFactory: serviceProvider => ignoredHandler);
 
             // Act
             services.AddServiceBusMessageRouting();
@@ -181,7 +182,7 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus
             string expectedBody = JsonConvert.SerializeObject(expectedMessage);
             var serializer = new TestMessageBodySerializer(expectedBody, new SubOrder());
             collection.WithServiceBusMessageHandler<StubServiceBusMessageHandler<Order>, Order>(messageBodySerializer: serializer, implementationFactory: serviceProvider => spyHandler)
-                    .WithServiceBusMessageHandler<StubServiceBusMessageHandler<TestMessage>, TestMessage>(implementationFactory: serviceProvider => ignoredHandler);
+                      .WithServiceBusMessageHandler<StubServiceBusMessageHandler<TestMessage>, TestMessage>(implementationFactory: serviceProvider => ignoredHandler);
 
             // Act
             services.AddServiceBusMessageRouting();
@@ -215,23 +216,22 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus
             string expectedBody = JsonConvert.SerializeObject(expectedMessage);
             var serializer = new TestMessageBodySerializer(expectedBody, OrderGenerator.Generate());
             
-            collection
-                .WithServiceBusMessageHandler<StubServiceBusMessageHandler<Order>, Order>(
-                        messageContextFilter: ctx => ctx != null,
-                        messageBodyFilter: body => body != null,
-                        messageBodySerializer: new TestMessageBodySerializer(expectedBody, new Customer()),
-                        implementationFactory: serviceProvider => ignoredHandler3)
-                    .WithServiceBusMessageHandler<StubServiceBusMessageHandler<TestMessage>, TestMessage>(
-                        messageBodyFilter: body => body is null,
-                        implementationFactory: serviceProvider => ignoredHandler2)
-                    .WithServiceBusMessageHandler<StubServiceBusMessageHandler<Order>, Order>(
-                        messageBodySerializer: serializer, 
-                        messageBodyFilter: body => body.Customer != null,
-                        messageContextFilter: ctx => ctx.MessageId.StartsWith("message-id"),
-                        implementationFactory: serviceProvider => spyHandler)
-                    .WithServiceBusMessageHandler<StubServiceBusMessageHandler<TestMessage>, TestMessage>()
-                    .WithServiceBusMessageHandler<StubServiceBusMessageHandler<TestMessage>, TestMessage>(
-                        implementationFactory: serviceProvider => ignoredHandler1);
+            collection.WithServiceBusMessageHandler<StubServiceBusMessageHandler<Order>, Order>(
+                          messageContextFilter: ctx => ctx != null,
+                          messageBodyFilter: body => body != null,
+                          messageBodySerializer: new TestMessageBodySerializer(expectedBody, new Customer()),
+                          implementationFactory: serviceProvider => ignoredHandler3)
+                      .WithServiceBusMessageHandler<StubServiceBusMessageHandler<TestMessage>, TestMessage>(
+                          messageBodyFilter: body => body is null,
+                          implementationFactory: serviceProvider => ignoredHandler2)
+                      .WithServiceBusMessageHandler<StubServiceBusMessageHandler<Order>, Order>(
+                          messageBodySerializer: serializer, 
+                          messageBodyFilter: body => body.Customer != null,
+                          messageContextFilter: ctx => ctx.MessageId.StartsWith("message-id"),
+                          implementationFactory: serviceProvider => spyHandler)
+                      .WithServiceBusMessageHandler<StubServiceBusMessageHandler<TestMessage>, TestMessage>()
+                      .WithServiceBusMessageHandler<StubServiceBusMessageHandler<TestMessage>, TestMessage>(
+                          implementationFactory: serviceProvider => ignoredHandler1);
 
             // Act
             services.AddServiceBusMessageRouting();
@@ -266,6 +266,67 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus
             IServiceProvider provider = services.BuildServiceProvider();
             Assert.IsType<TestAzureServiceBusMessageRouter>(provider.GetRequiredService<IAzureServiceBusMessageRouter>());
             Assert.IsType<TestAzureServiceBusMessageRouter>(provider.GetRequiredService<IMessageRouter>());
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task WithServiceBusRouting_IgnoreMissingMembers_ResultsInDifferentMessageHandler(bool ignoreMissingMembers)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var collection = new ServiceBusMessageHandlerCollection(services);
+            var messageHandlerV1 = new OrderV1AzureServiceBusMessageHandler();
+            var messageHandlerV2 = new OrderV2AzureServiceBusMessageHandler();
+            collection.WithServiceBusMessageHandler<OrderV1AzureServiceBusMessageHandler, Order>(provider => messageHandlerV1)
+                      .WithServiceBusMessageHandler<OrderV2AzureServiceBusMessageHandler, OrderV2>(provider => messageHandlerV2);
+            
+            // Act
+            services.AddServiceBusMessageRouting(options => options.Deserialization.IgnoreMissingMembers = ignoreMissingMembers);
+            
+            // Assert
+            IServiceProvider serviceProvider = services.BuildServiceProvider();
+            var router = serviceProvider.GetRequiredService<IAzureServiceBusMessageRouter>();
+
+            OrderV2 orderV2 = OrderV2Generator.Generate();
+            ServiceBusReceivedMessage message = orderV2.AsServiceBusReceivedMessage();
+            AzureServiceBusMessageContext context = AzureServiceBusMessageContextFactory.Generate();
+            var correlationInfo = new MessageCorrelationInfo("operation-id", "transaction-id");
+            await router.RouteMessageAsync(message, context, correlationInfo, CancellationToken.None);
+            
+            Assert.NotEqual(ignoreMissingMembers, messageHandlerV2.IsProcessed);
+            Assert.Equal(ignoreMissingMembers, messageHandlerV1.IsProcessed);
+        }
+
+        [Fact]
+        public void CreateWithoutOptionsAndLogger_WithoutServiceProvider_Fails()
+        {
+            Assert.ThrowsAny<ArgumentException>(
+                () => new AzureServiceBusMessageRouter(serviceProvider: null));
+        }
+
+        [Fact]
+        public void CreateWithoutOptions_WithoutServiceProvider_Fails()
+        {
+            Assert.ThrowsAny<ArgumentException>(
+                () => new AzureServiceBusMessageRouter(serviceProvider: null, logger: NullLogger<AzureServiceBusMessageRouter>.Instance));
+        }
+
+        [Fact]
+        public void CreateWithoutLogger_WithoutServiceProvider_Fails()
+        {
+            Assert.ThrowsAny<ArgumentException>(
+                () => new AzureServiceBusMessageRouter(serviceProvider: null, options: new AzureServiceBusMessageRouterOptions()));
+        }
+
+        [Fact]
+        public void Create_WithoutServiceProvider_Fails()
+        {
+            Assert.ThrowsAny<ArgumentException>(
+                () => new AzureServiceBusMessageRouter(
+                    serviceProvider: null,
+                    options: new AzureServiceBusMessageRouterOptions(),
+                    logger: NullLogger<AzureServiceBusMessageRouter>.Instance));
         }
     }
 }

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/Extensions/IServiceCollectionExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/Extensions/IServiceCollectionExtensionsTests.cs
@@ -3,7 +3,7 @@ using Arcus.Messaging.Tests.Unit.Fixture;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
-namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
+namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus.Extensions
 {
     public class IServiceCollectionExtensionsTests
     {

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/Extensions/Message.ServiceBusMessageHandlerCollectionExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/Extensions/Message.ServiceBusMessageHandlerCollectionExtensionsTests.cs
@@ -3,35 +3,26 @@ using System.Collections.Generic;
 using Arcus.Messaging.Abstractions.MessageHandling;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 using Arcus.Messaging.Tests.Unit.Fixture;
-using Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Stubs;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
-namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
+namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus.Extensions
 {
     public partial class ServiceBusMessageHandlerCollectionExtensionsTests
     {
         [Theory]
-        [InlineData(false, false)]
-        [InlineData(false, true)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
-        public void WithServiceBusMessageHandler_WithMessageContextFilterWithMessageBodyFilter_UsesSerializer(bool matchesContext, bool matchesBody)
+        [InlineData(false)]
+        [InlineData(true)]
+        public void WithServiceBusMessageHandler_WithMessageBodyFilter_UsesFilter(bool matchesBody)
         {
             // Arrange
             var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
             var expectedMessage = new TestMessage();
-            var expectedContext = AzureServiceBusMessageContextFactory.Generate();
             var expectedHandler = new TestServiceBusMessageHandler();
 
             // Act
             collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
-                messageContextFilter: context =>
-                {
-                    Assert.Same(expectedContext, context);
-                    return matchesContext;
-                },
                 messageBodyFilter: body =>
                 {
                     Assert.Same(expectedMessage, body);
@@ -44,13 +35,12 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
             Assert.NotNull(handlers);
             MessageHandler handler = Assert.Single(handlers);
             Assert.NotNull(handler);
-            Assert.NotSame(expectedHandler, handler.GetMessageHandlerInstance());
-            Assert.Equal(matchesContext, handler.CanProcessMessageBasedOnContext(expectedContext));
+            Assert.NotSame(expectedHandler, handler);
             Assert.Equal(matchesBody, handler.CanProcessMessageBasedOnMessage(expectedMessage));
         }
 
         [Fact]
-        public void WithServiceBusMessageHandler_WithoutMessageContextFilterWithMessageBodyFilter_Fails()
+        public void WithServiceBusMessageHandler_WithMessageBodyFilter_Fails()
         {
             // Arrange
             var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
@@ -58,43 +48,21 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
-                    messageContextFilter: null,
-                    messageBodyFilter: body => true));
-        }
-
-        [Fact]
-        public void WithServiceBusMessageHandler_WithMessageContextFilterWithoutMessageBodyFilter_Fails()
-        {
-            // Arrange
-            var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
-
-            // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(
-                () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
-                    messageContextFilter: context => true,
                     messageBodyFilter: null));
         }
 
         [Theory]
-        [InlineData(false, false)]
-        [InlineData(false, true)]
-        [InlineData(true, false)]
-        [InlineData(true, true)]
-        public void WithServiceBusMessageHandler_WithMessageContextFilterWithMessageBodyFilterWithImplementationFactory_UsesSerializer(bool matchesContext, bool matchesBody)
+        [InlineData(false)]
+        [InlineData(true)]
+        public void WithServiceBusMessageHandler_WithMessageBodyFilterWithImplementationFactory_UsesFilter(bool matchesBody)
         {
             // Arrange
             var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
             var expectedMessage = new TestMessage();
-            var expectedContext = AzureServiceBusMessageContextFactory.Generate();
             var expectedHandler = new TestServiceBusMessageHandler();
 
             // Act
             collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
-                messageContextFilter: context =>
-                {
-                    Assert.Same(expectedContext, context);
-                    return matchesContext;
-                },
                 messageBodyFilter: body =>
                 {
                     Assert.Same(expectedMessage, body);
@@ -109,12 +77,11 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
             MessageHandler handler = Assert.Single(handlers);
             Assert.NotNull(handler);
             Assert.Same(expectedHandler, handler.GetMessageHandlerInstance());
-            Assert.Equal(matchesContext, handler.CanProcessMessageBasedOnContext(expectedContext));
             Assert.Equal(matchesBody, handler.CanProcessMessageBasedOnMessage(expectedMessage));
         }
 
         [Fact]
-        public void WithServiceBusMessageHandler_WithoutMessageContextFilterWithMessageBodyFilterWithImplementationFactory_Fails()
+        public void WithServiceBusMessageHandler_WithoutMessageBodyFilterWithImplementationFactory_Fails()
         {
             // Arrange
             var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
@@ -122,27 +89,12 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
-                    messageContextFilter: null,
-                    messageBodyFilter: body => true,
-                    implementationFactory: serviceProvider => new TestServiceBusMessageHandler()));
-        }
-
-        [Fact]
-        public void WithServiceBusMessageHandler_WithMessageContextFilterWithoutMessageBodyFilterWithImplementationFactory_Fails()
-        {
-            // Arrange
-            var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
-
-            // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(
-                () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
-                    messageContextFilter: context => true,
                     messageBodyFilter: null,
                     implementationFactory: serviceProvider => new TestServiceBusMessageHandler()));
         }
 
         [Fact]
-        public void WithServiceBusMessageHandler_WithMessageContextFilterWithMessageBodyFilterWithoutImplementationFactory_Fails()
+        public void WithServiceBusMessageHandler_WithMessageBodyFilterWithoutImplementationFactory_Fails()
         {
             // Arrange
             var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
@@ -150,8 +102,7 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
-                    messageContextFilter: context => true,
-                    messageBodyFilter: body => false,
+                    messageBodyFilter: body => true,
                     implementationFactory: null));
         }
     }

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/Extensions/MessageContext.Message.ServiceBusMessageHandlerCollectionExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/Extensions/MessageContext.Message.ServiceBusMessageHandlerCollectionExtensionsTests.cs
@@ -1,29 +1,37 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using Arcus.Messaging.Abstractions.MessageHandling;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 using Arcus.Messaging.Tests.Unit.Fixture;
+using Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus.Stubs;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
-namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
+namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus.Extensions
 {
     public partial class ServiceBusMessageHandlerCollectionExtensionsTests
     {
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void WithServiceBusMessageHandler_WithMessageBodyFilter_UsesFilter(bool matchesBody)
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void WithServiceBusMessageHandler_WithMessageContextFilterWithMessageBodyFilter_UsesSerializer(bool matchesContext, bool matchesBody)
         {
             // Arrange
             var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
             var expectedMessage = new TestMessage();
+            var expectedContext = AzureServiceBusMessageContextFactory.Generate();
             var expectedHandler = new TestServiceBusMessageHandler();
 
             // Act
             collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
+                messageContextFilter: context =>
+                {
+                    Assert.Same(expectedContext, context);
+                    return matchesContext;
+                },
                 messageBodyFilter: body =>
                 {
                     Assert.Same(expectedMessage, body);
@@ -36,12 +44,13 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
             Assert.NotNull(handlers);
             MessageHandler handler = Assert.Single(handlers);
             Assert.NotNull(handler);
-            Assert.NotSame(expectedHandler, handler);
+            Assert.NotSame(expectedHandler, handler.GetMessageHandlerInstance());
+            Assert.Equal(matchesContext, handler.CanProcessMessageBasedOnContext(expectedContext));
             Assert.Equal(matchesBody, handler.CanProcessMessageBasedOnMessage(expectedMessage));
         }
 
         [Fact]
-        public void WithServiceBusMessageHandler_WithMessageBodyFilter_Fails()
+        public void WithServiceBusMessageHandler_WithoutMessageContextFilterWithMessageBodyFilter_Fails()
         {
             // Arrange
             var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
@@ -49,21 +58,43 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
+                    messageContextFilter: null,
+                    messageBodyFilter: body => true));
+        }
+
+        [Fact]
+        public void WithServiceBusMessageHandler_WithMessageContextFilterWithoutMessageBodyFilter_Fails()
+        {
+            // Arrange
+            var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
+                    messageContextFilter: context => true,
                     messageBodyFilter: null));
         }
 
         [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void WithServiceBusMessageHandler_WithMessageBodyFilterWithImplementationFactory_UsesFilter(bool matchesBody)
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void WithServiceBusMessageHandler_WithMessageContextFilterWithMessageBodyFilterWithImplementationFactory_UsesSerializer(bool matchesContext, bool matchesBody)
         {
             // Arrange
             var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
             var expectedMessage = new TestMessage();
+            var expectedContext = AzureServiceBusMessageContextFactory.Generate();
             var expectedHandler = new TestServiceBusMessageHandler();
 
             // Act
             collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
+                messageContextFilter: context =>
+                {
+                    Assert.Same(expectedContext, context);
+                    return matchesContext;
+                },
                 messageBodyFilter: body =>
                 {
                     Assert.Same(expectedMessage, body);
@@ -78,11 +109,12 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
             MessageHandler handler = Assert.Single(handlers);
             Assert.NotNull(handler);
             Assert.Same(expectedHandler, handler.GetMessageHandlerInstance());
+            Assert.Equal(matchesContext, handler.CanProcessMessageBasedOnContext(expectedContext));
             Assert.Equal(matchesBody, handler.CanProcessMessageBasedOnMessage(expectedMessage));
         }
 
         [Fact]
-        public void WithServiceBusMessageHandler_WithoutMessageBodyFilterWithImplementationFactory_Fails()
+        public void WithServiceBusMessageHandler_WithoutMessageContextFilterWithMessageBodyFilterWithImplementationFactory_Fails()
         {
             // Arrange
             var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
@@ -90,12 +122,27 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
+                    messageContextFilter: null,
+                    messageBodyFilter: body => true,
+                    implementationFactory: serviceProvider => new TestServiceBusMessageHandler()));
+        }
+
+        [Fact]
+        public void WithServiceBusMessageHandler_WithMessageContextFilterWithoutMessageBodyFilterWithImplementationFactory_Fails()
+        {
+            // Arrange
+            var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
+                    messageContextFilter: context => true,
                     messageBodyFilter: null,
                     implementationFactory: serviceProvider => new TestServiceBusMessageHandler()));
         }
 
         [Fact]
-        public void WithServiceBusMessageHandler_WithMessageBodyFilterWithoutImplementationFactory_Fails()
+        public void WithServiceBusMessageHandler_WithMessageContextFilterWithMessageBodyFilterWithoutImplementationFactory_Fails()
         {
             // Arrange
             var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
@@ -103,7 +150,8 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
-                    messageBodyFilter: body => true,
+                    messageContextFilter: context => true,
+                    messageBodyFilter: body => false,
                     implementationFactory: null));
         }
     }

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/Extensions/MessageContext.MessageSerializer.ServiceBusMessageHandlerCollectionExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/Extensions/MessageContext.MessageSerializer.ServiceBusMessageHandlerCollectionExtensionsTests.cs
@@ -4,33 +4,35 @@ using System.Threading.Tasks;
 using Arcus.Messaging.Abstractions.MessageHandling;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 using Arcus.Messaging.Tests.Unit.Fixture;
+using Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus.Stubs;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
-namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
+namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus.Extensions
 {
     public partial class ServiceBusMessageHandlerCollectionExtensionsTests
     {
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public async Task WithMessageHandler_WithMessageBodySerializerWithMessageBodyFilter_UsesSerializer(bool matches)
+        public async Task WithMessageHandler_WithMessageContextFilterWithMessageBodySerializer_UsesSerializer(bool matches)
         {
             // Arrange
             var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
             var expectedBody = $"test-message-body-{Guid.NewGuid()}";
             var expectedMessage = new TestMessage();
+            var expectedContext = AzureServiceBusMessageContextFactory.Generate();
             var serializer = new TestMessageBodySerializer(expectedBody, expectedMessage);
 
             // Act
             collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
-                messageBodySerializer: serializer,
-                messageBodyFilter: body =>
+                messageContextFilter: context =>
                 {
-                    Assert.Same(expectedMessage, body);
+                    Assert.Same(expectedContext, context);
                     return matches;
-                });
+                },
+                messageBodySerializer: serializer);
 
             // Assert
             IServiceProvider provider = collection.Services.BuildServiceProvider();
@@ -38,7 +40,7 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
             Assert.NotNull(handlers);
             MessageHandler handler = Assert.Single(handlers);
             Assert.NotNull(handler);
-            bool actual = handler.CanProcessMessageBasedOnMessage(expectedMessage);
+            bool actual = handler.CanProcessMessageBasedOnContext(expectedContext);
             Assert.Equal(matches, actual);
             MessageResult result = await handler.TryCustomDeserializeMessageAsync(expectedBody);
             Assert.NotNull(result);
@@ -46,7 +48,7 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
         }
 
         [Fact]
-        public void WithMessageHandler_WithoutMessageBodySerializerWithMessageBodyFilter_Fails()
+        public void WithMessageHandler_WithoutMessageContextFilterWithMessageBodySerializer_Fails()
         {
             // Arrange
             var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
@@ -54,12 +56,12 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
-                    messageBodySerializer: null,
-                    messageBodyFilter: body => true));
+                    messageContextFilter: null,
+                    messageBodySerializer: new TestMessageBodySerializer()));
         }
 
         [Fact]
-        public void WithMessageHandler_WithMessageBodySerializerWithoutMessageBodyFilter_Fails()
+        public void WithMessageHandler_WithMessageContextFilterWithoutMessageBodySerializer_Fails()
         {
             // Arrange
             var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
@@ -67,29 +69,30 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
-                    messageBodySerializer: new TestMessageBodySerializer(),
-                    messageBodyFilter: null));
+                    messageContextFilter: context => true,
+                    messageBodySerializer: null));
         }
 
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public async Task WithMessageHandler_WithMessageBodySerializerImplementationFactoryWithMessageBodyFilter_UsesSerializer(bool matches)
+        public async Task WithMessageHandler_WithMessageContextFilterWithMessageBodySerializerImplementationFactory_UsesSerializer(bool matches)
         {
             // Arrange
             var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
             var expectedBody = $"test-message-body-{Guid.NewGuid()}";
             var expectedMessage = new TestMessage();
+            var expectedContext = AzureServiceBusMessageContextFactory.Generate();
             var serializer = new TestMessageBodySerializer(expectedBody, expectedMessage);
 
             // Act
             collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
-                messageBodySerializerImplementationFactory: serviceProvider => serializer,
-                messageBodyFilter: body =>
+                messageContextFilter: context =>
                 {
-                    Assert.Same(expectedMessage, body);
+                    Assert.Same(expectedContext, context);
                     return matches;
-                });
+                },
+                messageBodySerializerImplementationFactory: serviceProvider => serializer);
 
             // Assert
             IServiceProvider provider = collection.Services.BuildServiceProvider();
@@ -97,7 +100,7 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
             Assert.NotNull(handlers);
             MessageHandler handler = Assert.Single(handlers);
             Assert.NotNull(handler);
-            bool actual = handler.CanProcessMessageBasedOnMessage(expectedMessage);
+            bool actual = handler.CanProcessMessageBasedOnContext(expectedContext);
             Assert.Equal(matches, actual);
             MessageResult result = await handler.TryCustomDeserializeMessageAsync(expectedBody);
             Assert.NotNull(result);
@@ -105,7 +108,7 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
         }
 
         [Fact]
-        public void WithMessageHandler_WithoutMessageBodySerializerImplementationFactoryWithMessageBodyFilter_Fails()
+        public void WithMessageHandler_WithoutMessageContextFilterWithMessageBodySerializerImplementationFactory_Fails()
         {
             // Arrange
             var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
@@ -113,12 +116,12 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
-                    messageBodySerializerImplementationFactory: null,
-                    messageBodyFilter: body => true));
+                    messageContextFilter: null,
+                    messageBodySerializerImplementationFactory: serviceProvider => new TestMessageBodySerializer()));
         }
 
         [Fact]
-        public void WithMessageHandler_WithMessageBodySerializerImplementationFactoryWithoutMessageBodyFilter_Fails()
+        public void WithMessageHandler_WithMessageContextFilterWithoutMessageBodySerializerImplementationFactory_Fails()
         {
             // Arrange
             var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
@@ -126,30 +129,31 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
-                    messageBodySerializerImplementationFactory: serviceProvider =>  new TestMessageBodySerializer(),
-                    messageBodyFilter: null));
+                    messageContextFilter: context => true,
+                    messageBodySerializerImplementationFactory: null));
         }
 
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public async Task WithMessageHandler_WithMessageBodySerializerWithMessageBodyFilterWithMessageHandlerImplementationFactory_UsesSerializer(bool matches)
+        public async Task WithMessageHandler_WithMessageContextFilterWithMessageBodySerializerWithMessageHandlerImplementationFactory_UsesSerializer(bool matches)
         {
             // Arrange
             var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
             var expectedBody = $"test-message-body-{Guid.NewGuid()}";
             var expectedMessage = new TestMessage();
+            var expectedContext = AzureServiceBusMessageContextFactory.Generate();
             var serializer = new TestMessageBodySerializer(expectedBody, expectedMessage);
             var expectedHandler = new TestServiceBusMessageHandler();
 
             // Act
             collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
-                messageBodySerializer: serializer,
-                messageBodyFilter: body =>
+                messageContextFilter: context =>
                 {
-                    Assert.Same(expectedMessage, body);
+                    Assert.Same(expectedContext, context);
                     return matches;
                 },
+                messageBodySerializer: serializer,
                 implementationFactory: serviceProvider => expectedHandler);
 
             // Assert
@@ -159,7 +163,7 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
             MessageHandler handler = Assert.Single(handlers);
             Assert.NotNull(handler);
             Assert.Same(expectedHandler, handler.GetMessageHandlerInstance());
-            bool actual = handler.CanProcessMessageBasedOnMessage(expectedMessage);
+            bool actual = handler.CanProcessMessageBasedOnContext(expectedContext);
             Assert.Equal(matches, actual);
             MessageResult result = await handler.TryCustomDeserializeMessageAsync(expectedBody);
             Assert.NotNull(result);
@@ -167,7 +171,7 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
         }
 
         [Fact]
-        public void WithMessageHandler_WithoutMessageBodySerializerWithMessageBodyFilterWithMessageHandlerImplementationFactory_Fails()
+        public void WithMessageHandler_WithoutMessageContextFilterWithMessageBodySerializerWithMessageHandlerImplementationFactory_Fails()
         {
             // Arrange
             var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
@@ -175,13 +179,27 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
+                    messageContextFilter: null,
+                    messageBodySerializer: new TestMessageBodySerializer(),
+                    implementationFactory: serviceProvider => new TestServiceBusMessageHandler()));
+        }
+
+        [Fact]
+        public void WithMessageHandler_WithMessageContextFilterWithoutMessageBodySerializerWithMessageHandlerImplementationFactory_Fails()
+        {
+            // Arrange
+            var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
+                    messageContextFilter: context => true,
                     messageBodySerializer: null,
-                    messageBodyFilter: body => true,
                     implementationFactory: serviceProvider => new TestServiceBusMessageHandler()));
         }
 
         [Fact]
-        public void WithMessageHandler_WithMessageBodySerializerWithoutMessageBodyFilterWithMessageHandlerImplementationFactory_Fails()
+        public void WithMessageHandler_WithMessageContextFilterWithMessageBodySerializerWithoutMessageHandlerImplementationFactory_Fails()
         {
             // Arrange
             var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
@@ -189,45 +207,32 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
+                    messageContextFilter: context => true,
                     messageBodySerializer: new TestMessageBodySerializer(),
-                    messageBodyFilter: null,
-                    implementationFactory: serviceProvider => new TestServiceBusMessageHandler()));
-        }
-
-        [Fact]
-        public void WithMessageHandler_WithMessageBodySerializerWithMessageBodyFilterWithoutMessageHandlerImplementationFactory_Fails()
-        {
-            // Arrange
-            var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
-
-            // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(
-                () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
-                    messageBodySerializer: new TestMessageBodySerializer(),
-                    messageBodyFilter: body => true,
                     implementationFactory: null));
         }
 
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public async Task WithMessageHandler_WithMessageBodySerializerImplementationFactoryWithMessageBodyFilterWithMessageHandlerImplementationFactory_UsesSerializer(bool matches)
+        public async Task WithMessageHandler_WithMessageContextFilterWithMessageBodySerializerImplementationFactoryWithMessageHandlerImplementationFactory_UsesSerializer(bool matches)
         {
             // Arrange
             var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
             var expectedBody = $"test-message-body-{Guid.NewGuid()}";
             var expectedMessage = new TestMessage();
+            var expectedContext = AzureServiceBusMessageContextFactory.Generate();
             var serializer = new TestMessageBodySerializer(expectedBody, expectedMessage);
             var expectedHandler = new TestServiceBusMessageHandler();
 
             // Act
             collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
-                messageBodySerializerImplementationFactory: serviceProvider => serializer,
-                messageBodyFilter: body =>
+                messageContextFilter: context =>
                 {
-                    Assert.Same(expectedMessage, body);
+                    Assert.Same(expectedContext, context);
                     return matches;
                 },
+                messageBodySerializerImplementationFactory: serviceProvider => serializer,
                 messageHandlerImplementationFactory: serviceProvider => expectedHandler);
 
             // Assert
@@ -237,7 +242,7 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
             MessageHandler handler = Assert.Single(handlers);
             Assert.NotNull(handler);
             Assert.Same(expectedHandler, handler.GetMessageHandlerInstance());
-            bool actual = handler.CanProcessMessageBasedOnMessage(expectedMessage);
+            bool actual = handler.CanProcessMessageBasedOnContext(expectedContext);
             Assert.Equal(matches, actual);
             MessageResult result = await handler.TryCustomDeserializeMessageAsync(expectedBody);
             Assert.NotNull(result);
@@ -245,7 +250,7 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
         }
 
         [Fact]
-        public void WithMessageHandler_WithoutMessageBodySerializerImplementationFactoryWithMessageBodyFilterWithMessageHandlerImplementationFactory_Fails()
+        public void WithMessageHandler_WithoutMessageContextFilterWithMessageBodySerializerImplementationFactoryWithMessageHandlerImplementationFactory_Fails()
         {
             // Arrange
             var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
@@ -253,13 +258,27 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
+                    messageContextFilter: null,
+                    messageBodySerializerImplementationFactory: serviceProvider => new TestMessageBodySerializer(),
+                    messageHandlerImplementationFactory: serviceProvider => new TestServiceBusMessageHandler()));
+        }
+
+        [Fact]
+        public void WithMessageHandler_WithMessageContextFilterWithoutMessageBodySerializerImplementationFactoryWithMessageHandlerImplementationFactory_Fails()
+        {
+            // Arrange
+            var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
+                    messageContextFilter: context => true,
                     messageBodySerializerImplementationFactory: null,
-                    messageBodyFilter: body => true,
                     messageHandlerImplementationFactory: serviceProvider => new TestServiceBusMessageHandler()));
         }
 
         [Fact]
-        public void WithMessageHandler_WithMessageBodySerializerImplementationFactoryWithoutMessageBodyFilterWithMessageHandlerImplementationFactory_Fails()
+        public void WithMessageHandler_WithMessageContextFilterWithMessageBodySerializerImplementationFactoryWithoutMessageHandlerImplementationFactory_Fails()
         {
             // Arrange
             var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
@@ -267,22 +286,8 @@ namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
-                    messageBodySerializerImplementationFactory: serviceProvider => new TestMessageBodySerializer(),
-                    messageBodyFilter: null,
-                    messageHandlerImplementationFactory: serviceProvider => new TestServiceBusMessageHandler()));
-        }
-
-        [Fact]
-        public void WithMessageHandler_WithMessageBodySerializerImplementationFactoryWithMessageBodyFilterWithoutMessageHandlerImplementationFactory_Fails()
-        {
-            // Arrange
-            var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
-
-            // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(
-                () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
-                    messageBodySerializerImplementationFactory: serviceProvider => new TestMessageBodySerializer(),
-                    messageBodyFilter: body => true,
+                    messageContextFilter: context => true,
+                    messageBodySerializerImplementationFactory: serviceProvider => new TestMessageBodySerializer(), 
                     messageHandlerImplementationFactory: null));
         }
     }

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/Extensions/MessageContext.ServiceBusMessageHandlerCollectionExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/Extensions/MessageContext.ServiceBusMessageHandlerCollectionExtensionsTests.cs
@@ -3,12 +3,12 @@ using System.Collections.Generic;
 using Arcus.Messaging.Abstractions.MessageHandling;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 using Arcus.Messaging.Tests.Unit.Fixture;
-using Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Stubs;
+using Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus.Stubs;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
-namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
+namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus.Extensions
 {
     public partial class ServiceBusMessageHandlerCollectionExtensionsTests
     {

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/Extensions/MessageSerializer.ServiceBusMessageHandlerCollectionExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/Extensions/MessageSerializer.ServiceBusMessageHandlerCollectionExtensionsTests.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
-namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Extensions
+namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus.Extensions
 {
     public partial class ServiceBusMessageHandlerCollectionExtensionsTests
     {

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/Stubs/AzureServiceBusMessageContextFactory.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/Stubs/AzureServiceBusMessageContextFactory.cs
@@ -6,7 +6,7 @@ using Azure.Core.Amqp;
 using Azure.Messaging.ServiceBus;
 using Bogus;
 
-namespace Arcus.Messaging.Tests.Unit.Pumps.ServiceBus.Stubs
+namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus.Stubs
 {
     /// <summary>
     /// Test factory to generate valid <see cref="AzureServiceBusMessageContext"/> instances.

--- a/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrderV2AzureServiceBusMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrderV2AzureServiceBusMessageHandler.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Net.Mime;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.EventGrid.Publishing.Interfaces;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Abstractions.ServiceBus;
+using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
+using Arcus.Messaging.Tests.Core.Events.v1;
+using Arcus.Messaging.Tests.Core.Messages.v2;
+using CloudNative.CloudEvents;
+using GuardNet;
+using Microsoft.Extensions.Logging;
+
+namespace Arcus.Messaging.Tests.Workers.MessageHandlers
+{
+    public class OrderV2AzureServiceBusMessageHandler : IAzureServiceBusMessageHandler<OrderV2>
+    {
+        private readonly IEventGridPublisher _eventGridPublisher;
+        private readonly ILogger<OrderV2AzureServiceBusMessageHandler> _logger;
+
+        public OrderV2AzureServiceBusMessageHandler(IEventGridPublisher eventGridPublisher, ILogger<OrderV2AzureServiceBusMessageHandler> logger)
+        {
+            Guard.NotNull(eventGridPublisher, nameof(eventGridPublisher));
+            Guard.NotNull(logger, nameof(logger));
+
+            _eventGridPublisher = eventGridPublisher;
+            _logger = logger;
+        }
+
+        /// <summary>
+        ///     Process a new message that was received
+        /// </summary>
+        /// <param name="order">Message that was received</param>
+        /// <param name="azureMessageContext">Context providing more information concerning the processing</param>
+        /// <param name="correlationInfo">
+        ///     Information concerning correlation of telemetry and processes by using a variety of unique
+        ///     identifiers
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        public async Task ProcessMessageAsync(
+            OrderV2 order,
+            AzureServiceBusMessageContext azureMessageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Processing order {OrderId} for {OrderAmount} units of {OrderArticle} bought by {CustomerFirstName} {CustomerLastName}", 
+                                   order.Id, order.Amount, order.ArticleNumber, order.Customer.FirstName, order.Customer.LastName);
+
+            await PublishEventToEventGridAsync(order, correlationInfo.OperationId, correlationInfo);
+
+            _logger.LogInformation("Order {OrderId} processed", order.Id);
+        }
+
+        private async Task PublishEventToEventGridAsync(OrderV2 orderMessage, string operationId, MessageCorrelationInfo correlationInfo)
+        {
+            var eventData = new OrderCreatedEventData(
+                orderMessage.Id,
+                orderMessage.Amount,
+                orderMessage.ArticleNumber,
+                $"{orderMessage.Customer.FirstName} {orderMessage.Customer.LastName}",
+                correlationInfo);
+
+            var orderCreatedEvent = new CloudEvent(
+                CloudEventsSpecVersion.V1_0,
+                "OrderCreatedEvent",
+                new Uri("http://test-host"),
+                operationId,
+                DateTime.UtcNow)
+            {
+                Data = eventData,
+                DataContentType = new ContentType("application/json")
+            };
+
+            await _eventGridPublisher.PublishAsync(orderCreatedEvent);
+
+            _logger.LogInformation("Event {EventId} was published with subject {EventSubject}", orderCreatedEvent.Id, orderCreatedEvent.Subject);
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Workers/MessageHandlers/ShipmentAzureServiceBusMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Workers/MessageHandlers/ShipmentAzureServiceBusMessageHandler.cs
@@ -1,0 +1,31 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Abstractions.ServiceBus;
+using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
+using Arcus.Messaging.Tests.Core.Messages.v1;
+
+namespace Arcus.Messaging.Tests.Workers.MessageHandlers
+{
+    public class ShipmentAzureServiceBusMessageHandler : IAzureServiceBusMessageHandler<Shipment>
+    {
+        /// <summary>
+        ///     Process a new message that was received
+        /// </summary>
+        /// <param name="message">Message that was received</param>
+        /// <param name="messageContext">Context providing more information concerning the processing</param>
+        /// <param name="correlationInfo">
+        ///     Information concerning correlation of telemetry and processes by using a variety of unique
+        ///     identifiers
+        /// </param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        public Task ProcessMessageAsync(
+            Shipment message,
+            AzureServiceBusMessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
Add an message router option to toggle whether or not the JSON deserialization should ignore missing members upon matching incoming messages with registered message handlers.

Closes #192 