### PR TITLE
feat: make message correlation enrichment properties configurable

### DIFF
--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
@@ -209,7 +209,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
             var isSuccessful = false;
             using (DurationMeasurement measurement = DurationMeasurement.Start())
             using (IServiceScope serviceScope = ServiceProvider.CreateScope())
-            using (LogContext.Push(new MessageCorrelationInfoEnricher(correlationInfo)))
+            using (LogContext.Push(new MessageCorrelationInfoEnricher(correlationInfo, Options.Telemetry)))
             {
                 try
                 {

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
@@ -209,7 +209,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
             var isSuccessful = false;
             using (DurationMeasurement measurement = DurationMeasurement.Start())
             using (IServiceScope serviceScope = ServiceProvider.CreateScope())
-            using (LogContext.Push(new MessageCorrelationInfoEnricher(correlationInfo, Options.Telemetry)))
+            using (LogContext.Push(new MessageCorrelationInfoEnricher(correlationInfo, Options.CorrelationEnricher)))
             {
                 try
                 {

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageCorrelationEnricherOptions.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageCorrelationEnricherOptions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Arcus.Messaging.Abstractions.Telemetry;
+using Arcus.Observability.Telemetry.Serilog.Enrichers.Configuration;
+using GuardNet;
+
+namespace Arcus.Messaging.Abstractions.MessageHandling
+{
+    /// <summary>
+    /// Represents the consumer configurable options model to change the behavior of the Serilog <see cref="MessageCorrelationInfoEnricher"/>.
+    /// </summary>
+    internal class MessageCorrelationEnricherOptions : CorrelationInfoEnricherOptions
+    {
+        private string _cycleIdPropertyName = "CycleId";
+
+        /// <summary>
+        /// Gets or sets the property name to enrich the log event with the correlation information cycle ID.
+        /// </summary>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="value"/> is blank.</exception>
+        public string CycleIdPropertyName
+        {
+            get => _cycleIdPropertyName;
+            set
+            {
+                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank property name to enrich the log event with the correlation information cycle ID");
+                _cycleIdPropertyName = value;
+            }
+        }
+    }
+}

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageCorrelationEnricherOptions.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageCorrelationEnricherOptions.cs
@@ -8,7 +8,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
     /// <summary>
     /// Represents the consumer configurable options model to change the behavior of the Serilog <see cref="MessageCorrelationInfoEnricher"/>.
     /// </summary>
-    internal class MessageCorrelationEnricherOptions : CorrelationInfoEnricherOptions
+    public class MessageCorrelationEnricherOptions : CorrelationInfoEnricherOptions
     {
         private string _cycleIdPropertyName = "CycleId";
 

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
@@ -147,7 +147,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires correlation information to send to the message handler");
 
             using (IServiceScope serviceScope = ServiceProvider.CreateScope())
-            using (LogContext.Push(new MessageCorrelationInfoEnricher(correlationInfo)))
+            using (LogContext.Push(new MessageCorrelationInfoEnricher(correlationInfo, Options.Telemetry)))
             {
                 var accessor = serviceScope.ServiceProvider.GetService<IMessageCorrelationInfoAccessor>();
                 accessor?.SetCorrelationInfo(correlationInfo);
@@ -181,7 +181,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires correlation information to send to the message handler");
 
             using (IServiceScope serviceScope = ServiceProvider.CreateScope())
-            using (LogContext.Push(new MessageCorrelationInfoEnricher(correlationInfo)))
+            using (LogContext.Push(new MessageCorrelationInfoEnricher(correlationInfo, Options.Telemetry)))
             {
                 var accessor = serviceScope.ServiceProvider.GetService<IMessageCorrelationInfoAccessor>();
                 accessor?.SetCorrelationInfo(correlationInfo);

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
@@ -147,7 +147,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires correlation information to send to the message handler");
 
             using (IServiceScope serviceScope = ServiceProvider.CreateScope())
-            using (LogContext.Push(new MessageCorrelationInfoEnricher(correlationInfo, Options.Telemetry)))
+            using (LogContext.Push(new MessageCorrelationInfoEnricher(correlationInfo, Options.CorrelationEnricher)))
             {
                 var accessor = serviceScope.ServiceProvider.GetService<IMessageCorrelationInfoAccessor>();
                 accessor?.SetCorrelationInfo(correlationInfo);
@@ -181,7 +181,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires correlation information to send to the message handler");
 
             using (IServiceScope serviceScope = ServiceProvider.CreateScope())
-            using (LogContext.Push(new MessageCorrelationInfoEnricher(correlationInfo, Options.Telemetry)))
+            using (LogContext.Push(new MessageCorrelationInfoEnricher(correlationInfo, Options.CorrelationEnricher)))
             {
                 var accessor = serviceScope.ServiceProvider.GetService<IMessageCorrelationInfoAccessor>();
                 accessor?.SetCorrelationInfo(correlationInfo);

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouterOptions.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouterOptions.cs
@@ -21,6 +21,6 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// <summary>
         /// Gets the options to control the Serilog <see cref="MessageCorrelationInfoEnricher"/> when the incoming message is routed via the message router.
         /// </summary>
-        public MessageCorrelationEnricherOptions Telemetry { get; } = new MessageCorrelationEnricherOptions();
+        public MessageCorrelationEnricherOptions CorrelationEnricher { get; } = new MessageCorrelationEnricherOptions();
     }
 }

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouterOptions.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouterOptions.cs
@@ -1,4 +1,7 @@
-﻿namespace Arcus.Messaging.Abstractions.MessageHandling
+﻿using Arcus.Messaging.Abstractions.Telemetry;
+using Arcus.Observability.Telemetry.Serilog.Enrichers.Configuration;
+
+namespace Arcus.Messaging.Abstractions.MessageHandling
 {
     /// <summary>
     /// Represents the consumer-configurable options to change the behavior of the <see cref="MessageRouter"/>.
@@ -14,5 +17,10 @@
         /// Gets the options to control the correlation information upon the receiving of messages in the message router.
         /// </summary>
         public MessageCorrelationOptions Correlation { get; } = new MessageCorrelationOptions();
+
+        /// <summary>
+        /// Gets the options to control the Serilog <see cref="MessageCorrelationInfoEnricher"/> when the incoming message is routed via the message router.
+        /// </summary>
+        public MessageCorrelationEnricherOptions Telemetry { get; } = new MessageCorrelationEnricherOptions();
     }
 }

--- a/src/Arcus.Messaging.Abstractions/Telemetry/MessageCorrelationInfoEnricher.cs
+++ b/src/Arcus.Messaging.Abstractions/Telemetry/MessageCorrelationInfoEnricher.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Arcus.Messaging.Abstractions.MessageHandling;
 using Arcus.Observability.Correlation;
 using Arcus.Observability.Telemetry.Core;
 using GuardNet;
@@ -14,6 +15,7 @@ namespace Arcus.Messaging.Abstractions.Telemetry
     {
         private readonly ICorrelationInfoAccessor<MessageCorrelationInfo> _correlationInfoAccessor;
         private readonly MessageCorrelationInfo _messageCorrelationInfo;
+        private readonly MessageCorrelationEnricherOptions _options;
         private const string CycleId = "CycleId";
 
         /// <summary>
@@ -32,11 +34,15 @@ namespace Arcus.Messaging.Abstractions.Telemetry
         /// Initializes a new instance of the <see cref="MessageCorrelationInfoEnricher" /> class.
         /// </summary>
         /// <param name="messageCorrelationInfo">The current message correlation instance that should be enriched on the log events.</param>
-        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="messageCorrelationInfo"/> is <c>null</c>.</exception>
-        public MessageCorrelationInfoEnricher(MessageCorrelationInfo messageCorrelationInfo)
+        /// <param name="options">The additional options to change the behavior of the message correlation enrichment on the log events.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="messageCorrelationInfo"/> or <paramref name="options"/> is <c>null</c>.</exception>
+        public MessageCorrelationInfoEnricher(MessageCorrelationInfo messageCorrelationInfo, MessageCorrelationEnricherOptions options)
         {
             Guard.NotNull(messageCorrelationInfo, nameof(messageCorrelationInfo), "Requires a message correlation instance to enrich the log events");
+            Guard.NotNull(options, nameof(options), "Requires a set of options to control the message correlation enrichment on the log events");
+
             _messageCorrelationInfo = messageCorrelationInfo;
+            _options = options;
         }
 
         /// <summary>
@@ -52,10 +58,10 @@ namespace Arcus.Messaging.Abstractions.Telemetry
                 return;
             }
 
-            AddPropertyIfAbsent(ContextProperties.Correlation.OperationId, correlation.OperationId, logEvent, propertyFactory);
-            AddPropertyIfAbsent(ContextProperties.Correlation.TransactionId, correlation.TransactionId, logEvent, propertyFactory);
-            AddPropertyIfAbsent(ContextProperties.Correlation.OperationParentId, correlation.OperationParentId, logEvent, propertyFactory);
-            AddPropertyIfAbsent(CycleId, correlation.CycleId, logEvent, propertyFactory);
+            AddPropertyIfAbsent(_options.OperationIdPropertyName, correlation.OperationId, logEvent, propertyFactory);
+            AddPropertyIfAbsent(_options.TransactionIdPropertyName, correlation.TransactionId, logEvent, propertyFactory);
+            AddPropertyIfAbsent(_options.OperationParentIdPropertyName, correlation.OperationParentId, logEvent, propertyFactory);
+            AddPropertyIfAbsent(_options.CycleIdPropertyName, correlation.CycleId, logEvent, propertyFactory);
         }
 
         private MessageCorrelationInfo DetermineMessageCorrelationInfo()

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusQueueMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusQueueMessagePumpOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions.MessageHandling;
+using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 
 namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
 {
@@ -47,11 +48,13 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// <summary>
         /// Gets the options to control the correlation information upon the receiving of Azure Service Bus messages in the <see cref="AzureServiceBusMessagePump"/>.
         /// </summary>
+        [Obsolete("Will be moved to message routing options in the future")]
         AzureServiceBusCorrelationOptions Correlation { get; }
         
         /// <summary>
         /// Gets the consumer-configurable options to change the deserialization behavior.
         /// </summary>
+        [Obsolete("Will be moved to message routing options in the future")]
          MessageDeserializationOptions Deserialization { get; }
     }
 }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusTopicMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusTopicMessagePumpOptions.cs
@@ -56,11 +56,13 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// <summary>
         /// Gets the options to control the correlation information upon the receiving of Azure Service Bus messages in the <see cref="AzureServiceBusMessagePump"/>.
         /// </summary>
+        [Obsolete("Will be moved to message routing options in the future")]
         AzureServiceBusCorrelationOptions Correlation { get; }
         
         /// <summary>
         /// Gets the consumer-configurable options to change the deserialization behavior.
         /// </summary>
+        [Obsolete("Will be moved to message routing options in the future")]
         MessageDeserializationOptions Deserialization { get; }
     }
 }


### PR DESCRIPTION
Make the Serilog log event properties that are being enriched from the message correlation model configurable, as they were using these constants `ContextProperties.xxx` previously.

Closes #303