### PR TITLE
chore: inform consumer about secret store dependency

### DIFF
--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpSettings.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpSettings.cs
@@ -9,6 +9,7 @@ using Azure.Messaging.ServiceBus.Administration;
 using GuardNet;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -306,9 +307,11 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
 
             if (userDefinedSecretProvider is null)
             {
-                throw new KeyNotFoundException(
-                    $"No configured {nameof(ICachedSecretProvider)} or {nameof(ISecretProvider)} implementation found in the service container. "
-                    + "Please configure such an implementation (ex. in the Startup) of your application");
+                throw new InvalidOperationException(
+                    "Could not retrieve the Azure Service Bus connection string from the Arcus secret store because no secret store was configured in the application,"
+                    + $"please configure the Arcus secret store with '{nameof(IHostBuilderExtensions.ConfigureSecretStore)}' on the application '{nameof(IHost)}' "
+                    + $"or during the service collection registration 'AddSecretStore' on the application '{nameof(IServiceCollection)}'."
+                    + "For more information on the Arcus secret store, see: https://security.arcus-azure.net/features/secret-store");
             }
 
             Task<string> getConnectionStringTask = _getConnectionStringFromSecretFunc(userDefinedSecretProvider);

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
@@ -25,7 +25,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Adds a message pump to consume messages from Azure Service Bus Queue.
         /// </summary>
         /// <remarks>
-        ///     When using this approach; the connection string should be scoped to the queue that is being processed, not the namespace.
+        ///     <para>When using this approach; the connection string should be scoped to the queue that is being processed, not the namespace.</para>
+        ///     <para>Make sure that the application has the Arcus secret store configured correctly.
+        ///           For on the Arcus secret store: <a href="https://security.arcus-azure.net/features/secret-store" />.</para>
         /// </remarks>
         /// <param name="services">The collection of services to add the message pump to.</param>
         /// <param name="getConnectionStringFromSecretFunc">The function to look up the connection string scoped to the Azure Service Bus Queue from the secret store.</param>
@@ -52,7 +54,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Adds a message pump to consume messages from Azure Service Bus Queue.
         /// </summary>
         /// <remarks>
-        ///     When using this approach; the connection string should be scoped to the queue that is being processed, not the namespace.
+        ///     <para>When using this approach; the connection string should be scoped to the queue that is being processed, not the namespace.</para>
+        ///     <para>Make sure that the application has the Arcus secret store configured correctly.
+        ///           For on the Arcus secret store: <a href="https://security.arcus-azure.net/features/secret-store" />.</para>
         /// </remarks>
         /// <param name="services">The collection of services to add the message pump to.</param>
         /// <param name="getConnectionStringFromConfigurationFunc">The function to look up the connection string scoped to the Azure Service Bus Queue from the configuration.</param>
@@ -79,7 +83,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Adds a message pump to consume messages from Azure Service Bus Queue
         /// </summary>
         /// <remarks>
-        ///     When using this approach; the connection string should be scoped to the queue that is being processed, not the namespace.
+        ///     <para>When using this approach; the connection string should be scoped to the queue that is being processed, not the namespace.</para>
+        ///     <para>Make sure that the application has the Arcus secret store configured correctly.
+        ///           For on the Arcus secret store: <a href="https://security.arcus-azure.net/features/secret-store" />.</para>
         /// </remarks>
         /// <param name="services">The collection of services to add the message pump to.</param>
         /// <param name="secretName">
@@ -108,6 +114,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Adds a message pump to consume messages from Azure Service Bus Queue
         /// </summary>
+        /// <remarks>
+        ///     Make sure that the application has the Arcus secret store configured correctly.
+        ///     For on the Arcus secret store: <a href="https://security.arcus-azure.net/features/secret-store" />.
+        /// </remarks>
         /// <param name="services">The collection of services to add the message pump to.</param>
         /// <param name="queueName">The name of the Azure Service Bus Queue to process.</param>
         /// <param name="secretName">
@@ -138,6 +148,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Adds a message pump to consume messages from Azure Service Bus Queue.
         /// </summary>
+        /// <remarks>
+        ///     Make sure that the application has the Arcus secret store configured correctly.
+        ///     For on the Arcus secret store: <a href="https://security.arcus-azure.net/features/secret-store" />.
+        /// </remarks>
         /// <param name="queueName">The name of the Azure Service Bus Queue to process.</param>
         /// <param name="services">The collection of services to add the message pump to.</param>
         /// <param name="getConnectionStringFromSecretFunc">The function to look up the connection string scoped to the Azure Service Bus Queue from the secret store.</param>
@@ -258,7 +272,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Adds a message pump to consume messages from Azure Service Bus Topic.
         /// </summary>
         /// <remarks>
