### PR TITLE
fix: Use reasonable dependency ranges to unblock v1.0.0-preview-1

### DIFF
--- a/src/Arcus.Messaging.Abstractions/Arcus.Messaging.Abstractions.csproj
+++ b/src/Arcus.Messaging.Abstractions/Arcus.Messaging.Abstractions.csproj
@@ -21,12 +21,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Observability.Correlation" Version="[0.2.1,1.0.0)" />
+    <PackageReference Include="Arcus.Observability.Correlation" Version="[2.0.0,3.0.0)" />
     <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[3.1.0,5.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.0,5.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[3.1.0,5.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[3.1.8,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.8,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[3.1.8,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Newtonsoft.Json" Version="[12.0.0,13.0.0)" />
   </ItemGroup>
 

--- a/src/Arcus.Messaging.Abstractions/Arcus.Messaging.Abstractions.csproj
+++ b/src/Arcus.Messaging.Abstractions/Arcus.Messaging.Abstractions.csproj
@@ -22,12 +22,12 @@
 
   <ItemGroup>
     <PackageReference Include="Arcus.Observability.Correlation" Version="[0.2.1,1.0.0)" />
-    <PackageReference Include="Guard.NET" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[3.1.0,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.0,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[3.1.0,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0,5.0.0)" />
+    <PackageReference Include="Newtonsoft.Json" Version="[12.0.0,13.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Messaging.Health/Arcus.Messaging.Health.csproj
+++ b/src/Arcus.Messaging.Health/Arcus.Messaging.Health.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[3.1.0,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Newtonsoft.Json" Version="[12.0.0,13.0.0)" />
   </ItemGroup>
 

--- a/src/Arcus.Messaging.Health/Arcus.Messaging.Health.csproj
+++ b/src/Arcus.Messaging.Health/Arcus.Messaging.Health.csproj
@@ -19,9 +19,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Guard.NET" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[3.1.0,5.0.0)" />
+    <PackageReference Include="Newtonsoft.Json" Version="[12.0.0,13.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Messaging.Pumps.Abstractions/Arcus.Messaging.Pumps.Abstractions.csproj
+++ b/src/Arcus.Messaging.Pumps.Abstractions/Arcus.Messaging.Pumps.Abstractions.csproj
@@ -20,14 +20,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[0.2.1,1.0.0)" />
-    <PackageReference Include="Guard.NET" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[2.0.0,3.0.0)" />
+    <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[3.1.0,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.0,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[3.1.0,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0,5.0.0)" />
+    <PackageReference Include="Newtonsoft.Json" Version="[12.0.0,13.0.0)" />
+    <PackageReference Include="Serilog" Version="[2.9.0,3.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Messaging.Pumps.Abstractions/Arcus.Messaging.Pumps.Abstractions.csproj
+++ b/src/Arcus.Messaging.Pumps.Abstractions/Arcus.Messaging.Pumps.Abstractions.csproj
@@ -22,10 +22,10 @@
   <ItemGroup>
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[2.0.0,3.0.0)" />
     <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[3.1.0,5.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.0,5.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[3.1.0,5.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[3.1.8,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.8,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[3.1.8,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Newtonsoft.Json" Version="[12.0.0,13.0.0)" />
     <PackageReference Include="Serilog" Version="[2.9.0,3.0.0)" />
   </ItemGroup>

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Arcus.Messaging.Pumps.ServiceBus.csproj
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Arcus.Messaging.Pumps.ServiceBus.csproj
@@ -22,14 +22,14 @@
 
   <ItemGroup>
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="[1.3.0,2.0.0)" />
-    <PackageReference Include="Azure.Identity" Version="1.0.0" />
-    <PackageReference Include="Guard.NET" Version="1.2.0" />
+    <PackageReference Include="Azure.Identity" Version="[1.0.0,2.0.0)" />
+    <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
     <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[3.1.0,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="[3.1.0,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.0,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[3.1.0,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0,5.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Arcus.Messaging.Pumps.ServiceBus.csproj
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Arcus.Messaging.Pumps.ServiceBus.csproj
@@ -24,12 +24,12 @@
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="[1.3.0,2.0.0)" />
     <PackageReference Include="Azure.Identity" Version="[1.0.0,2.0.0)" />
     <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
-    <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[3.1.0,5.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="[3.1.0,5.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.0,5.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[3.1.0,5.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.0,5.0.0)" />
+    <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="[2.1.0,3.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[3.1.8,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="[3.1.8,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.8,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[3.1.8,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.8,5.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Arcus.Messaging.Pumps.ServiceBus.csproj
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Arcus.Messaging.Pumps.ServiceBus.csproj
@@ -21,8 +21,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="[1.3.0,2.0.0)" />
-    <PackageReference Include="Azure.Identity" Version="[1.0.0,2.0.0)" />
+    <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="[1.4.0,2.0.0)" />
+    <PackageReference Include="Azure.Identity" Version="[1.2.3,2.0.0)" />
     <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
     <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="[2.1.0,3.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[3.1.8,5.0.0)" />

--- a/src/Arcus.Messaging.ServiceBus.Core/Arcus.Messaging.ServiceBus.Core.csproj
+++ b/src/Arcus.Messaging.ServiceBus.Core/Arcus.Messaging.ServiceBus.Core.csproj
@@ -20,8 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.0.0" />
-    <PackageReference Include="Guard.NET" Version="1.2.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="[7.0.0,8.0.0)" />
+    <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Messaging.Tests.Contracts/Arcus.Messaging.Tests.Contracts.csproj
+++ b/src/Arcus.Messaging.Tests.Contracts/Arcus.Messaging.Tests.Contracts.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Arcus.EventGrid" Version="3.0.0-preview-1" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="[12.0.0,13.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Messaging.Tests.Core/Arcus.Messaging.Tests.Core.csproj
+++ b/src/Arcus.Messaging.Tests.Core/Arcus.Messaging.Tests.Core.csproj
@@ -8,12 +8,13 @@
 
   <ItemGroup>
     <PackageReference Include="Arcus.EventGrid" Version="3.1.0" />
-    <PackageReference Include="Arcus.Testing.Logging" Version="0.1.0" />
+    <PackageReference Include="Arcus.Testing.Logging" Version="0.2.0" />
     <PackageReference Include="Bogus" Version="29.0.2" />
     <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="[12.0.0,13.0.0)" />
+    <PackageReference Include="Polly" Version="7.2.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/src/Arcus.Messaging.Tests.Core/Arcus.Messaging.Tests.Core.csproj
+++ b/src/Arcus.Messaging.Tests.Core/Arcus.Messaging.Tests.Core.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="[12.0.0,13.0.0)" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/src/Arcus.Messaging.Tests.Core/Arcus.Messaging.Tests.Core.csproj
+++ b/src/Arcus.Messaging.Tests.Core/Arcus.Messaging.Tests.Core.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.EventGrid" Version="3.0.0" />
+    <PackageReference Include="Arcus.EventGrid" Version="3.1.0" />
     <PackageReference Include="Arcus.Testing.Logging" Version="0.1.0" />
     <PackageReference Include="Bogus" Version="29.0.2" />
-    <PackageReference Include="Guard.NET" Version="1.2.0" />
+    <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/src/Arcus.Messaging.Tests.Integration/Arcus.Messaging.Tests.Integration.csproj
+++ b/src/Arcus.Messaging.Tests.Integration/Arcus.Messaging.Tests.Integration.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Arcus.EventGrid.Testing" Version="3.1.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.0.0,3.0.0)" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="[2.0.0,3.0.0)" />
-    <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.3.0" />
+    <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.4.0" />
     <PackageReference Include="Arcus.Testing.Logging" Version="0.2.0" />
     <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
     <PackageReference Include="Microsoft.Azure.ApplicationInsights.Query" Version="1.0.0" />
@@ -31,7 +31,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.8,5.0.0)" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.4.2" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Serilog" Version="[2.9.0,3.0.0)" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="3.1.0" />

--- a/src/Arcus.Messaging.Tests.Integration/Arcus.Messaging.Tests.Integration.csproj
+++ b/src/Arcus.Messaging.Tests.Integration/Arcus.Messaging.Tests.Integration.csproj
@@ -18,22 +18,22 @@
   <ItemGroup>
     <PackageReference Include="Arcus.EventGrid.Publishing" Version="3.1.0" />
     <PackageReference Include="Arcus.EventGrid.Testing" Version="3.1.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="0.4.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="0.4.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.0.0,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="[2.0.0,3.0.0)" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.3.0" />
     <PackageReference Include="Arcus.Testing.Logging" Version="0.2.0" />
     <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
     <PackageReference Include="Microsoft.Azure.ApplicationInsights.Query" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="[3.1.8,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="[3.1.8,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[3.1.8,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="[3.1.8,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="[3.1.8,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog" Version="[2.9.0,3.0.0)" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/src/Arcus.Messaging.Tests.Integration/Arcus.Messaging.Tests.Integration.csproj
+++ b/src/Arcus.Messaging.Tests.Integration/Arcus.Messaging.Tests.Integration.csproj
@@ -16,13 +16,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.EventGrid.Publishing" Version="3.0.0" />
-    <PackageReference Include="Arcus.EventGrid.Testing" Version="3.0.0" />
+    <PackageReference Include="Arcus.EventGrid.Publishing" Version="3.1.0" />
+    <PackageReference Include="Arcus.EventGrid.Testing" Version="3.1.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="0.4.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="0.4.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.3.0" />
     <PackageReference Include="Arcus.Testing.Logging" Version="0.2.0" />
-    <PackageReference Include="Guard.Net" Version="1.2.0" />
+    <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
     <PackageReference Include="Microsoft.Azure.ApplicationInsights.Query" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.8" />

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/TestMessagePumpService.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/TestMessagePumpService.cs
@@ -159,7 +159,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             await using (var client = new ServiceBusClient(connectionString))
             await using (var receiver = client.CreateReceiver(properties.EntityPath, options))
             {
-                RetryPolicy<ServiceBusReceivedMessage> retryPolicy =
+                AsyncRetryPolicy<ServiceBusReceivedMessage> retryPolicy =
                     Policy.HandleResult<ServiceBusReceivedMessage>(result => result is null)
                           .WaitAndRetryForeverAsync(index => TimeSpan.FromSeconds(1));
 

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/TestMessagePumpService.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/TestMessagePumpService.cs
@@ -159,9 +159,8 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             await using (var client = new ServiceBusClient(connectionString))
             await using (var receiver = client.CreateReceiver(properties.EntityPath, options))
             {
-                AsyncRetryPolicy<ServiceBusReceivedMessage> retryPolicy =
-                    Policy.HandleResult<ServiceBusReceivedMessage>(result => result is null)
-                          .WaitAndRetryForeverAsync(index => TimeSpan.FromSeconds(1));
+                var retryPolicy = Policy.HandleResult<ServiceBusReceivedMessage>(result => result is null)
+                                        .WaitAndRetryForeverAsync(index => TimeSpan.FromSeconds(1));
 
                 await Policy.TimeoutAsync(TimeSpan.FromMinutes(2))
                             .WrapAsync(retryPolicy)

--- a/src/Arcus.Messaging.Tests.Unit/Arcus.Messaging.Tests.Unit.csproj
+++ b/src/Arcus.Messaging.Tests.Unit/Arcus.Messaging.Tests.Unit.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.EventGrid.Testing" Version="3.0.0" />
+    <PackageReference Include="Arcus.EventGrid.Testing" Version="3.1.0" />
     <PackageReference Include="Bogus" Version="29.0.2" />
-    <PackageReference Include="Guard.Net" Version="1.2.0" />
+    <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.4.2" />

--- a/src/Arcus.Messaging.Tests.Unit/Arcus.Messaging.Tests.Unit.csproj
+++ b/src/Arcus.Messaging.Tests.Unit/Arcus.Messaging.Tests.Unit.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="Arcus.EventGrid.Testing" Version="3.1.0" />
     <PackageReference Include="Bogus" Version="29.0.2" />
     <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="[3.1.8,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Moq" Version="4.13.1" />

--- a/src/Arcus.Messaging.Tests.Unit/Arcus.Messaging.Tests.Unit.csproj
+++ b/src/Arcus.Messaging.Tests.Unit/Arcus.Messaging.Tests.Unit.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.8,5.0.0)" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.4.2" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/src/Arcus.Messaging.Tests.Unit/ServiceBus/KeyRotation/AzureServiceBusKeyRotationTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/ServiceBus/KeyRotation/AzureServiceBusKeyRotationTests.cs
@@ -80,7 +80,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus.KeyRotation
         public async Task RotateServiceBusSecret_WithValidArguments_RotatesPrimarySecondaryAlternately(ServiceBusEntityType entity)
         {
             // Arrange
-            string vaultUrl = BogusGenerator.Internet.UrlWithPath(protocol: "https");
+            string vaultUrl = $"https://{BogusGenerator.Name.FirstName()}.vault.azure.net";
             string secretName = BogusGenerator.Random.Word();
             AzureServiceBusNamespace @namespace = GenerateAzureServiceBusLocation(entity);
             var response = new AzureOperationResponse<AccessKeys>

--- a/src/Arcus.Messaging.Tests.Workers.ServiceBus.Queue/Arcus.Messaging.Tests.Workers.ServiceBus.Queue.csproj
+++ b/src/Arcus.Messaging.Tests.Workers.ServiceBus.Queue/Arcus.Messaging.Tests.Workers.ServiceBus.Queue.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.EventGrid.Publishing" Version="3.1.0" />
-    <PackageReference Include="Arcus.EventGrid.Testing" Version="3.1.0" />
+    <PackageReference Include="Arcus.EventGrid.Publishing" Version="[3.1.0,4.0.0)" />
+    <PackageReference Include="Arcus.EventGrid.Testing" Version="[3.1.0,4.0.0)" />
     <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="[3.1.8,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.4.2" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.5" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="[12.0.0,13.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Messaging.Tests.Workers.ServiceBus.Queue/Arcus.Messaging.Tests.Workers.ServiceBus.Queue.csproj
+++ b/src/Arcus.Messaging.Tests.Workers.ServiceBus.Queue/Arcus.Messaging.Tests.Workers.ServiceBus.Queue.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="[3.1.8,5.0.0)" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.4.2" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.5" />
     <PackageReference Include="Newtonsoft.Json" Version="[12.0.0,13.0.0)" />
   </ItemGroup>

--- a/src/Arcus.Messaging.Tests.Workers.ServiceBus.Queue/Arcus.Messaging.Tests.Workers.ServiceBus.Queue.csproj
+++ b/src/Arcus.Messaging.Tests.Workers.ServiceBus.Queue/Arcus.Messaging.Tests.Workers.ServiceBus.Queue.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.EventGrid.Publishing" Version="3.0.0" />
-    <PackageReference Include="Arcus.EventGrid.Testing" Version="3.0.0" />
-    <PackageReference Include="Guard.NET" Version="1.2.0" />
+    <PackageReference Include="Arcus.EventGrid.Publishing" Version="3.1.0" />
+    <PackageReference Include="Arcus.EventGrid.Testing" Version="3.1.0" />
+    <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.4.2" />

--- a/src/Arcus.Messaging.Tests.Workers.ServiceBus.Queue/Program.cs
+++ b/src/Arcus.Messaging.Tests.Workers.ServiceBus.Queue/Program.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using Arcus.EventGrid.Publishing;
 using Arcus.Messaging.Tests.Core.Messages.v1;
 using Arcus.Messaging.Tests.Workers.MessageHandlers;
@@ -7,7 +5,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 
 namespace Arcus.Messaging.Tests.Workers.ServiceBus.Queue
 {

--- a/src/Arcus.Messaging.Tests.Workers.ServiceBus.Topic/Arcus.Messaging.Tests.Workers.ServiceBus.Topic.csproj
+++ b/src/Arcus.Messaging.Tests.Workers.ServiceBus.Topic/Arcus.Messaging.Tests.Workers.ServiceBus.Topic.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.EventGrid.Publishing" Version="3.1.0" />
-    <PackageReference Include="Arcus.EventGrid.Testing" Version="3.1.0" />
+    <PackageReference Include="Arcus.EventGrid.Publishing" Version="[3.1.0,4.0.0)" />
+    <PackageReference Include="Arcus.EventGrid.Testing" Version="[3.1.0,4.0.0)" />
     <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="[3.1.8,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.4.2" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.5" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="[12.0.0,13.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Messaging.Tests.Workers.ServiceBus.Topic/Arcus.Messaging.Tests.Workers.ServiceBus.Topic.csproj
+++ b/src/Arcus.Messaging.Tests.Workers.ServiceBus.Topic/Arcus.Messaging.Tests.Workers.ServiceBus.Topic.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="[3.1.8,5.0.0)" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.4.2" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.5" />
     <PackageReference Include="Newtonsoft.Json" Version="[12.0.0,13.0.0)" />
   </ItemGroup>

--- a/src/Arcus.Messaging.Tests.Workers.ServiceBus.Topic/Arcus.Messaging.Tests.Workers.ServiceBus.Topic.csproj
+++ b/src/Arcus.Messaging.Tests.Workers.ServiceBus.Topic/Arcus.Messaging.Tests.Workers.ServiceBus.Topic.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.EventGrid.Publishing" Version="3.0.0" />
-    <PackageReference Include="Arcus.EventGrid.Testing" Version="3.0.0" />
-    <PackageReference Include="Guard.NET" Version="1.2.0" />
+    <PackageReference Include="Arcus.EventGrid.Publishing" Version="3.1.0" />
+    <PackageReference Include="Arcus.EventGrid.Testing" Version="3.1.0" />
+    <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.4.2" />

--- a/src/Arcus.Messaging.Tests.Workers/Arcus.Messaging.Tests.Workers.csproj
+++ b/src/Arcus.Messaging.Tests.Workers/Arcus.Messaging.Tests.Workers.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.EventGrid.Publishing" Version="3.1.0" />
-    <PackageReference Include="Arcus.EventGrid.Testing" Version="3.1.0" />
+    <PackageReference Include="Arcus.EventGrid.Publishing" Version="[3.1.0,4.0.0)" />
+    <PackageReference Include="Arcus.EventGrid.Testing" Version="[3.1.0,4.0.0)" />
     <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="[3.1.8,5.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.4.2" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.5" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="[12.0.0,13.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Messaging.Tests.Workers/Arcus.Messaging.Tests.Workers.csproj
+++ b/src/Arcus.Messaging.Tests.Workers/Arcus.Messaging.Tests.Workers.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="[3.1.8,5.0.0)" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.4.2" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.5" />
     <PackageReference Include="Newtonsoft.Json" Version="[12.0.0,13.0.0)" />
   </ItemGroup>

--- a/src/Arcus.Messaging.Tests.Workers/Arcus.Messaging.Tests.Workers.csproj
+++ b/src/Arcus.Messaging.Tests.Workers/Arcus.Messaging.Tests.Workers.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.EventGrid.Publishing" Version="3.0.0" />
-    <PackageReference Include="Arcus.EventGrid.Testing" Version="3.0.0" />
-    <PackageReference Include="Guard.NET" Version="1.2.0" />
+    <PackageReference Include="Arcus.EventGrid.Publishing" Version="3.1.0" />
+    <PackageReference Include="Arcus.EventGrid.Testing" Version="3.1.0" />
+    <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.4.2" />


### PR DESCRIPTION
Fix dependency ranges for v1.0.0-preview-1 which are blocking me from upgrading since it enforces Arcus Observability < v1.0