### PR TITLE
fix: add correlation registration in message router

### DIFF
--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Arcus.Messaging.Abstractions.ServiceBus.csproj
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Arcus.Messaging.Abstractions.ServiceBus.csproj
@@ -20,6 +20,14 @@
     <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Serilog" Version="2.10.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
+    <PackageReference Include="Serilog" Version="2.9.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Arcus.Messaging.Abstractions\Arcus.Messaging.Abstractions.csproj" />
     <ProjectReference Include="..\Arcus.Messaging.ServiceBus.Core\Arcus.Messaging.ServiceBus.Core.csproj" />

--- a/src/Arcus.Messaging.Abstractions/Arcus.Messaging.Abstractions.csproj
+++ b/src/Arcus.Messaging.Abstractions/Arcus.Messaging.Abstractions.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Arcus.Observability.Correlation" Version="[2.4.0,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[2.4.0,3.0.0)" />
     <PackageReference Include="Guard.NET" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
@@ -31,6 +32,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
     <PackageReference Include="Arcus.Observability.Correlation" Version="[2.0.0,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[2.0.0,3.0.0)" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.8,5.0.0)" />

--- a/src/Arcus.Messaging.Abstractions/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/IServiceCollectionExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.MessageHandling;
+using Arcus.Observability.Correlation;
 using GuardNet;
 using Microsoft.Extensions.Logging;
 
@@ -61,6 +63,13 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             Guard.NotNull(services, nameof(services), "Requires a set of services to add the message routing");
             Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message router");
+
+            services.AddCorrelation<MessageCorrelationInfo>()
+                    .AddScoped<IMessageCorrelationInfoAccessor>(serviceProvider =>
+                    {
+                        return new MessageCorrelationInfoAccessor(
+                            serviceProvider.GetRequiredService<ICorrelationInfoAccessor<MessageCorrelationInfo>>());
+                    });
 
             services.AddSingleton<IMessageRouter>(serviceProvider => implementationFactory(serviceProvider));
             return new MessageHandlerCollection(services);

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
@@ -226,6 +226,19 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         }
 
         /// <summary>
+        /// Gets all the registered <see cref="IMessageHandler{TMessage,TMessageContext}"/> instances in the application.
+        /// </summary>
+        /// <param name="serviceProvider">The scoped service provider from which the registered message handlers will be extracted.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
+        protected IEnumerable<MessageHandler> GetRegisteredMessageHandlers(IServiceProvider serviceProvider)
+        {
+            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires a service provider to extract the registered services from");
+            
+            IEnumerable<MessageHandler> handlers = MessageHandler.SubtractFrom(serviceProvider, Logger);
+            return handlers;
+        }
+
+        /// <summary>
         /// Deserializes the incoming <paramref name="message"/> within the <paramref name="messageContext"/> for a specific <paramref name="handler"/>.
         /// </summary>
         /// <param name="message">The incoming message that needs to be deserialized so it can be processed by the <paramref name="handler"/>.</param>

