### PR TITLE
fix: Update Newtonsoft.Json package reference to use 12.0.1

### DIFF
--- a/src/Arcus.Messaging.Abstractions/Arcus.Messaging.Abstractions.csproj
+++ b/src/Arcus.Messaging.Abstractions/Arcus.Messaging.Abstractions.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.8,5.0.0)" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="[12.0.1,13.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Messaging.Health/Arcus.Messaging.Health.csproj
+++ b/src/Arcus.Messaging.Health/Arcus.Messaging.Health.csproj
@@ -21,7 +21,7 @@
   <ItemGroup>
     <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[3.1.8,5.0.0)" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="[12.0.1,13.0.0)" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Messaging.Pumps.Abstractions/Arcus.Messaging.Pumps.Abstractions.csproj
+++ b/src/Arcus.Messaging.Pumps.Abstractions/Arcus.Messaging.Pumps.Abstractions.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[3.1.8,5.0.0)" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="[12.0.1,13.0.0)" />
     <PackageReference Include="Serilog" Version="2.9.0" />
   </ItemGroup>
 

--- a/src/Arcus.Messaging.Tests.Contracts/Arcus.Messaging.Tests.Contracts.csproj
+++ b/src/Arcus.Messaging.Tests.Contracts/Arcus.Messaging.Tests.Contracts.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Arcus.EventGrid" Version="3.0.0-preview-1" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="[12.0.0,13.0.0)" />
+    <PackageReference Include="Newtonsoft.Json" Version="[12.0.1,13.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Messaging.Tests.Core/Arcus.Messaging.Tests.Core.csproj
+++ b/src/Arcus.Messaging.Tests.Core/Arcus.Messaging.Tests.Core.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Guard.NET" Version="[1.2.0,2.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="[12.0.0,13.0.0)" />
+    <PackageReference Include="Newtonsoft.Json" Version="[12.0.1,13.0.0)" />
     <PackageReference Include="Polly" Version="7.2.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/src/Arcus.Messaging.Tests.Workers.ServiceBus.Queue/Arcus.Messaging.Tests.Workers.ServiceBus.Queue.csproj
+++ b/src/Arcus.Messaging.Tests.Workers.ServiceBus.Queue/Arcus.Messaging.Tests.Workers.ServiceBus.Queue.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.5" />
-    <PackageReference Include="Newtonsoft.Json" Version="[12.0.0,13.0.0)" />
+    <PackageReference Include="Newtonsoft.Json" Version="[12.0.1,13.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Messaging.Tests.Workers.ServiceBus.Topic/Arcus.Messaging.Tests.Workers.ServiceBus.Topic.csproj
+++ b/src/Arcus.Messaging.Tests.Workers.ServiceBus.Topic/Arcus.Messaging.Tests.Workers.ServiceBus.Topic.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.5" />
-    <PackageReference Include="Newtonsoft.Json" Version="[12.0.0,13.0.0)" />
+    <PackageReference Include="Newtonsoft.Json" Version="[12.0.1,13.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Messaging.Tests.Workers/Arcus.Messaging.Tests.Workers.csproj
+++ b/src/Arcus.Messaging.Tests.Workers/Arcus.Messaging.Tests.Workers.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.5" />
-    <PackageReference Include="Newtonsoft.Json" Version="[12.0.0,13.0.0)" />
+    <PackageReference Include="Newtonsoft.Json" Version="[12.0.1,13.0.0)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update Newtonsoft.Json package reference to use 12.0.1 since 12.0.0 does not exist

This is causing build warning:
> [...] Warning NU1603: Arcus.Messaging.Abstractions 1.0.1 depends on Newtonsoft.Json (>= 12.0.0) but Newtonsoft.Json 12.0.0 was not found. An approximate best match of Newtonsoft.Json 12.0.1 was resolved.