### PR TITLE
feat: make message routing options public for custom routers

### DIFF
--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
@@ -104,12 +104,13 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// <summary>
         /// Gets the consumer-configurable options to change the deserialization behavior.
         /// </summary>
-        public MessageDeserializationOptions Deserialization => MessageRouterOptions.Deserialization;
+        [Obsolete("Use the " + nameof(Routing) + ".Deserialization instead")]
+        public MessageDeserializationOptions Deserialization => Routing.Deserialization;
 
         /// <summary>
         /// Gets the consumer-configurable options to change the behavior of the message router.
         /// </summary>
-        internal AzureServiceBusMessageRouterOptions MessageRouterOptions { get; } = new AzureServiceBusMessageRouterOptions();
+        public AzureServiceBusMessageRouterOptions Routing { get; } = new AzureServiceBusMessageRouterOptions();
 
         /// <summary>
         /// Gets the default consumer-configurable options for Azure Service Bus Queue message pumps.

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
@@ -830,7 +830,7 @@ namespace Microsoft.Extensions.DependencyInjection
             ServiceBusMessageHandlerCollection collection = services.AddServiceBusMessageRouting(provider =>
             {
                 var logger = provider.GetService<ILogger<AzureServiceBusMessageRouter>>();
-                return new AzureServiceBusMessageRouter(provider, options.MessageRouterOptions, logger);
+                return new AzureServiceBusMessageRouter(provider, options.Routing, logger);
             });
             
             services.AddHostedService(serviceProvider =>


### PR DESCRIPTION
When creating custom message router (like the CloudEvents message router in the background jobs repo), we could benefit from the message pump options and therefore the message router options, but then we need to have access to the message router options directly.

Closes #212