### PR TITLE
feat: use message correlation model directly

### DIFF
--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
@@ -8,6 +8,7 @@ using Arcus.Observability.Telemetry.Core;
 using Arcus.Messaging.Abstractions.Telemetry;
 using Azure.Messaging.ServiceBus;
 using GuardNet;
+using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -212,6 +213,9 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
             {
                 try
                 {
+                    var accessor = serviceScope.ServiceProvider.GetRequiredService<IMessageCorrelationInfoAccessor>();
+                    accessor.SetCorrelationInfo(correlationInfo);
+
                     await TryRouteMessageWithPotentialFallbackAsync(serviceScope.ServiceProvider, messageReceiver, message, messageContext, correlationInfo, cancellationToken);
                     isSuccessful = true;
                 }

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
@@ -208,7 +208,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
             var isSuccessful = false;
             using (DurationMeasurement measurement = DurationMeasurement.Start())
             using (IServiceScope serviceScope = ServiceProvider.CreateScope())
-            using (UsingMessageCorrelationEnricher(serviceScope.ServiceProvider, correlationInfo))
+            using (LogContext.Push(new MessageCorrelationInfoEnricher(correlationInfo)))
             {
                 try
                 {

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
@@ -213,8 +213,8 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
             {
                 try
                 {
-                    var accessor = serviceScope.ServiceProvider.GetRequiredService<IMessageCorrelationInfoAccessor>();
-                    accessor.SetCorrelationInfo(correlationInfo);
+                    var accessor = serviceScope.ServiceProvider.GetService<IMessageCorrelationInfoAccessor>();
+                    accessor?.SetCorrelationInfo(correlationInfo);
 
                     await TryRouteMessageWithPotentialFallbackAsync(serviceScope.ServiceProvider, messageReceiver, message, messageContext, correlationInfo, cancellationToken);
                     isSuccessful = true;

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
@@ -149,6 +149,9 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             using (IServiceScope serviceScope = ServiceProvider.CreateScope())
             using (LogContext.Push(new MessageCorrelationInfoEnricher(correlationInfo)))
             {
+                var accessor = serviceScope.ServiceProvider.GetRequiredService<IMessageCorrelationInfoAccessor>();
+                accessor.SetCorrelationInfo(correlationInfo);
+
                 bool isProcessed = await TryProcessMessageAsync(serviceScope.ServiceProvider, message, messageContext, correlationInfo, cancellationToken);
                 return isProcessed; 
             }
@@ -180,6 +183,9 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             using (IServiceScope serviceScope = ServiceProvider.CreateScope())
             using (LogContext.Push(new MessageCorrelationInfoEnricher(correlationInfo)))
             {
+                var accessor = serviceScope.ServiceProvider.GetRequiredService<IMessageCorrelationInfoAccessor>();
+                accessor.SetCorrelationInfo(correlationInfo);
+
                 await RouteMessageAsync(serviceScope.ServiceProvider, message, messageContext, correlationInfo, cancellationToken);
             }
         }
@@ -217,7 +223,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             CancellationToken cancellationToken)
             where TMessageContext : MessageContext
         {
-            bool isProcessed = await TryProcessMessageAsync(serviceProvider, message, messageContext, correlationInfo, cancellationToken);
+           bool isProcessed = await TryProcessMessageAsync(serviceProvider, message, messageContext, correlationInfo, cancellationToken);
             if (isProcessed)
             {
                 return;

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
@@ -147,7 +147,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires correlation information to send to the message handler");
 
             using (IServiceScope serviceScope = ServiceProvider.CreateScope())
-            using (UsingMessageCorrelationEnricher(serviceScope.ServiceProvider, correlationInfo))
+            using (LogContext.Push(new MessageCorrelationInfoEnricher(correlationInfo)))
             {
                 bool isProcessed = await TryProcessMessageAsync(serviceScope.ServiceProvider, message, messageContext, correlationInfo, cancellationToken);
                 return isProcessed; 
@@ -178,7 +178,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires correlation information to send to the message handler");
 
             using (IServiceScope serviceScope = ServiceProvider.CreateScope())
-            using (UsingMessageCorrelationEnricher(serviceScope.ServiceProvider, correlationInfo))
+            using (LogContext.Push(new MessageCorrelationInfoEnricher(correlationInfo)))
             {
                 await RouteMessageAsync(serviceScope.ServiceProvider, message, messageContext, correlationInfo, cancellationToken);
             }
@@ -193,6 +193,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         ///     A temporary set of a Serilog message correlation enricher on the Serilog <see cref="LogContext"/>.
         /// </returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> or <paramref name="correlationInfo"/> is <c>null</c>.</exception>
+        [Obsolete("Use the " + nameof(MessageCorrelationInfoAccessor) + " directly with the message correlation model")]
         protected IDisposable UsingMessageCorrelationEnricher(IServiceProvider serviceProvider, MessageCorrelationInfo correlationInfo)
         {
             Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires a scoped service provider to extract the message correlation accessor");

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
@@ -149,8 +149,8 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             using (IServiceScope serviceScope = ServiceProvider.CreateScope())
             using (LogContext.Push(new MessageCorrelationInfoEnricher(correlationInfo)))
             {
-                var accessor = serviceScope.ServiceProvider.GetRequiredService<IMessageCorrelationInfoAccessor>();
-                accessor.SetCorrelationInfo(correlationInfo);
+                var accessor = serviceScope.ServiceProvider.GetService<IMessageCorrelationInfoAccessor>();
+                accessor?.SetCorrelationInfo(correlationInfo);
 
                 bool isProcessed = await TryProcessMessageAsync(serviceScope.ServiceProvider, message, messageContext, correlationInfo, cancellationToken);
                 return isProcessed; 
@@ -183,8 +183,8 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             using (IServiceScope serviceScope = ServiceProvider.CreateScope())
             using (LogContext.Push(new MessageCorrelationInfoEnricher(correlationInfo)))
             {
-                var accessor = serviceScope.ServiceProvider.GetRequiredService<IMessageCorrelationInfoAccessor>();
-                accessor.SetCorrelationInfo(correlationInfo);
+                var accessor = serviceScope.ServiceProvider.GetService<IMessageCorrelationInfoAccessor>();
+                accessor?.SetCorrelationInfo(correlationInfo);
 
                 await RouteMessageAsync(serviceScope.ServiceProvider, message, messageContext, correlationInfo, cancellationToken);
             }

--- a/src/Arcus.Messaging.Abstractions/Telemetry/MessageCorrelationInfoEnricher.cs
+++ b/src/Arcus.Messaging.Abstractions/Telemetry/MessageCorrelationInfoEnricher.cs
@@ -1,5 +1,7 @@
-﻿using Arcus.Observability.Correlation;
-using Arcus.Observability.Telemetry.Serilog.Enrichers;
+﻿using System;
+using Arcus.Observability.Correlation;
+using Arcus.Observability.Telemetry.Core;
+using GuardNet;
 using Serilog.Core;
 using Serilog.Events;
 
@@ -8,35 +10,70 @@ namespace Arcus.Messaging.Abstractions.Telemetry
     /// <summary>
     /// Logger enrichment of the <see cref="MessageCorrelationInfo" /> model.
     /// </summary>
-    public class MessageCorrelationInfoEnricher : CorrelationInfoEnricher<MessageCorrelationInfo>
+    public class MessageCorrelationInfoEnricher : ILogEventEnricher
     {
+        private readonly ICorrelationInfoAccessor<MessageCorrelationInfo> _correlationInfoAccessor;
+        private readonly MessageCorrelationInfo _messageCorrelationInfo;
         private const string CycleId = "CycleId";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="T:Arcus.Observability.Telemetry.Serilog.Enrichers.CorrelationInfoEnricher`1" /> class.
         /// </summary>
         /// <param name="correlationInfoAccessor">The accessor implementation for the custom <see cref="T:Arcus.Observability.Correlation.CorrelationInfo" /> model.</param>
-        public MessageCorrelationInfoEnricher(ICorrelationInfoAccessor<MessageCorrelationInfo> correlationInfoAccessor) 
-            : base(correlationInfoAccessor)
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="correlationInfoAccessor"/> is <c>null</c>.</exception>
+        [Obsolete("Use the constructor overload with the message correlation model instead")]
+        public MessageCorrelationInfoEnricher(ICorrelationInfoAccessor<MessageCorrelationInfo> correlationInfoAccessor)
         {
+            Guard.NotNull(correlationInfoAccessor, nameof(correlationInfoAccessor), "Requires a correlation accessor to retrieve the correlation information that needs to be enriched on the log events");
+            _correlationInfoAccessor = correlationInfoAccessor;
         }
 
         /// <summary>
-        /// Enrich the <paramref name="logEvent" /> with the given <paramref name="correlationInfo" /> model.
+        /// Initializes a new instance of the <see cref="MessageCorrelationInfoEnricher" /> class.
         /// </summary>
-        /// <param name="logEvent">The log event to enrich with correlation information.</param>
-        /// <param name="propertyFactory">The log property factory to create log properties with correlation information.</param>
-        /// <param name="correlationInfo">The correlation model that contains the current correlation information.</param>
-        protected override void EnrichCorrelationInfo(
-            LogEvent logEvent,
-            ILogEventPropertyFactory propertyFactory,
-            MessageCorrelationInfo correlationInfo)
+        /// <param name="messageCorrelationInfo">The current message correlation instance that should be enriched on the log events.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="messageCorrelationInfo"/> is <c>null</c>.</exception>
+        public MessageCorrelationInfoEnricher(MessageCorrelationInfo messageCorrelationInfo)
         {
-            base.EnrichCorrelationInfo(logEvent, propertyFactory, correlationInfo);
+            Guard.NotNull(messageCorrelationInfo, nameof(messageCorrelationInfo), "Requires a message correlation instance to enrich the log events");
+            _messageCorrelationInfo = messageCorrelationInfo;
+        }
 
-            if (!string.IsNullOrEmpty(correlationInfo.CycleId))
+        /// <summary>
+        /// Enrich the log event.
+        /// </summary>
+        /// <param name="logEvent">The log event to enrich.</param>
+        /// <param name="propertyFactory">Factory for creating new properties to add to the event.</param>
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            MessageCorrelationInfo correlation = DetermineMessageCorrelationInfo();
+            if (correlation is null)
             {
-                LogEventProperty property = propertyFactory.CreateProperty(CycleId, correlationInfo.CycleId);
+                return;
+            }
+
+            AddPropertyIfAbsent(ContextProperties.Correlation.OperationId, correlation.OperationId, logEvent, propertyFactory);
+            AddPropertyIfAbsent(ContextProperties.Correlation.TransactionId, correlation.TransactionId, logEvent, propertyFactory);
+            AddPropertyIfAbsent(ContextProperties.Correlation.OperationParentId, correlation.OperationParentId, logEvent, propertyFactory);
+            AddPropertyIfAbsent(CycleId, correlation.CycleId, logEvent, propertyFactory);
+        }
+
+        private MessageCorrelationInfo DetermineMessageCorrelationInfo()
+        {
+            if (_messageCorrelationInfo != null)
+            {
+                return _messageCorrelationInfo;
+            }
+
+            MessageCorrelationInfo correlation = _correlationInfoAccessor?.GetCorrelationInfo();
+            return correlation;
+        }
+
+        private static void AddPropertyIfAbsent(string propertyName, string propertyValue, LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            if (!string.IsNullOrEmpty(propertyValue))
+            {
+                LogEventProperty property = propertyFactory.CreateProperty(propertyName, propertyValue);
                 logEvent.AddPropertyIfAbsent(property);
             }
         }


### PR DESCRIPTION
Use the message correlation model directly instead of doing a detour via the message correlation accessor.
This will make sure that we have the correct message correlation is used and will be more efficient and stable instead of going through the service provider.

Closes #301