### PR TITLE
feat: use message handler options to pass-in az servicebus receiver

### DIFF
--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageHandlerOptions.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageHandlerOptions.cs
@@ -1,0 +1,16 @@
+﻿using Azure.Messaging.ServiceBus;
+
+namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
+{
+    /// <summary>
+    /// Represents the additional options to change the behavior of the Azure Service Bus message handling during the routing of the <see cref="AzureServiceBusMessageRouter"/>.
+    /// </summary>
+    public class AzureServiceBusMessageHandlerOptions
+    {
+        /// <summary>
+        /// Gets or sets the instance that can call operations (dead letter, complete...) on an Azure Service Bus <see cref="ServiceBusReceivedMessage"/>;
+        /// used within <see cref="AzureServiceBusMessageHandler{TMessage}"/>s or <see cref="AzureServiceBusFallbackMessageHandler"/>s with Azure Service Bus specific operations.
+        /// </summary>
+        public ServiceBusReceiver ServiceBusReceiver { get; set; }
+    }
+}

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
@@ -108,15 +108,18 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
 
         /// <summary>
         /// Handle a new <paramref name="message"/> that was received by routing them through registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/>s
-        /// and optionally through an registered <see cref="IFallbackMessageHandler"/> or <see cref="IAzureServiceBusFallbackMessageHandler"/> if none of the message handlers were able to process the <paramref name="message"/>.
+        /// and optionally through an registered <see cref="IFallbackMessageHandler"/> or <see cref="IAzureServiceBusFallbackMessageHandler"/>
+        /// if none of the message handlers were able to process the <paramref name="message"/>.
         /// </summary>
-        /// <param name="message">The message that was received.</param>
+        /// <param name="message">The incoming message that needs to be routed through registered message handlers.</param>
         /// <param name="messageContext">The context in which the <paramref name="message"/> should be processed.</param>
         /// <param name="correlationInfo">The information concerning correlation of telemetry and processes by using a variety of unique identifiers.</param>
         /// <param name="cancellationToken">The token to cancel the message processing.</param>
         /// <remarks>
-        ///     Note that registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/>s with specific Azure Service Bus operations, will not be able to call those operations
-        ///     without an <see cref="ServiceBusReceiver"/>. Use the <see cref="RouteMessageAsync(ServiceBusReceiver,ServiceBusReceivedMessage,AzureServiceBusMessageContext,MessageCorrelationInfo,CancellationToken)"/> instead.
+        ///     Note that registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/>s with specific Azure Service Bus operations (dead letter, complete...),
+        ///     will not be able to call those operations without an <see cref="ServiceBusReceiver"/>.
+        ///     Use the <see cref="RouteMessageAsync(ServiceBusReceivedMessage,AzureServiceBusMessageContext,MessageCorrelationInfo,CancellationToken,Action{AzureServiceBusMessageHandlerOptions})"/> instead
+        ///     and set the <see cref="AzureServiceBusMessageHandlerOptions.ServiceBusReceiver"/>.
         /// </remarks>
         /// <exception cref="ArgumentNullException">
         ///     Thrown when the <paramref name="message"/>, <paramref name="messageContext"/>, or <paramref name="correlationInfo"/> is <c>null</c>.
@@ -133,64 +136,60 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
             Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires an correlation information to correlate between incoming Azure Service Bus messages");
 
             await RouteMessageWithPotentialFallbackAsync(
-                messageReceiver: null,
                 message: message,
                 messageContext: messageContext,
                 correlationInfo: correlationInfo,
-                cancellationToken: cancellationToken);
+                cancellationToken: cancellationToken,
+                configureOptions: null);
         }
 
         /// <summary>
         /// Handle a new <paramref name="message"/> that was received by routing them through registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/>s
-        /// and optionally through an registered <see cref="IFallbackMessageHandler"/> or <see cref="IAzureServiceBusFallbackMessageHandler"/> if none of the message handlers were able to process the <paramref name="message"/>.
+        /// and optionally through an registered <see cref="IFallbackMessageHandler"/> or <see cref="IAzureServiceBusFallbackMessageHandler"/>
+        /// if none of the message handlers were able to process the <paramref name="message"/>.
         /// </summary>
-        /// <param name="messageReceiver">
-        ///     The instance that can receive Azure Service Bus <see cref="ServiceBusReceivedMessage"/>; used within <see cref="IMessageHandler{TMessage,TMessageContext}"/>s with Azure Service Bus specific operations.
-        /// </param>
-        /// <param name="message">The message that was received by the <paramref name="messageReceiver"/>.</param>
+        /// <param name="message">The incoming message that needs to be routed through registered message handlers.</param>
         /// <param name="messageContext">The context in which the <paramref name="message"/> should be processed.</param>
         /// <param name="correlationInfo">The information concerning correlation of telemetry and processes by using a variety of unique identifiers.</param>
         /// <param name="cancellationToken">The token to cancel the message processing.</param>
+        /// <param name="configureOptions">The function to configure additional options to change the behavior of the message handling.</param>
         /// <exception cref="ArgumentNullException">
