### PR TITLE
fix: relax correlation properties guards in message builder

### DIFF
--- a/src/Arcus.Messaging.Tests.Unit/Arcus.Messaging.Tests.Unit.csproj
+++ b/src/Arcus.Messaging.Tests.Unit/Arcus.Messaging.Tests.Unit.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="3.1.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 

--- a/src/Arcus.Messaging.Tests.Unit/Fixture/Order.cs
+++ b/src/Arcus.Messaging.Tests.Unit/Fixture/Order.cs
@@ -7,10 +7,69 @@ namespace Arcus.Messaging.Tests.Unit.Fixture
     /// <summary>
     /// Test message implementation to test specific message handling scenario's.
     /// </summary>
-    public class Order
+    public class Order : IEquatable<Order>
     {
         public string OrderId { get; set; }
 
         public string CustomerName { get; set; }
+
+        /// <summary>Indicates whether the current object is equal to another object of the same type.</summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// <see langword="true" /> if the current object is equal to the <paramref name="other" /> parameter; otherwise, <see langword="false" />.</returns>
+        public bool Equals(Order other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return OrderId == other.OrderId && CustomerName == other.CustomerName;
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <param name="obj">The object to compare with the current object.</param>
+        /// <returns>
+        /// <see langword="true" /> if the specified object  is equal to the current object; otherwise, <see langword="false" />.</returns>
+        public override bool Equals(object obj)
+        {
+            if (obj is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj is Order order && Equals(order);
+        }
+
+        /// <summary>
+        /// Serves as the default hash function.
+        /// </summary>
+        /// <returns>A hash code for the current object.</returns>
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(OrderId, CustomerName);
+        }
+
+        public static bool operator ==(Order left, Order right)
+        {
+            return Equals(left, right);
+        }
+
+        public static bool operator !=(Order left, Order right)
+        {
+            return !Equals(left, right);
+        }
     }
 }


### PR DESCRIPTION
Relaxes the guards for correlation properties in the Azure Service Bus message builder.

Closes #293