### PR TITLE
feat: add operation id overload w custom prop name

### DIFF
--- a/src/Arcus.Messaging.ServiceBus.Core/ServiceBusMessageBuilder.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/ServiceBusMessageBuilder.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.ServiceBus
         /// with <paramref name="transactionIdPropertyName"/> as key.
         /// </summary>
         /// <param name="transactionId">The unique identifier of the current transaction.</param>
-        /// <param name="transactionIdPropertyName">The name of the application property for the <paramref name="transactionId"/>.</param>
+        /// <param name="transactionIdPropertyName">The custom name that must be given to the application property that contains the <paramref name="transactionId"/>.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="transactionId"/> or the <paramref name="transactionIdPropertyName"/> is blank.</exception>
         public ServiceBusMessageBuilder WithTransactionId(string transactionId, string transactionIdPropertyName)
         {
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.ServiceBus
         /// with <paramref name="operationParentIdPropertyName"/> as key.
         /// </summary>
         /// <param name="operationParentId">The unique identifier of the current operation.</param>
-        /// <param name="operationParentIdPropertyName">The name of the application property for the <paramref name="operationParentId"/>.</param>
+        /// <param name="operationParentIdPropertyName">The custom name that must be given to the application property that contains the <paramref name="operationParentId"/>.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="operationParentId"/> or the <paramref name="operationParentIdPropertyName"/> is blank.</exception>
         public ServiceBusMessageBuilder WithOperationParentId(
             string operationParentId,

--- a/src/Arcus.Messaging.ServiceBus.Core/ServiceBusMessageBuilder.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/ServiceBusMessageBuilder.cs
@@ -151,11 +151,11 @@ namespace Microsoft.Azure.ServiceBus
                 }
             };
 
-            if (_operationIdProperty.Key is null)
+            if (_operationIdProperty.Key is null && _operationIdProperty.Value is not null)
             {
                 message.CorrelationId = _operationIdProperty.Value?.ToString();
             } 
-            else
+            else if (_operationIdProperty.Value is not null)
             {
                 message.ApplicationProperties.Add(_operationIdProperty);
             }

--- a/src/Arcus.Messaging.ServiceBus.Core/ServiceBusMessageBuilder.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/ServiceBusMessageBuilder.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.ServiceBus
         /// Adds an <paramref name="operationId"/> as an application property in the <see cref="ServiceBusMessage.ApplicationProperties"/>.
         /// </summary>
         /// <param name="operationId">The unique identifier for this operation.</param>
-        /// <param name="operationIdPropertyName">The name of the application property of the <paramref name="operationIdPropertyName"/>.</param>
+        /// <param name="operationIdPropertyName">The name of the application property where the <paramref name="operationId"/> will be set.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="operationId"/> or the <paramref name="operationIdPropertyName"/> is blank.</exception>
         public ServiceBusMessageBuilder WithOperationId(string operationId, string operationIdPropertyName)
         {

--- a/src/Arcus.Messaging.ServiceBus.Core/ServiceBusMessageBuilder.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/ServiceBusMessageBuilder.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.ServiceBus
         /// Adds an <paramref name="operationId"/> as an application property in the <see cref="ServiceBusMessage.ApplicationProperties"/>.
         /// </summary>
         /// <param name="operationId">The unique identifier for this operation.</param>
-        /// <param name="operationIdPropertyName">The name of the application property where the <paramref name="operationId"/> will be set.</param>
+        /// <param name="operationIdPropertyName">The custom name that must be given to the application property that contains the <paramref name="operationId"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="operationId"/> or the <paramref name="operationIdPropertyName"/> is blank.</exception>
         public ServiceBusMessageBuilder WithOperationId(string operationId, string operationIdPropertyName)
         {

--- a/src/Arcus.Messaging.Tests.Unit/ServiceBus/ServiceBusMessageBuilderTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/ServiceBus/ServiceBusMessageBuilderTests.cs
@@ -94,6 +94,23 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             Assert.Equal(transactionId, message.ApplicationProperties[transactionIdPropertyName]);
         }
 
+        [Fact]
+        public void Create_WithTransactionIdPropertyNameTwice_Succeeds()
+        {
+            // Arrange
+            var builder = ServiceBusMessageBuilder.CreateForBody(messageBody: 1);
+            var transactionId = $"transaction-{Guid.NewGuid()}";
+            var wrongPropertyName = "MyTransaction";
+
+            // Act
+            builder.WithTransactionId(transactionId, wrongPropertyName).WithTransactionId(transactionId);
+
+            // Assert
+            ServiceBusMessage message = builder.Build();
+            Assert.Equal(transactionId, message.ApplicationProperties[PropertyNames.TransactionId]);
+            Assert.DoesNotContain(wrongPropertyName, message.ApplicationProperties.Keys);
+        }
+
         [Theory]
         [ClassData(typeof(Blanks))]
         public void CreateWithDefaultTransactionId_WithoutTransactionId_Fails(string transactionId)
@@ -144,6 +161,23 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             Assert.Equal(operationId, message.CorrelationId);
         }
 