-        ///     Thrown when the <paramref name="messageReceiver"/>, <paramref name="message"/>, <paramref name="messageContext"/>, or <paramref name="correlationInfo"/> is <c>null</c>.
+        ///     Thrown when the <paramref name="message"/>, <paramref name="messageContext"/>, or <paramref name="correlationInfo"/> is <c>null</c>.
         /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when no message handlers or none matching message handlers are found to process the message.</exception>
         public async Task RouteMessageAsync(
-            ServiceBusReceiver messageReceiver,
             ServiceBusReceivedMessage message,
             AzureServiceBusMessageContext messageContext,
             MessageCorrelationInfo correlationInfo,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken,
+            Action<AzureServiceBusMessageHandlerOptions> configureOptions)
         {
-            Guard.NotNull(messageReceiver, nameof(messageReceiver), "Requires an Azure Service Bus message receiver while processing the message, so message handlers can call Azure Service Bus specific operations");
             Guard.NotNull(message, nameof(message), "Requires an Azure Service Bus message to be processed by the registered message handlers");
             Guard.NotNull(messageContext, nameof(messageContext), "Requires an Azure Service Bus message context in which the incoming message can be processed");
             Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires an correlation information to correlate between incoming Azure Service Bus messages");
 
-            await RouteMessageWithPotentialFallbackAsync(messageReceiver, message, messageContext, correlationInfo, cancellationToken);
+            await RouteMessageWithPotentialFallbackAsync(message, messageContext, correlationInfo, cancellationToken, configureOptions);
         }
 
         /// <summary>
         /// Handle a new <paramref name="message"/> that was received by routing them through registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/>s
         /// and optionally through an registered <see cref="IFallbackMessageHandler"/> or <see cref="IAzureServiceBusFallbackMessageHandler"/> if none of the message handlers were able to process the <paramref name="message"/>.
         /// </summary>
-        /// <param name="messageReceiver">
-        ///     The instance that can receive Azure Service Bus <see cref="ServiceBusReceivedMessage"/>; used within <see cref="IMessageHandler{TMessage,TMessageContext}"/>s with Azure Service Bus specific operations.
-        /// </param>
-        /// <param name="message">The message that was received by the <paramref name="messageReceiver"/>.</param>
+        /// <param name="message">The incoming message that needs to be routed through registered message handlers.</param>
         /// <param name="messageContext">The context in which the <paramref name="message"/> should be processed.</param>
         /// <param name="correlationInfo">The information concerning correlation of telemetry and processes by using a variety of unique identifiers.</param>
         /// <param name="cancellationToken">The token to cancel the message processing.</param>
+        /// <param name="configureOptions">The function to configure additional options to change the behavior of the message handling.</param>
         /// <exception cref="ArgumentNullException">
