### PR TITLE
docs: mention arcus secret store in az servicebus message pump

### DIFF
--- a/docs/preview/02-Features/message-pumps/service-bus.md
+++ b/docs/preview/02-Features/message-pumps/service-bus.md
@@ -131,7 +131,7 @@ Next to that, we provide a **variety of overloads** to allow you to:
 - Specify the name of the queue/topic
 - Only provide a prefix for the topic subscription, so each topic message pump is handling messages on separate subscriptions
 - Configure how the message pump should work *(ie. max concurrent calls & auto delete)*
-- Read the connection string from the configuration *(although we highly recommend using a secret store instead)*
+- Read the connection string from the configuration *(although we highly recommend using the [Arcus secret store](https://security.arcus-azure.net/features/secret-store) instead)*
 
 ```csharp
 using Microsoft.Extensions.DependencyInjection;

--- a/docs/versioned_docs/version-v0.1.0/02-Features/message-pumps/service-bus.md
+++ b/docs/versioned_docs/version-v0.1.0/02-Features/message-pumps/service-bus.md
@@ -107,7 +107,7 @@ Next to that, we provide a **variety of overloads** to allow you to:
 - Specify the name of the queue/topic
 - Only provide a prefix for the topic subscription, so each topic message pump is handling messages on separate subscriptions
 - Configure how the message pump should work *(ie. max concurrent calls & auto delete)*
-- Read the connection string from the configuration *(although we highly recommend using a secret store instead)*
+- Read the connection string from the configuration *(although we highly recommend using the [Arcus secret store](https://security.arcus-azure.net/features/secret-store) instead)*
 
 ```csharp
 using Microsoft.Extensions.DependencyInjection;
@@ -197,7 +197,7 @@ string cycleId = correlationInfo.CycleId;
 // Unique identifier that relates different requests together.
 string transactionId = correlationInfo.TransactionId;
 
-// Unique idenfier that distinguishes the request.
+// Unique identifier that distinguishes the request.
 string operationId = correlationInfo.OperationId;
 ```
 

--- a/docs/versioned_docs/version-v0.2.0/02-Features/message-pumps/service-bus.md
+++ b/docs/versioned_docs/version-v0.2.0/02-Features/message-pumps/service-bus.md
@@ -114,7 +114,7 @@ Next to that, we provide a **variety of overloads** to allow you to:
 - Specify the name of the queue/topic
 - Only provide a prefix for the topic subscription, so each topic message pump is handling messages on separate subscriptions
 - Configure how the message pump should work *(ie. max concurrent calls & auto delete)*
-- Read the connection string from the configuration *(although we highly recommend using a secret store instead)*
+- Read the connection string from the configuration *(although we highly recommend using the [Arcus secret store](https://security.arcus-azure.net/features/secret-store) instead)*
 
 ```csharp
 using Microsoft.Extensions.DependencyInjection;

--- a/docs/versioned_docs/version-v0.3.0/02-Features/message-pumps/service-bus.md
+++ b/docs/versioned_docs/version-v0.3.0/02-Features/message-pumps/service-bus.md
@@ -116,7 +116,7 @@ Next to that, we provide a **variety of overloads** to allow you to:
 - Specify the name of the queue/topic
 - Only provide a prefix for the topic subscription, so each topic message pump is handling messages on separate subscriptions
 - Configure how the message pump should work *(ie. max concurrent calls & auto delete)*
-- Read the connection string from the configuration *(although we highly recommend using a secret store instead)*
+- Read the connection string from the configuration *(although we highly recommend using the [Arcus secret store](https://security.arcus-azure.net/features/secret-store) instead)*
 
 ```csharp
 using Microsoft.Extensions.DependencyInjection;

--- a/docs/versioned_docs/version-v0.4.0/02-Features/message-pumps/service-bus.md
+++ b/docs/versioned_docs/version-v0.4.0/02-Features/message-pumps/service-bus.md
@@ -126,7 +126,7 @@ Next to that, we provide a **variety of overloads** to allow you to:
 - Specify the name of the queue/topic
 - Only provide a prefix for the topic subscription, so each topic message pump is handling messages on separate subscriptions
 - Configure how the message pump should work *(ie. max concurrent calls & auto delete)*
-- Read the connection string from the configuration *(although we highly recommend using a secret store instead)*
+- Read the connection string from the configuration *(although we highly recommend using the [Arcus secret store](https://security.arcus-azure.net/features/secret-store) instead)*
 
 ```csharp
 using Microsoft.Extensions.DependencyInjection;
@@ -190,7 +190,7 @@ public class Startup
                 options.JobId = Guid.NewGuid().ToString();
             });
 
-        // Multiple message handlers can be added to the servies, based on the message type (ex. 'Order', 'Customer'...), 
+        // Multiple message handlers can be added to the services, based on the message type (ex. 'Order', 'Customer'...), 
         // the correct message handler will be selected.
         services.WithServiceBusMessageHandler<OrdersMessageHandler, Order>()
                 .WithMessageHandler<CustomerMessageHandler, Customer>();

--- a/docs/versioned_docs/version-v0.5.0/02-Features/message-pumps/service-bus.md
+++ b/docs/versioned_docs/version-v0.5.0/02-Features/message-pumps/service-bus.md
@@ -126,7 +126,7 @@ Next to that, we provide a **variety of overloads** to allow you to:
 - Specify the name of the queue/topic
 - Only provide a prefix for the topic subscription, so each topic message pump is handling messages on separate subscriptions
 - Configure how the message pump should work *(ie. max concurrent calls & auto delete)*
-- Read the connection string from the configuration *(although we highly recommend using a secret store instead)*
+- Read the connection string from the configuration *(although we highly recommend using the [Arcus secret store](https://security.arcus-azure.net/features/secret-store) instead)*
 
 ```csharp
 using Microsoft.Extensions.DependencyInjection;

--- a/docs/versioned_docs/version-v0.6.0/02-Features/message-pumps/service-bus.md
+++ b/docs/versioned_docs/version-v0.6.0/02-Features/message-pumps/service-bus.md
@@ -130,7 +130,7 @@ Next to that, we provide a **variety of overloads** to allow you to:
 - Specify the name of the queue/topic
 - Only provide a prefix for the topic subscription, so each topic message pump is handling messages on separate subscriptions
 - Configure how the message pump should work *(ie. max concurrent calls & auto delete)*
-- Read the connection string from the configuration *(although we highly recommend using a secret store instead)*
+- Read the connection string from the configuration *(although we highly recommend using the [Arcus secret store](https://security.arcus-azure.net/features/secret-store) instead)*
 
 ```csharp
 using Microsoft.Extensions.DependencyInjection;

--- a/docs/versioned_docs/version-v1.0.0/02-Features/message-pumps/service-bus.md
+++ b/docs/versioned_docs/version-v1.0.0/02-Features/message-pumps/service-bus.md
@@ -134,7 +134,7 @@ Next to that, we provide a **variety of overloads** to allow you to:
 - Specify the name of the queue/topic
 - Only provide a prefix for the topic subscription, so each topic message pump is handling messages on separate subscriptions
 - Configure how the message pump should work *(ie. max concurrent calls & auto delete)*
-- Read the connection string from the configuration *(although we highly recommend using a secret store instead)*
+- Read the connection string from the configuration *(although we highly recommend using the [Arcus secret store](https://security.arcus-azure.net/features/secret-store) instead)*
 
 ```csharp
 using Microsoft.Extensions.DependencyInjection;

--- a/docs/versioned_docs/version-v1.1.0/02-Features/message-pumps/service-bus.md
+++ b/docs/versioned_docs/version-v1.1.0/02-Features/message-pumps/service-bus.md
@@ -131,7 +131,7 @@ Next to that, we provide a **variety of overloads** to allow you to:
 - Specify the name of the queue/topic
 - Only provide a prefix for the topic subscription, so each topic message pump is handling messages on separate subscriptions
 - Configure how the message pump should work *(ie. max concurrent calls & auto delete)*
-- Read the connection string from the configuration *(although we highly recommend using a secret store instead)*
+- Read the connection string from the configuration *(although we highly recommend using the [Arcus secret store](https://security.arcus-azure.net/features/secret-store) instead)*
 
 ```csharp
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
Mention the Arcus secret store when explaining how Azure Service Bus message pumps should be registered.