### PR TITLE
chore: treat warnings as errors

### DIFF
--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Arcus.Messaging.Abstractions.ServiceBus.csproj
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Arcus.Messaging.Abstractions.ServiceBus.csproj
@@ -17,6 +17,8 @@
     <PackageTags>Azure;Messaging;ServiceBus</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Messaging.Abstractions/Arcus.Messaging.Abstractions.csproj
+++ b/src/Arcus.Messaging.Abstractions/Arcus.Messaging.Abstractions.csproj
@@ -17,6 +17,7 @@
     <PackageTags>Azure;Messaging</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
 

--- a/src/Arcus.Messaging.AzureFunctions.ServiceBus/Arcus.Messaging.AzureFunctions.ServiceBus.csproj
+++ b/src/Arcus.Messaging.AzureFunctions.ServiceBus/Arcus.Messaging.AzureFunctions.ServiceBus.csproj
@@ -17,7 +17,10 @@
     <PackageTags>Azure;Messaging;ServiceBus;AzureFunctions</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
   </ItemGroup>  

--- a/src/Arcus.Messaging.Health/Arcus.Messaging.Health.csproj
+++ b/src/Arcus.Messaging.Health/Arcus.Messaging.Health.csproj
@@ -16,6 +16,8 @@
     <PackageTags>Azure;Messaging;Health;Operations</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Messaging.Pumps.Abstractions/Arcus.Messaging.Pumps.Abstractions.csproj
+++ b/src/Arcus.Messaging.Pumps.Abstractions/Arcus.Messaging.Pumps.Abstractions.csproj
@@ -17,6 +17,8 @@
     <PackageTags>Azure;Messaging</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Arcus.Messaging.Pumps.ServiceBus.csproj
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Arcus.Messaging.Pumps.ServiceBus.csproj
@@ -17,6 +17,7 @@
     <PackageTags>Azure;Messaging;ServiceBus</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
 

--- a/src/Arcus.Messaging.Pumps.ServiceBus/KeyRotation/AzureServiceBusKeyRotation.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/KeyRotation/AzureServiceBusKeyRotation.cs
@@ -13,6 +13,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.KeyRotation
     /// <summary>
     /// Represents the functionality to rotate Azure Service Bus connection string keys stored inside a Azure Key Vault.
     /// </summary>
+    [Obsolete("To auto-restart Azure Service Bus message pumps upon rotated credentials, please use the 'Arcus.BackgroundJobs.KeyVault' package instead")]
     public class AzureServiceBusKeyRotation
     {
         private readonly AzureServiceBusClient _serviceBusClient;

--- a/src/Arcus.Messaging.ServiceBus.Core/Arcus.Messaging.ServiceBus.Core.csproj
+++ b/src/Arcus.Messaging.ServiceBus.Core/Arcus.Messaging.ServiceBus.Core.csproj
@@ -17,6 +17,8 @@
     <PackageTags>Azure;Messaging;ServiceBus</PackageTags>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Treat warnings as erors in messaging.

Relates to https://github.com/arcus-azure/arcus/issues/196