-        ///     When using this approach; the connection string should be scoped to the topic that is being processed, not the namespace.
+        ///     <para>When using this approach; the connection string should be scoped to the topic that is being processed, not the namespace.</para>
+        ///     <para>Make sure that the application has the Arcus secret store configured correctly.
+        ///           For on the Arcus secret store: <a href="https://security.arcus-azure.net/features/secret-store" />.</para>
         /// </remarks>
         /// <param name="subscriptionName">The name of the Azure Service Bus Topic subscription to process.</param>
         /// <param name="services">The collection of services to add the message pump to.</param>
@@ -293,7 +309,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Adds a message pump to consume messages from Azure Service Bus Topic.
         /// </summary>
         /// <remarks>
-        ///     When using this approach; the connection string should be scoped to the topic that is being processed, not the namespace.
+        ///     <para>When using this approach; the connection string should be scoped to the topic that is being processed, not the namespace.</para>
+        ///     <para>Make sure that the application has the Arcus secret store configured correctly.
+        ///           For on the Arcus secret store: <a href="https://security.arcus-azure.net/features/secret-store" />.</para>
         /// </remarks>
         /// <param name="subscriptionName">The name of the Azure Service Bus Topic subscription to process.</param>
         /// <param name="services">The collection of services to add the message pump to.</param>
@@ -361,6 +379,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Adds a message pump to consume messages from Azure Service Bus Topic.
         /// </summary>
+        /// <remarks>
+        ///     Make sure that the application has the Arcus secret store configured correctly.
+        ///     For on the Arcus secret store: <a href="https://security.arcus-azure.net/features/secret-store" />.
+        /// </remarks>
         /// <param name="topicName">The name of the Azure Service Bus Topic to process.</param>
         /// <param name="subscriptionName">The name of the Azure Service Bus Topic subscription to process</param>
         /// <param name="services">The collection of services to add the message pump to.</param>
@@ -397,6 +419,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Adds a message pump to consume messages from Azure Service Bus Topic.
         /// </summary>
+        /// <remarks>
+        ///     Make sure that the application has the Arcus secret store configured correctly.
+        ///     For on the Arcus secret store: <a href="https://security.arcus-azure.net/features/secret-store" />.
+        /// </remarks>
         /// <param name="topicName">The name of the Azure Service Bus Topic to process.</param>
         /// <param name="subscriptionName">The name of the Azure Service Bus Topic subscription to process.</param>
         /// <param name="services">The collection of services to add the message pump to.</param>
@@ -504,7 +530,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Adds a message pump to consume messages from Azure Service Bus Topic.
         /// </summary>
         /// <remarks>
-        ///     When using this approach; the connection string should be scoped to the topic that is being processed, not the namespace.
+        ///     <para>When using this approach; the connection string should be scoped to the topic that is being processed, not the namespace.</para>
+        ///     <para>Make sure that the application has the Arcus secret store configured correctly.
+        ///           For on the Arcus secret store: <a href="https://security.arcus-azure.net/features/secret-store" />.</para>
         /// </remarks>
         /// <param name="services">The collection of services to add the message pump to.</param>
         /// <param name="subscriptionPrefix">
@@ -540,7 +568,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Adds a message pump to consume messages from Azure Service Bus Topic.
         /// </summary>
         /// <remarks>
-        ///     When using this approach; the connection string should be scoped to the topic that is being processed, not the namespace.
+        ///     <para>When using this approach; the connection string should be scoped to the topic that is being processed, not the namespace.</para>
+        ///     <para>Make sure that the application has the Arcus secret store configured correctly.
+        ///           For on the Arcus secret store: <a href="https://security.arcus-azure.net/features/secret-store" />.</para>
         /// </remarks>
         /// <param name="services">The collection of services to add the message pump to.</param>
         /// <param name="subscriptionPrefix">
@@ -610,6 +640,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Adds a message pump to consume messages from Azure Service Bus Topic.
         /// </summary>
+        /// <remarks>
+        ///     Make sure that the application has the Arcus secret store configured correctly.
+        ///     For on the Arcus secret store: <a href="https://security.arcus-azure.net/features/secret-store" />.
+        /// </remarks>
         /// <param name="services">The collection of services to add the message pump to.</param>
         /// <param name="topicName">The name of the Azure Service Bus Topic to process.</param>
         /// <param name="subscriptionPrefix">
@@ -648,6 +682,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Adds a message pump to consume messages from Azure Service Bus Topic
         /// </summary>
+        /// <remarks>
+        ///     Make sure that the application has the Arcus secret store configured correctly.
+        ///     For on the Arcus secret store: <a href="https://security.arcus-azure.net/features/secret-store" />.
+        /// </remarks>
         /// <param name="services">The collection of services to add the message pump to.</param>
         /// <param name="topicName">The name of the Azure Service Bus Topic to process.</param>
         /// <param name="subscriptionPrefix">


### PR DESCRIPTION
Informs the consumer about the Arcus secret store dependency when registering the Azure Service Bus message pump.

Follow-up of https://github.com/arcus-azure/arcus.backgroundjobs/issues/140