-        ///     Thrown when the <paramref name="messageReceiver"/>, <paramref name="message"/>, <paramref name="messageContext"/>, or <paramref name="correlationInfo"/> is <c>null</c>.
+        ///     Thrown when the <paramref name="message"/>, <paramref name="messageContext"/>, or <paramref name="correlationInfo"/> is <c>null</c>.
         /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when no message handlers or none matching message handlers are found to process the message.</exception>
         protected async Task RouteMessageWithPotentialFallbackAsync(
-            ServiceBusReceiver messageReceiver,
             ServiceBusReceivedMessage message,
             AzureServiceBusMessageContext messageContext,
             MessageCorrelationInfo correlationInfo,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken,
+            Action<AzureServiceBusMessageHandlerOptions> configureOptions)
         {
             Guard.NotNull(message, nameof(message), "Requires an Azure Service Bus message to be processed by the registered message handlers");
             Guard.NotNull(messageContext, nameof(messageContext), "Requires an Azure Service Bus message context in which the incoming message can be processed");
@@ -198,6 +197,9 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
 
             try
             {
+                var handlerOptions = new AzureServiceBusMessageHandlerOptions();
+                configureOptions?.Invoke(handlerOptions);
+                
                 MessageHandler[] messageHandlers = GetRegisteredMessageHandlers().ToArray();
                 if (messageHandlers.Length <= 0 && !HasFallbackMessageHandler && !HasAzureServiceBusFallbackHandler)
                 {
@@ -210,13 +212,13 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
 
                 Encoding encoding = messageContext.GetMessageEncodingProperty(Logger);
                 string messageBody = encoding.GetString(message.Body.ToArray());
-
+                var args = new ProcessMessageEventArgs(message, handlerOptions.ServiceBusReceiver, cancellationToken);
+                
                 foreach (MessageHandler messageHandler in messageHandlers)
                 {
                     MessageResult result = await DeserializeMessageForHandlerAsync(messageBody, messageContext, messageHandler);
                     if (result.IsSuccess)
                     {
-                        var args = new ProcessMessageEventArgs(message, messageReceiver, cancellationToken);
                         SetServiceBusPropertiesForSpecificOperations(messageHandler, args, messageContext);
                         
                         await messageHandler.ProcessMessageAsync(result.DeserializedMessage, messageContext, correlationInfo, cancellationToken);
@@ -234,7 +236,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
                 }
 
                 await TryFallbackProcessMessageAsync(messageBody, messageContext, correlationInfo, cancellationToken);
-                await TryServiceBusFallbackMessageAsync(messageReceiver, message, messageContext, correlationInfo, cancellationToken);
+                await TryServiceBusFallbackMessageAsync(handlerOptions.ServiceBusReceiver, message, messageContext, correlationInfo, cancellationToken);
             }
             catch (Exception exception)
             {

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/IAzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/IAzureServiceBusMessageRouter.cs
@@ -13,15 +13,18 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
     {
         /// <summary>
         /// Handle a new <paramref name="message"/> that was received by routing them through registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/>s
-        /// and optionally through an registered <see cref="IFallbackMessageHandler"/> or <see cref="IAzureServiceBusFallbackMessageHandler"/> if none of the message handlers were able to process the <paramref name="message"/>.
+        /// and optionally through an registered <see cref="IFallbackMessageHandler"/> or <see cref="IAzureServiceBusFallbackMessageHandler"/>
+        /// if none of the message handlers were able to process the <paramref name="message"/>.
         /// </summary>
-        /// <param name="message">The message that was received.</param>
+        /// <param name="message">The incoming message that needs to be routed through registered message handlers.</param>
         /// <param name="messageContext">The context in which the <paramref name="message"/> should be processed.</param>
         /// <param name="correlationInfo">The information concerning correlation of telemetry and processes by using a variety of unique identifiers.</param>
         /// <param name="cancellationToken">The token to cancel the message processing.</param>
         /// <remarks>
-        ///     Note that registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/>s with specific Azure Service Bus operations, will not be able to call those operations
-        ///     without an <see cref="ServiceBusReceiver"/>. Use the <see cref="RouteMessageAsync(ServiceBusReceiver,ServiceBusReceivedMessage,AzureServiceBusMessageContext,MessageCorrelationInfo,CancellationToken)"/> instead.
+        ///     Note that registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/>s with specific Azure Service Bus operations (dead letter, complete...),
+        ///     will not be able to call those operations without an <see cref="ServiceBusReceiver"/>.
+        ///     Use the <see cref="RouteMessageAsync(ServiceBusReceivedMessage,AzureServiceBusMessageContext,MessageCorrelationInfo,CancellationToken,Action{AzureServiceBusMessageHandlerOptions})"/> instead
+        ///     and set the <see cref="AzureServiceBusMessageHandlerOptions.ServiceBusReceiver"/>.
         /// </remarks>
         /// <exception cref="ArgumentNullException">
         ///     Thrown when the <paramref name="message"/>, <paramref name="messageContext"/>, or <paramref name="correlationInfo"/> is <c>null</c>.
@@ -35,24 +38,23 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
 
         /// <summary>
         /// Handle a new <paramref name="message"/> that was received by routing them through registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/>s
-        /// and optionally through an registered <see cref="IFallbackMessageHandler"/> or <see cref="IAzureServiceBusFallbackMessageHandler"/> if none of the message handlers were able to process the <paramref name="message"/>.
+        /// and optionally through an registered <see cref="IFallbackMessageHandler"/> or <see cref="IAzureServiceBusFallbackMessageHandler"/>
+        /// if none of the message handlers were able to process the <paramref name="message"/>.
         /// </summary>
-        /// <param name="messageReceiver">
-        ///     The instance that can receive Azure Service Bus <see cref="ServiceBusReceivedMessage"/>; used within <see cref="IMessageHandler{TMessage,TMessageContext}"/>s with Azure Service Bus specific operations.
-        /// </param>
-        /// <param name="message">The message that was received by the <paramref name="messageReceiver"/>.</param>
+        /// <param name="message">The incoming message that needs to be routed through registered message handlers.</param>
         /// <param name="messageContext">The context in which the <paramref name="message"/> should be processed.</param>
         /// <param name="correlationInfo">The information concerning correlation of telemetry and processes by using a variety of unique identifiers.</param>
         /// <param name="cancellationToken">The token to cancel the message processing.</param>
+        /// <param name="configureOptions">The function to configure additional options to change the behavior of the message handling.</param>
         /// <exception cref="ArgumentNullException">
-        ///     Thrown when the <paramref name="messageReceiver"/>, <paramref name="message"/>, <paramref name="messageContext"/>, or <paramref name="correlationInfo"/> is <c>null</c>.
+        ///     Thrown when the <paramref name="message"/>, <paramref name="messageContext"/>, or <paramref name="correlationInfo"/> is <c>null</c>.
         /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when no message handlers or none matching message handlers are found to process the message.</exception>
         Task RouteMessageAsync(
-            ServiceBusReceiver messageReceiver,
             ServiceBusReceivedMessage message,
             AzureServiceBusMessageContext messageContext,
             MessageCorrelationInfo correlationInfo,
-            CancellationToken cancellationToken);
+            CancellationToken cancellationToken,
+            Action<AzureServiceBusMessageHandlerOptions> configureOptions);
     }
 }


### PR DESCRIPTION
Pass-in the `ServiceBusReceiver` via an options model, so can more easily change things later.

Closes #195 