### PR TITLE
test: add az func tests to release build

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -109,52 +109,7 @@ stages:
             inputs:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
-          - template: templates/build-and-run-worker-container.yml
-            parameters:
-              projectName: 'Arcus.Messaging.Tests.Workers.ServiceBus.Queue'
-              containerName: '$(Images.ServiceBus.Queue)'
-              imageName: '$(Images.ServiceBus.Queue)'
-              imageTag: $(Build.BuildId)
-              healthPort: $(Arcus.Health.Port.Queue)
-              connectionString: '$(Arcus.ServiceBus.Docker.ConnectionStringWithQueue)'
-          - template: templates/build-and-run-worker-container.yml
-            parameters:
-              projectName: 'Arcus.Messaging.Tests.Workers.ServiceBus.Topic'
-              containerName: '$(Images.ServiceBus.Topic)'
-              imageName: '$(Images.ServiceBus.Topic)'
-              imageTag: $(Build.BuildId)
-              healthPort: $(Arcus.Health.Port.Topic)
-              connectionString: '$(Arcus.ServiceBus.Docker.ConnectionStringWithTopic)'
-          - template: templates/build-and-run-az-func-container.yml
-            parameters:
-              projectName: 'Arcus.Messaging.Tests.Runtimes.AzureFunction.ServiceBus.Queue'
-              containerName: '$(Images.AzureFunction.ServiceBus.Queue)'
-              imageName: '$(Images.AzureFunction.ServiceBus.Queue)'
-              imageTag: '$(Build.BuildId)'
-              port: '$(Arcus.AzureFunctions.Queue.Port)'
-          - template: test/run-integration-tests.yml@templates
-            parameters:
-              dotnetSdkVersion: '$(DotNet.Sdk.Version)'
-              projectName: '$(Project).Tests.Integration'
-              category: 'Docker'
-          - task: PowerShell@2
-            displayName: 'Get Docker container logs for Service Bus Queue worker project'
-            inputs:
-              targetType: 'inline'
-              script: 'docker logs $(Images.ServiceBus.Queue)'
-            condition: failed()
-          - task: PowerShell@2
-            displayName: 'Get Docker container logs for Service Bus Topic worker project'
-            inputs:
-              targetType: 'inline'
-              script: 'docker logs $(Images.ServiceBus.Topic)'
-            condition: failed()
-          - task: PowerShell@2
-            displayName: 'Get Docker container logs for Azure Functions Service Bus Queue project'
-            inputs:
-              targetType: 'inline'
-              script: 'docker logs $(Images.AzureFunction.ServiceBus.Queue)'
-            condition: failed()
+          - template: templates/run-docker-integration-tests.yml
 
   - stage: SelfContainingIntegrationTests
     displayName: Self-Containing Integration Tests

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -75,10 +75,14 @@ stages:
         value: 'workers-service-bus-queue'
       - name: 'Images.ServiceBus.Topic'
         value: 'workers-service-bus-topic'
+      - name: 'Images.AzureFunction.ServiceBus.Queue'
+        value: 'runtimes-az-func-service-bus-queue'
       - name: 'Arcus.Health.Port.Queue'
         value: '42063'
       - name: 'Arcus.Health.Port.Topic'
         value: '42064'
+      - name: 'Arcus.AzureFunctions.Queue.Port'
+        value: '42065'
     jobs:
       - job: DockerIntegrationTests
         displayName: 'Run Docker integration tests'
@@ -90,33 +94,7 @@ stages:
             inputs:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
