### PR TITLE
fix: use camelCase for tcp health probe serialization

### DIFF
--- a/src/Arcus.Messaging.Health/Tcp/TcpHealthListener.cs
+++ b/src/Arcus.Messaging.Health/Tcp/TcpHealthListener.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
 
 namespace Arcus.Messaging.Health.Tcp
 {
@@ -87,7 +88,8 @@ namespace Arcus.Messaging.Health.Tcp
             var serializingSettings = new JsonSerializerSettings
             {
                 Formatting = Formatting.None, 
-                NullValueHandling = NullValueHandling.Ignore
+                NullValueHandling = NullValueHandling.Ignore,
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
             };
 
             var enumConverter = new StringEnumConverter { AllowIntegerValues = false };

--- a/src/Arcus.Messaging.Tests.Integration/Health/HealthReportEntryConverter.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Health/HealthReportEntryConverter.cs
@@ -33,13 +33,13 @@ namespace Arcus.Messaging.Tests.Integration.Health
         {
             JToken token = JToken.Load(reader);
 
-            var healthStatus = token["Status"].ToObject<HealthStatus>();
-            var description = token["Description"]?.ToObject<string>();
-            var duration = token["Duration"].ToObject<TimeSpan>();
-            var exception = token["Exception"]?.ToObject<Exception>();
-            var data = token["Data"]?.ToObject<Dictionary<string, object>>();
+            var healthStatus = token["status"].ToObject<HealthStatus>();
+            var description = token["description"]?.ToObject<string>();
+            var duration = token["duration"].ToObject<TimeSpan>();
+            var exception = token["exception"]?.ToObject<Exception>();
+            var data = token["data"]?.ToObject<Dictionary<string, object>>();
             var readOnlyDictionary = new ReadOnlyDictionary<string, object>(data ?? new Dictionary<string, object>());
-            var tags = token["Tags"]?.ToObject<string[]>();
+            var tags = token["tags"]?.ToObject<string[]>();
             
             return new HealthReportEntry(healthStatus, description, duration, exception, readOnlyDictionary, tags);
         }


### PR DESCRIPTION
We should use camelCasing for the TCP health probe to be consistent with our other repo's JSON settings (like the templates repo).

Closes #226 