### PR TITLE
chore: add readme and proj url to nuget pkg

### DIFF
--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Arcus.Messaging.Abstractions.ServiceBus.csproj
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Arcus.Messaging.Abstractions.ServiceBus.csproj
@@ -9,7 +9,7 @@
     <Description>Provides Azure Service Bus abstractions for message handling in both message pumps and Azure Functions triggers</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.messaging/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.messaging</PackageProjectUrl>
+    <PackageProjectUrl>https://messaging.arcus-azure.net/</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.messaging</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
@@ -19,6 +19,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Serilog" Version="2.10.0" />

--- a/src/Arcus.Messaging.Abstractions/Arcus.Messaging.Abstractions.csproj
+++ b/src/Arcus.Messaging.Abstractions/Arcus.Messaging.Abstractions.csproj
@@ -9,7 +9,7 @@
     <Description>Provides abstractions for running message pumps</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.messaging/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.messaging</PackageProjectUrl>
+    <PackageProjectUrl>https://messaging.arcus-azure.net/</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.security</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
@@ -19,6 +19,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Arcus.Observability.Correlation" Version="[2.4.0,3.0.0)" />

--- a/src/Arcus.Messaging.AzureFunctions.ServiceBus/Arcus.Messaging.AzureFunctions.ServiceBus.csproj
+++ b/src/Arcus.Messaging.AzureFunctions.ServiceBus/Arcus.Messaging.AzureFunctions.ServiceBus.csproj
@@ -9,7 +9,7 @@
     <Description>Provides Azure Service Bus message handling/routing for Azure Functions.</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.messaging/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.messaging</PackageProjectUrl>
+    <PackageProjectUrl>https://messaging.arcus-azure.net/</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.messaging</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
@@ -19,6 +19,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />

--- a/src/Arcus.Messaging.Health/Arcus.Messaging.Health.csproj
+++ b/src/Arcus.Messaging.Health/Arcus.Messaging.Health.csproj
@@ -9,7 +9,7 @@
     <Description>Provide capability to expose health endpoint for messaging workloads</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.messaging/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.messaging</PackageProjectUrl>
+    <PackageProjectUrl>https://messaging.arcus-azure.net/</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.messaging</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
@@ -19,6 +19,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Guard.NET" Version="2.0.0" />

--- a/src/Arcus.Messaging.Pumps.Abstractions/Arcus.Messaging.Pumps.Abstractions.csproj
+++ b/src/Arcus.Messaging.Pumps.Abstractions/Arcus.Messaging.Pumps.Abstractions.csproj
@@ -9,7 +9,7 @@
     <Description>Provides abstractions for running an Azure Service Bus message pump</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.messaging/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.messaging</PackageProjectUrl>
+    <PackageProjectUrl>https://messaging.arcus-azure.net/</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.messaging</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
@@ -19,6 +19,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[2.4.0,3.0.0)" />

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Arcus.Messaging.Pumps.ServiceBus.csproj
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Arcus.Messaging.Pumps.ServiceBus.csproj
@@ -9,7 +9,7 @@
     <Description>Provides capability to run an Azure Service Bus message pump</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.messaging/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.messaging</PackageProjectUrl>
+    <PackageProjectUrl>https://messaging.arcus-azure.net/</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.messaging</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
@@ -19,6 +19,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="[1.7.0,2.0.0)" />

--- a/src/Arcus.Messaging.ServiceBus.Core/Arcus.Messaging.ServiceBus.Core.csproj
+++ b/src/Arcus.Messaging.ServiceBus.Core/Arcus.Messaging.ServiceBus.Core.csproj
@@ -9,7 +9,7 @@
     <Description>Provides the core capability to use Azure Service Bus</Description>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.messaging/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.messaging</PackageProjectUrl>
+    <PackageProjectUrl>https://messaging.arcus-azure.net/</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.security</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
@@ -19,6 +19,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5125;NU5048</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.2.0" />


### PR DESCRIPTION
Adds the GitHub README file to the NuGet package generation of the projects.
Adds feature docs project URL instead of GitHub URL to NuGet package.

Relates to arcus-azure/arcus#209
Relates to arcus-azure/arcus#208