-          - template: templates/build-and-run-worker-container.yml
-            parameters:
-              projectName: 'Arcus.Messaging.Tests.Workers.ServiceBus.Queue'
-              containerName: '$(Images.ServiceBus.Queue)'
-              imageName: '$(Images.ServiceBus.Queue)'
-              imageTag: $(Build.BuildId)
-              healthPort: $(Arcus.Health.Port.Queue)
-              connectionString: '$(Arcus.ServiceBus.Docker.ConnectionStringWithQueue)'
-          - template: templates/build-and-run-worker-container.yml
-            parameters:
-              projectName: 'Arcus.Messaging.Tests.Workers.ServiceBus.Topic'
-              containerName: '$(Images.ServiceBus.Topic)'
-              imageName: '$(Images.ServiceBus.Topic)'
-              imageTag: $(Build.BuildId)
-              healthPort: $(Arcus.Health.Port.Topic)
-              connectionString: '$(Arcus.ServiceBus.Docker.ConnectionStringWithTopic)'
-          - template: test/run-integration-tests.yml@templates
-            parameters:
-              dotnetSdkVersion: '$(DotNet.Sdk.Version)'
-              projectName: '$(Project).Tests.Integration'
-              category: 'Docker'
-          - task: PowerShell@2
-            displayName: 'Get Docker container logs'
-            inputs:
-              targetType: 'inline'
-              script: 'docker logs $(Images.ServiceBus.Queue)'
-            condition: failed()
+          - template: templates/run-docker-integration-tests.yml
 
   - stage: SelfContainingIntegrationTests
     displayName: Self-Containing Integration Tests

--- a/build/templates/run-docker-integration-tests.yml
+++ b/build/templates/run-docker-integration-tests.yml
@@ -1,0 +1,52 @@
+steps:
+- task: DownloadPipelineArtifact@2
+  displayName: 'Download build artifacts'
+  inputs:
+    artifact: 'Build'
+    path: '$(Build.SourcesDirectory)'
+- template: build-and-run-worker-container.yml
+  parameters:
+    projectName: 'Arcus.Messaging.Tests.Workers.ServiceBus.Queue'
+    containerName: '$(Images.ServiceBus.Queue)'
+    imageName: '$(Images.ServiceBus.Queue)'
+    imageTag: $(Build.BuildId)
+    healthPort: $(Arcus.Health.Port.Queue)
+    connectionString: '$(Arcus.ServiceBus.Docker.ConnectionStringWithQueue)'
+- template: build-and-run-worker-container.yml
+  parameters:
+    projectName: 'Arcus.Messaging.Tests.Workers.ServiceBus.Topic'
+    containerName: '$(Images.ServiceBus.Topic)'
+    imageName: '$(Images.ServiceBus.Topic)'
+    imageTag: $(Build.BuildId)
+    healthPort: $(Arcus.Health.Port.Topic)
+    connectionString: '$(Arcus.ServiceBus.Docker.ConnectionStringWithTopic)'
+- template: build-and-run-az-func-container.yml
+  parameters:
+    projectName: 'Arcus.Messaging.Tests.Runtimes.AzureFunction.ServiceBus.Queue'
+    containerName: '$(Images.AzureFunction.ServiceBus.Queue)'
+    imageName: '$(Images.AzureFunction.ServiceBus.Queue)'
+    imageTag: '$(Build.BuildId)'
+    port: '$(Arcus.AzureFunctions.Queue.Port)'
+- template: test/run-integration-tests.yml@templates
+  parameters:
+    dotnetSdkVersion: '$(DotNet.Sdk.Version)'
+    projectName: '$(Project).Tests.Integration'
+    category: 'Docker'
+- task: PowerShell@2
+  displayName: 'Get Docker container logs for Service Bus Queue worker project'
+  inputs:
+    targetType: 'inline'
+    script: 'docker logs $(Images.ServiceBus.Queue)'
+  condition: failed()
+- task: PowerShell@2
+  displayName: 'Get Docker container logs for Service Bus Topic worker project'
+  inputs:
+    targetType: 'inline'
+    script: 'docker logs $(Images.ServiceBus.Topic)'
+  condition: failed()
+- task: PowerShell@2
+  displayName: 'Get Docker container logs for Azure Functions Service Bus Queue project'
+  inputs:
+    targetType: 'inline'
+    script: 'docker logs $(Images.AzureFunction.ServiceBus.Queue)'
+  condition: failed()


### PR DESCRIPTION
The release Docker integration tests weren't including the Azure Functions Docker test project which made the tests fail.
This fixes that and makes sure that future changes to these tests are by-default ported to the release build.