### PR TITLE
fix: re-introduce 'None' enum member for az service bus topic sub

### DIFF
--- a/src/Arcus.Messaging.Pumps.ServiceBus/TopicSubscription.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/TopicSubscription.cs
@@ -9,12 +9,17 @@ namespace Arcus.Messaging.Pumps.ServiceBus
     public enum TopicSubscription
     {
         /// <summary>
-        /// Creates a new topic subscription when the message pump starts.
+        /// Don't create any Azure Service Bus Topic subscription during the lifecycle of the <see cref="AzureServiceBusMessagePump"/>.
+        /// </summary>
+        None = 0,
+        
+        /// <summary>
+        /// Creates a new Azure Service Bus Topic subscription when the message pump starts.
         /// </summary>
         CreateOnStart = 1,
 
         /// <summary>
-        /// Deletes the new topic subscription when the message pump stops.
+        /// Deletes the new Azure Service Bus Topic subscription when the message pump stops.
         /// </summary>
         DeleteOnStop = 2
     }


### PR DESCRIPTION
Re-introduce the `None` enum member for the `TopicSubscription` enumeration as to make the Azure Service Bus Topic configuration more explicit.

Closes #216 