### PR TITLE
chore: mark keyrotation as obsolete

### DIFF
--- a/docs/preview/02-Features/message-pumps/service-bus.md
+++ b/docs/preview/02-Features/message-pumps/service-bus.md
@@ -489,55 +489,7 @@ public class DependencyService
 
 ## Automatic Azure Key Vault credentials rotation
 
-The additional library `Arcus.Messaging.Pumps.ServiceBus.KeyRotation` provides an extension on the message pump to restart the pump automatically when the credentials of the pump stored in Azure Key Vault are changed.
-This feature allows more reliable restarting instead of relying on authentication exceptions that may be throwed during the lifetime of the message pump.
-
-## How does this work?
-
-A background job is polling for `SecretNewVersionCreated` events on an Azure Service Bus Topic for the secret that stores the connection string.
-
-That way, when the background job receives a new Key Vault event, it will get the latest connection string, restart the message pump and authenticate with the latest credentials.
-
-### Installation
-
-This features requires to install our NuGet package:
-
-```shell
-PM > Install-Package Arcus.Messaging.Pumps.ServiceBus.KeyRotation
-```
-
-### Usage
-
-When the package is installed, you'll be able to use the extension in your application:
-
-```csharp
-public void ConfigureServices(IServiceCollection services)
-{
-    // You should have a unique Job ID to identity the message pump so the automatic process knows which pump to restart.
-    string jobId = Guid.NewGuid().ToString();
-
-    string secretName = hostContext.Configuration["ARCUS_KEYVAULT_CONNECTIONSTRINGSECRETNAME"];
-    services.AddServiceBusQueueMessagePump(secretName, options => options.JobId = jobId)
-            
-            // This extension will be available to you once you installed the package.
-            .WithAutoRestartServiceBusMessagePumpOnRotatedCredentials(
-                jobId: jobId, 
-                subscriptionNamePrefix: "TestSub", 
-                
-                // The secret key where the Azure Service Bus Topic connection string is located that the background job will use to receive the Azure Key vault events.
-                serviceBusTopicConnectionStringSecretKey: "ARCUS_KEYVAULT_SECRETNEWVERSIONCREATED_CONNECTIONSTRING",
-                
-                // The secret key where the Azure Service Bus connection string is located that your target message pump uses.
-                // This secret key name will be used to check if the received Azure Key Vault event is from this secret or not.
-                messagePumpConnectionStringKey: secretName,
-
-                // The maximum amount of thrown unauthorized exceptions that your message pump should allow before it should restart either way.
-                // This amount can be used to either wait for an Azure Key Vault event or rely on the thrown unauthorized exceptions.
-                maximumUnauthorizedExceptionsBeforeRestart: 5)
-            
-            .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
-}
-```
+This functionality is moved to [Arcus BackgroundJobs](https://background-jobs.arcus-azure.net/Features/Security/auto-restart-servicebus-messagepump-on-rotated-credentials).
 
 ## Want to get started easy? Use our templates!
 

--- a/src/Arcus.Messaging.Pumps.ServiceBus.KeyRotation/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus.KeyRotation/Extensions/IServiceCollectionExtensions.cs
@@ -29,6 +29,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.KeyRotation.Extensions
         ///     Thrown when the <paramref name="services"/> or the searched for <see cref="AzureServiceBusMessagePump"/> based on the given <paramref name="jobId"/> is <c>null</c>.
         /// </exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="subscriptionNamePrefix"/> or <paramref name="serviceBusTopicConnectionStringSecretKey"/> is blank.</exception>
+        [Obsolete("To auto-restart Azure Service Bus message pumps upon rotated credentials, please use the 'Arcus.BackgroundJobs.KeyVault' package instead")]
         public static ServiceBusMessageHandlerCollection WithAutoRestartServiceBusMessagePumpOnRotatedCredentials(
             this ServiceBusMessageHandlerCollection services,
             string jobId,

--- a/src/Arcus.Messaging.Pumps.ServiceBus.KeyRotation/ReAuthenticateOnRotatedCredentialsMessageHandler.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus.KeyRotation/ReAuthenticateOnRotatedCredentialsMessageHandler.cs
@@ -19,6 +19,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.KeyRotation
     /// Represents an <see cref="IMessageHandler{TMessage,TMessageContext}"/> that processes <see cref="CloudEvent"/>s representing <see cref="SecretNewVersionCreated"/> events
     /// that will eventually result in restarting an <see cref="AzureServiceBusMessagePump"/> instance.
     /// </summary>
+    [Obsolete("To auto-restart Azure Service Bus message pumps upon rotated credentials, please use the 'Arcus.BackgroundJobs.KeyVault' package instead")]
     public class ReAuthenticateOnRotatedCredentialsMessageHandler : IAzureServiceBusMessageHandler<CloudEvent>
     {
         private readonly string _targetConnectionStringKey;


### PR DESCRIPTION
Mark the current key rotation functionality as obsolete as this is moved to Arcus BackgroundJobs.

Relates to #229 