--- a/src/Arcus.Messaging.Abstractions/Telemetry/MessageCorrelationInfoEnricher.cs
+++ b/src/Arcus.Messaging.Abstractions/Telemetry/MessageCorrelationInfoEnricher.cs
@@ -1,0 +1,44 @@
+﻿using Arcus.Observability.Correlation;
+using Arcus.Observability.Telemetry.Serilog.Enrichers;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Arcus.Messaging.Abstractions.Telemetry
+{
+    /// <summary>
+    /// Logger enrichment of the <see cref="MessageCorrelationInfo" /> model.
+    /// </summary>
+    public class MessageCorrelationInfoEnricher : CorrelationInfoEnricher<MessageCorrelationInfo>
+    {
+        private const string CycleId = "CycleId";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:Arcus.Observability.Telemetry.Serilog.Enrichers.CorrelationInfoEnricher`1" /> class.
+        /// </summary>
+        /// <param name="correlationInfoAccessor">The accessor implementation for the custom <see cref="T:Arcus.Observability.Correlation.CorrelationInfo" /> model.</param>
+        public MessageCorrelationInfoEnricher(ICorrelationInfoAccessor<MessageCorrelationInfo> correlationInfoAccessor) 
+            : base(correlationInfoAccessor)
+        {
+        }
+
+        /// <summary>
+        /// Enrich the <paramref name="logEvent" /> with the given <paramref name="correlationInfo" /> model.
+        /// </summary>
+        /// <param name="logEvent">The log event to enrich with correlation information.</param>
+        /// <param name="propertyFactory">The log property factory to create log properties with correlation information.</param>
+        /// <param name="correlationInfo">The correlation model that contains the current correlation information.</param>
+        protected override void EnrichCorrelationInfo(
+            LogEvent logEvent,
+            ILogEventPropertyFactory propertyFactory,
+            MessageCorrelationInfo correlationInfo)
+        {
+            base.EnrichCorrelationInfo(logEvent, propertyFactory, correlationInfo);
+
+            if (!string.IsNullOrEmpty(correlationInfo.CycleId))
+            {
+                LogEventProperty property = propertyFactory.CreateProperty(CycleId, correlationInfo.CycleId);
+                logEvent.AddPropertyIfAbsent(property);
+            }
+        }
+    }
+}

--- a/src/Arcus.Messaging.Abstractions/Telemetry/ObsoleteMessageCorrelationInfoEnricher.cs
+++ b/src/Arcus.Messaging.Abstractions/Telemetry/ObsoleteMessageCorrelationInfoEnricher.cs
@@ -5,11 +5,13 @@ using Arcus.Observability.Telemetry.Serilog.Enrichers;
 using Serilog.Core;
 using Serilog.Events;
 
+// ReSharper disable once CheckNamespace - made deprecated.
 namespace Arcus.Messaging.Pumps.Abstractions.Telemetry
 {
     /// <summary>
     /// Logger enrichment of the <see cref="MessageCorrelationInfo" /> model.
     /// </summary>
+    [Obsolete("Use the message correlation enricher in a different namespace instead: " +  nameof(Messaging.Abstractions.Telemetry.MessageCorrelationInfoEnricher) + " without 'Pumps'")]
     public class MessageCorrelationInfoEnricher : CorrelationInfoEnricher<MessageCorrelationInfo>
     {
         private const string CycleId = "CycleId";

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
@@ -823,13 +823,6 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure Service Bus Queue message pump");
 
-            services.AddCorrelation<MessageCorrelationInfo>()
-                    .AddScoped<IMessageCorrelationInfoAccessor>(serviceProvider =>
-                    {
-                        return new MessageCorrelationInfoAccessor(
-                            serviceProvider.GetRequiredService<ICorrelationInfoAccessor<MessageCorrelationInfo>>());
-                    });
-
             AzureServiceBusMessagePumpOptions options = 
                 DetermineAzureServiceBusMessagePumpOptions(serviceBusEntity, configureQueueMessagePump, configureTopicMessagePump);
 

--- a/src/Arcus.Messaging.Tests.Integration/Arcus.Messaging.Tests.Integration.csproj
+++ b/src/Arcus.Messaging.Tests.Integration/Arcus.Messaging.Tests.Integration.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.EventGrid.Publishing" Version="3.1.0" />
-    <PackageReference Include="Arcus.EventGrid.Testing" Version="3.1.0" />
+    <PackageReference Include="Arcus.EventGrid.Publishing" Version="3.2.0" />
+    <PackageReference Include="Arcus.EventGrid.Testing" Version="3.2.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.4.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />
     <PackageReference Include="Arcus.Testing.Logging" Version="0.2.0" />

--- a/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthService.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthService.cs
@@ -7,7 +7,6 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 using GuardNet;
-using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrderBatchMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrderBatchMessageHandler.cs
@@ -20,9 +20,12 @@ namespace Arcus.Messaging.Tests.Workers.MessageHandlers
         /// <summary>
         /// Initializes a new instance of the <see cref="OrderBatchMessageHandler"/> class.
         /// </summary>
-        public OrderBatchMessageHandler(IEventGridPublisher eventGridPublisher, ILogger<OrdersAzureServiceBusMessageHandler> logger)
+        public OrderBatchMessageHandler(
+            IEventGridPublisher eventGridPublisher, 
+            IMessageCorrelationInfoAccessor correlationAccessor, 
+            ILogger<OrdersAzureServiceBusMessageHandler> logger)
         {
-            _messageHandler = new OrdersAzureServiceBusMessageHandler(eventGridPublisher, logger);
+            _messageHandler = new OrdersAzureServiceBusMessageHandler(eventGridPublisher, correlationAccessor, logger);
         }
 
         /// <summary>

--- a/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersAzureServiceBusCompleteMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Workers/MessageHandlers/OrdersAzureServiceBusCompleteMessageHandler.cs
@@ -16,10 +16,13 @@ namespace Arcus.Messaging.Tests.Workers.MessageHandlers
         /// <summary>
         /// Initializes a new instance of the <see cref="OrdersAzureServiceBusCompleteMessageHandler"/> class.
         /// </summary>
-        public OrdersAzureServiceBusCompleteMessageHandler(IEventGridPublisher eventGridPublisher, ILogger<OrdersAzureServiceBusMessageHandler> logger) 
+        public OrdersAzureServiceBusCompleteMessageHandler(
+            IEventGridPublisher eventGridPublisher, 
+            IMessageCorrelationInfoAccessor correlationAccessor,
+            ILogger<OrdersAzureServiceBusMessageHandler> logger) 
             : base(logger)
         {
-            _orderMessageHandler = new OrdersAzureServiceBusMessageHandler(eventGridPublisher, logger);
+            _orderMessageHandler = new OrdersAzureServiceBusMessageHandler(eventGridPublisher, correlationAccessor, logger);
         }
 
         /// <summary>


### PR DESCRIPTION
Since we need scoped correlation registration outside the message pump (see Azure Functions, where there is no message pump), we need to move to scoped correlation registration to the message router.

Closes #265 