### PR TITLE
docs: fix wrong bold syntax for in az service bus functions

### DIFF
--- a/docs/preview/02-Features/message-pumps/service-bus.md
+++ b/docs/preview/02-Features/message-pumps/service-bus.md
@@ -259,7 +259,7 @@ using Arcus.Messaging.Pumps.ServiceBus.MessageHandling;
 using Microsoft.Azure.ServiceBus;
 using Microsoft.Extensions.Logging;
 
-public class WarnsUserFallbackMessageHandler : IAzureServiceBusFallbackMessageHandller
+public class WarnsUserFallbackMessageHandler : IAzureServiceBusFallbackMessageHandler
 {
     private readonly ILogger _logger;
 
@@ -295,7 +295,7 @@ public class Startup
 ## Influence handling of Service Bus message in message handler
 
 When an Azure Service Bus message is received (either via regular message handlers or fallback message handlers), we allow specific Azure Service Bus operations during the message handling.
-Currently we support [**Dead letter**](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues) and [*Abandon**](https://docs.microsoft.com/en-us/dotnet/api/microsoft.servicebus.messaging.messagereceiver.abandon?view=azure-dotnet).
+Currently we support [**Dead letter**](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues) and [**Abandon**](https://docs.microsoft.com/en-us/dotnet/api/microsoft.servicebus.messaging.messagereceiver.abandon?view=azure-dotnet).
 
 ### During (regular) message handling
 

--- a/docs/versioned_docs/version-v0.4.0/02-Features/message-pumps/service-bus.md
+++ b/docs/versioned_docs/version-v0.4.0/02-Features/message-pumps/service-bus.md
@@ -249,7 +249,7 @@ public class Startup
 ## Influence handling of Service Bus message in message handler
 
 When an Azure Service Bus message is received (either via regular message handlers or fallback message handlers), we allow specific Azure Service Bus operations during the message handling.
-Currently we support [**Dead letter**](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues) and [*Abandon**](https://docs.microsoft.com/en-us/dotnet/api/microsoft.servicebus.messaging.messagereceiver.abandon?view=azure-dotnet).
+Currently we support [**Dead letter**](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues) and [**Abandon**](https://docs.microsoft.com/en-us/dotnet/api/microsoft.servicebus.messaging.messagereceiver.abandon?view=azure-dotnet).
 
 ### During (regular) message handling
 

--- a/docs/versioned_docs/version-v0.5.0/02-Features/message-pumps/service-bus.md
+++ b/docs/versioned_docs/version-v0.5.0/02-Features/message-pumps/service-bus.md
@@ -249,7 +249,7 @@ public class Startup
 ## Influence handling of Service Bus message in message handler
 
 When an Azure Service Bus message is received (either via regular message handlers or fallback message handlers), we allow specific Azure Service Bus operations during the message handling.
-Currently we support [**Dead letter**](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues) and [*Abandon**](https://docs.microsoft.com/en-us/dotnet/api/microsoft.servicebus.messaging.messagereceiver.abandon?view=azure-dotnet).
+Currently we support [**Dead letter**](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues) and [**Abandon**](https://docs.microsoft.com/en-us/dotnet/api/microsoft.servicebus.messaging.messagereceiver.abandon?view=azure-dotnet).
 
 ### During (regular) message handling
 

--- a/docs/versioned_docs/version-v0.6.0/02-Features/message-pumps/service-bus.md
+++ b/docs/versioned_docs/version-v0.6.0/02-Features/message-pumps/service-bus.md
@@ -263,7 +263,7 @@ public class Startup
 ## Influence handling of Service Bus message in message handler
 
 When an Azure Service Bus message is received (either via regular message handlers or fallback message handlers), we allow specific Azure Service Bus operations during the message handling.
-Currently we support [**Dead letter**](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues) and [*Abandon**](https://docs.microsoft.com/en-us/dotnet/api/microsoft.servicebus.messaging.messagereceiver.abandon?view=azure-dotnet).
+Currently we support [**Dead letter**](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues) and [**Abandon**](https://docs.microsoft.com/en-us/dotnet/api/microsoft.servicebus.messaging.messagereceiver.abandon?view=azure-dotnet).
 
 ### During (regular) message handling
 

--- a/docs/versioned_docs/version-v1.0.0/02-Features/message-pumps/service-bus.md
+++ b/docs/versioned_docs/version-v1.0.0/02-Features/message-pumps/service-bus.md
@@ -298,7 +298,7 @@ public class Startup
 ## Influence handling of Service Bus message in message handler
 
 When an Azure Service Bus message is received (either via regular message handlers or fallback message handlers), we allow specific Azure Service Bus operations during the message handling.
-Currently we support [**Dead letter**](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues) and [*Abandon**](https://docs.microsoft.com/en-us/dotnet/api/microsoft.servicebus.messaging.messagereceiver.abandon?view=azure-dotnet).
+Currently we support [**Dead letter**](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues) and [**Abandon**](https://docs.microsoft.com/en-us/dotnet/api/microsoft.servicebus.messaging.messagereceiver.abandon?view=azure-dotnet).
 
 ### During (regular) message handling
 

--- a/docs/versioned_docs/version-v1.1.0/02-Features/message-pumps/service-bus.md
+++ b/docs/versioned_docs/version-v1.1.0/02-Features/message-pumps/service-bus.md
@@ -295,7 +295,7 @@ public class Startup
 ## Influence handling of Service Bus message in message handler
 
 When an Azure Service Bus message is received (either via regular message handlers or fallback message handlers), we allow specific Azure Service Bus operations during the message handling.
-Currently we support [**Dead letter**](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues) and [*Abandon**](https://docs.microsoft.com/en-us/dotnet/api/microsoft.servicebus.messaging.messagereceiver.abandon?view=azure-dotnet).
+Currently we support [**Dead letter**](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-dead-letter-queues) and [**Abandon**](https://docs.microsoft.com/en-us/dotnet/api/microsoft.servicebus.messaging.messagereceiver.abandon?view=azure-dotnet).
 
 ### During (regular) message handling
 


### PR DESCRIPTION
Fixes Markdown bold syntax in features docs for Azure Service Bus functions.