+        [Fact]
+        public void Create_WithOperationIdPropertyName_Succeeds()
+        {
+            // Arrange
+            var builder = ServiceBusMessageBuilder.CreateForBody(messageBody: 1);
+            var operationId = $"operation-{Guid.NewGuid()}";
+            var operationIdPropertyName = "MyOperation";
+
+            // Act
+            builder.WithOperationId(operationId, operationIdPropertyName);
+
+            // Assert
+            ServiceBusMessage message = builder.Build();
+            Assert.NotEqual(operationId, message.CorrelationId);
+            Assert.Equal(operationId, message.ApplicationProperties[operationIdPropertyName]);
+        }
+
         [Theory]
         [ClassData(typeof(Blanks))]
         public void Create_WithoutOperationId_Fails(string operationId)
@@ -153,6 +187,46 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
 
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(() => builder.WithOperationId(operationId));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void CreateWithPropertyName_WithoutOperationId_Fails(string operationId)
+        {
+            // Arrange
+            var builder = ServiceBusMessageBuilder.CreateForBody(messageBody: 1);
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.WithOperationId(operationId));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void CreateWithPropertyName_WithoutOperationIdPropertyName_Fails(string operationIdPropertyName)
+        {
+            // Arrange
+            var builder = ServiceBusMessageBuilder.CreateForBody(messageBody: 1);
+            var operationId = $"operation-{Guid.NewGuid()}";
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => builder.WithOperationId(operationId, operationIdPropertyName));
+        }
+
+        [Fact]
+        public void Create_WithOperationIdPropertyNameTwice_Succeeds()
+        {
+            // Arrange
+            var builder = ServiceBusMessageBuilder.CreateForBody(messageBody: 1);
+            var operationId = $"operation-{Guid.NewGuid()}";
+            var wrongPropertyName = "MyOperation";
+
+            // Act
+            builder.WithOperationId(operationId, wrongPropertyName).WithOperationId(operationId);
+
+            // Assert
+            ServiceBusMessage message = builder.Build();
+            Assert.Equal(operationId, message.CorrelationId);
+            Assert.DoesNotContain(wrongPropertyName, message.ApplicationProperties.Keys);
         }
 
         [Fact]
@@ -184,6 +258,23 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             // Assert
             ServiceBusMessage message = builder.Build();
             Assert.Equal(operationParentId, message.ApplicationProperties[operationParentIdPropertyName]);
+        }
+
+        [Fact]
+        public void Create_WithOperationParentIdPropertyNameTwice_Succeeds()
+        {
+            // Arrange
+            var builder = ServiceBusMessageBuilder.CreateForBody(messageBody: 1);
+            var operationParentId = $"operation-{Guid.NewGuid()}";
+            var wrongPropertyName = "MyOperation";
+
+            // Act
+            builder.WithOperationParentId(operationParentId, wrongPropertyName).WithOperationParentId(operationParentId);
+
+            // Assert
+            ServiceBusMessage message = builder.Build();
+            Assert.Equal(operationParentId, message.ApplicationProperties[PropertyNames.OperationParentId]);
+            Assert.DoesNotContain(wrongPropertyName, message.ApplicationProperties.Keys);
         }
 
         [Theory]


### PR DESCRIPTION
Adds method overload in Azure Service Bus message builder to include the operation ID as a custom application property.

Closes #279