### PR TITLE
fix: remove internals visible to attribute

### DIFF
--- a/src/Arcus.Messaging.Abstractions.ServiceBus/InternalsVisibleTo.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/InternalsVisibleTo.cs
@@ -1,4 +1,0 @@
-﻿using System.Runtime.CompilerServices;
-
-// TODO: only temporary until we have extracted the message handling into routers.
-[assembly: InternalsVisibleTo("Arcus.Messaging.Pumps.ServiceBus")]


### PR DESCRIPTION
Was first introduced to give access to the message handling functionality from the Azure Service Bus project.
But since we extracted this into routers, we can reference a router instead of internal message handling logic.