### PR TITLE
feat: add servicebus sender correlation extensions

### DIFF
--- a/docs/preview/02-Features/04-service-bus-extensions.md
+++ b/docs/preview/02-Features/04-service-bus-extensions.md
@@ -1,17 +1,11 @@
----
+﻿---
 title: "Azure Service Bus Extensions"
 layout: default
 ---
 
 # Azure Service Bus Extensions
 
-We provide several additional features related to message creation and message/context discoverability.
-
-- [Azure Service Bus Extensions](#azure-service-bus-extensions)
-  - [Installation](#installation)
-  - [Simplify Creating Service Bus Messages](#simplify-creating-service-bus-messages)
-  - [Simplify Message Information Discovery](#simplify-message-information-discovery)
-  - [Simplify Message Context Information Discovery](#simplify-message-context-information-discovery)
+We provide several additional features related to message creation/sending and message/context discoverability.
 
 ## Installation
 
@@ -19,6 +13,68 @@ This features requires to install our NuGet package:
 
 ```shell
 PM > Install-Package Arcus.Messaging.ServiceBus.Core
+```
+
+## Automatic tracked and correlated Service Bus messages
+
+The Arcus message pump/router automatically makes sure that received Azure Service Bus messages are tracked as request telemetry in Application Insights. 
+If you also want the sender (dependency tracking) to be linked to the request, we provide a set of easy extensions on the `ServiceBusSender` to make this happen.
+For more information on dependency tracking, see the [Arcus Observability feature documentation on telemetry tracking](https://observability.arcus-azure.net/features/writing-different-telemetry-types/).
+
+Internally, we enrich the `ServiceBusMessage` with the message correlation and track the entire operation as an Azure Service Bus dependency.
+The result of this operation will result in a parent-child relationship between the dependency-request.
+
+Following example shows how any business content (`Order`) can be wrapped automatically internally in a `ServiceBusMessage`, and send as a correlated tracked message to the Azure Service Bus resource:
+
+```csharp
+using Azure.Messaging.ServiceBus;
+
+Order order = ... // Your business model.
+MessageCorrelationInfo correlation = ... // Retrieved from your message handler implementation.
+ILogger logger = ... // Your dependency injected logger from your application.
+
+await using (var client = new ServiceBusClient(...))
+await using (ServiceBusSender sender = client.CreateSender("my-queue-or-topic"))
+{
+    await sender.SendMessageAsync(order, correlation, logger);
+    // Output: {"DependencyType": "Azure Service Bus", "DependencyId": "c55c7885-30c5-4785-ad15-a96e03903bfa", "TargetName": "ordersqueue", "Duration": "00:00:00.2521801", "StartTime": "03/23/2020 09:56:31 +00:00", "IsSuccessful": true, "Context": {"EntityType": "Queue"}}
+}
+```
+
+The dependency tracking can also be configured with additional options to your needs. 
+You can also create your own `ServiceBusMessage` with one of the method overloads, so you have influence on the entire message's contents and application properties.
+
+> ⚠ Note that changes to the application property names should also reflect in changes in the application properties at the receiving side, so that the message pump/router knows where it will find these correlation properties.
+
+```csharp
+await sender.SendMessageAsync(order, correlation, logger, options =>
+{
+    // The Azure Service Bus application property name where the message correlation transaction ID will be set.
+    // Default: Transaction-Id
+    options.TransactionIdPropertyName = "My-Transaction-Id";
+
+    // The Azure Service Bus application property name where the dependency ID property will be set.
+    // This ID is by default generated and added to both the dependency tracking as the message.
+    // Default: Operation-Parent-Id
+    options.UpstreamServicepropertyName = "My-UpstreamService-Id";
+
+    // The Azure Service Bus application function to generate a dependency ID which will be added to both the message as the dependency tracking.
+    // Default: GUID generation.
+    options.GenerateDependencyId = () => $"dependency-{Guid.NewGuid()}";
+});
+
+ServiceBusMessage message = ...
+await sender.SendMessageAsync(message, ...);
+```
+
+We also support multiple message bodies or messages:
+
+```csharp
+Order[] orders = ...
+await sender.SendMessagesAsync(orders, ...);
+
+ServiceBusMessage[] messages = ...
+await sender.SendMessagesAsync(mesages, ...);
 ```
 
 ## Simplify Creating Service Bus Messages

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Arcus.Messaging.Abstractions.ServiceBus.csproj
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Arcus.Messaging.Abstractions.ServiceBus.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.4.0,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.5.0,3.0.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Messaging.Abstractions/Arcus.Messaging.Abstractions.csproj
+++ b/src/Arcus.Messaging.Abstractions/Arcus.Messaging.Abstractions.csproj
@@ -26,8 +26,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Arcus.Observability.Correlation" Version="[2.4.0,3.0.0)" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[2.4.0,3.0.0)" />
     <PackageReference Include="Guard.NET" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
@@ -36,8 +34,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
-    <PackageReference Include="Arcus.Observability.Correlation" Version="[2.2.0,3.0.0)" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[2.2.0,3.0.0)" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.8,5.0.0)" />
@@ -46,6 +42,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Arcus.Observability.Correlation" Version="[2.5.0,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[2.5.0,3.0.0)" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[2.5.0,3.0.0)" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/src/Arcus.Messaging.Pumps.Abstractions/Arcus.Messaging.Pumps.Abstractions.csproj
+++ b/src/Arcus.Messaging.Pumps.Abstractions/Arcus.Messaging.Pumps.Abstractions.csproj
@@ -26,7 +26,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[2.4.0,3.0.0)" />
     <PackageReference Include="Guard.NET" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
@@ -36,7 +35,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[2.2.0,3.0.0)" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[3.1.8,5.0.0)" />
@@ -46,6 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[2.5.0,3.0.0)" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Arcus.Messaging.Pumps.ServiceBus.csproj
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Arcus.Messaging.Pumps.ServiceBus.csproj
@@ -27,7 +27,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="[1.7.0,2.0.0)" />
-    <PackageReference Include="Azure.Identity" Version="1.4.0" />
     <PackageReference Include="Guard.NET" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
@@ -38,7 +37,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="[1.4.0,2.0.0)" />
-    <PackageReference Include="Azure.Identity" Version="1.2.3" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[3.1.8,5.0.0)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="[3.1.8,5.0.0)" />
@@ -48,6 +46,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.6.0" />
     <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="2.1.0" />
   </ItemGroup>
 

--- a/src/Arcus.Messaging.ServiceBus.Core/Arcus.Messaging.ServiceBus.Core.csproj
+++ b/src/Arcus.Messaging.ServiceBus.Core/Arcus.Messaging.ServiceBus.Core.csproj
@@ -36,6 +36,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Arcus.Messaging.Abstractions\Arcus.Messaging.Abstractions.csproj" />
   </ItemGroup>
 

--- a/src/Arcus.Messaging.ServiceBus.Core/Extensions/ServiceBusSenderExtensions.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/Extensions/ServiceBusSenderExtensions.cs
@@ -1,0 +1,324 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.ServiceBus.Core;
+using Arcus.Observability.Telemetry.Core;
+using GuardNet;
+using Microsoft.Extensions.Logging;
+
+// ReSharper disable once CheckNamespace
+namespace Azure.Messaging.ServiceBus
+{
+    /// <summary>
+    /// Extensions on the <see cref="ServiceBusSender"/> to more easily send and track correlated Azure Service Bus messages.
+    /// </summary>
+    public static class ServiceBusSenderExtensions
+    {
+        /// <summary>
+        ///   Sends a message to the associated entity of Service Bus.
+        /// </summary>
+        /// <param name="sender">The Azure Service Bus sender when sending the <paramref name="messageBody"/></param>
+        /// <param name="messageBody">The message contents to send as an Azure Service Bus message.</param>
+        /// <param name="correlationInfo">The message correlation instance to enrich the to-be-created message with.</param>
+        /// <param name="logger">The logger instance to track the Azure Service Bus dependency.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        /// <exception cref="ServiceBusException">
+        ///   The message exceeds the maximum size allowed, as determined by the Service Bus service.
+        ///   The <see cref="ServiceBusException.Reason" /> will be set to <see cref="ServiceBusFailureReason.MessageSizeExceeded" /> in this case.
+        ///   For more information on service limits, see
+        ///   <see href="https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas#messaging-quotas" />.
+        /// </exception>
+        public static async Task SendMessageAsync(
+            this ServiceBusSender sender,
+            object messageBody,
+            MessageCorrelationInfo correlationInfo,
+            ILogger logger,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Guard.NotNull(sender, nameof(sender), "Requires an Azure Service Bus sender to while sending a correlated message");
+            Guard.NotNull(messageBody, nameof(messageBody), "Requires a series of Azure Service Bus messages to send as correlated messages");
+            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a message correlation instance to include the transaction ID in the send out messages");
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure Service Bus dependency while sending the correlated messages");
+
+            await SendMessageAsync(sender, messageBody, correlationInfo, logger, configureOptions: null, cancellationToken);
+        }
+
+        /// <summary>
+        ///   Sends a message to the associated entity of Service Bus.
+        /// </summary>
+        /// <param name="sender">The Azure Service Bus sender when sending the <paramref name="messageBody"/></param>
+        /// <param name="messageBody">The message contents to send as an Azure Service Bus message.</param>
+        /// <param name="correlationInfo">The message correlation instance to enrich the to-be-created message with.</param>
+        /// <param name="logger">The logger instance to track the Azure Service Bus dependency.</param>
+        /// <param name="configureOptions">The function to configure additional options to the correlated message.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        /// <exception cref="ServiceBusException">
+        ///   The message exceeds the maximum size allowed, as determined by the Service Bus service.
+        ///   The <see cref="ServiceBusException.Reason" /> will be set to <see cref="ServiceBusFailureReason.MessageSizeExceeded" /> in this case.
+        ///   For more information on service limits, see
+        ///   <see href="https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas#messaging-quotas" />.
+        /// </exception>
+        public static async Task SendMessageAsync(
+            this ServiceBusSender sender,
+            object messageBody,
+            MessageCorrelationInfo correlationInfo,
+            ILogger logger,
+            Action<ServiceBusSenderMessageCorrelationOptions> configureOptions,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Guard.NotNull(sender, nameof(sender), "Requires an Azure Service Bus sender to while sending a correlated message");
+            Guard.NotNull(messageBody, nameof(messageBody), "Requires a series of Azure Service Bus messages to send as correlated messages");
+            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a message correlation instance to include the transaction ID in the send out messages");
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure Service Bus dependency while sending the correlated messages");
+
+            await SendMessagesAsync(sender, new [] { messageBody }, correlationInfo, logger, configureOptions, cancellationToken);
+        }
+
+        /// <summary>
+        ///   Sends a set of messages to the associated Service Bus entity using a batched approach.
+        ///   If the size of the messages exceed the maximum size of a single batch,
+        ///   an exception will be triggered and the send will fail. In order to ensure that the messages
+        ///   being sent will fit in a batch, use <see cref="ServiceBusSender.SendMessagesAsync(ServiceBusMessageBatch,CancellationToken)" /> instead.
+        /// </summary>
+        /// <param name="sender">The Azure Service Bus sender when sending the <paramref name="messageBodies"/>.</param>
+        /// <param name="messageBodies">The set of message bodies to send as Azure Service Bus messages.</param>
+        /// <param name="correlationInfo">The message correlation instance to enrich the to-be-created messages with.</param>
+        /// <param name="logger">The logger instance to track the Azure Service Bus dependency.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="sender"/>, <paramref name="messageBodies"/>, or <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="messageBodies"/> doesn't contain any elements or has any <c>null</c> elements.</exception>
+        /// <exception cref="ServiceBusException">
+        ///   The set of messages exceeds the maximum size allowed in a single batch, as determined by the Service Bus service.
+        ///   The <see cref="ServiceBusException.Reason" /> will be set to <see cref="ServiceBusFailureReason.MessageSizeExceeded" /> in this case.
+        ///   For more information on service limits, see
+        ///   <see href="https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas#messaging-quotas" />.
+        /// </exception>
+        public static async Task SendMessagesAsync(
+            this ServiceBusSender sender,
+            IEnumerable<object> messageBodies,
+            MessageCorrelationInfo correlationInfo,
+            ILogger logger,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Guard.NotNull(sender, nameof(sender), "Requires an Azure Service Bus sender to while sending a correlated message");
+            Guard.NotNull(messageBodies, nameof(messageBodies), "Requires a series of Azure Service Bus messages to send as correlated messages");
+            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a message correlation instance to include the transaction ID in the send out messages");
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure Service Bus dependency while sending the correlated messages");
+            Guard.NotAny(messageBodies, nameof(messageBodies), "Requires at least a single message to send to Azure Service Bus");
+            Guard.For(() => messageBodies.Any(message => message is null), new ArgumentException("Requires non-null items in Azure Service Bus message sequence", nameof(messageBodies)));
+
+            await SendMessagesAsync(sender, messageBodies, correlationInfo, logger, configureOptions: null, cancellationToken);
+        }
+
+        /// <summary>
+        ///   Sends a set of messages to the associated Service Bus entity using a batched approach.
+        ///   If the size of the messages exceed the maximum size of a single batch,
+        ///   an exception will be triggered and the send will fail. In order to ensure that the messages
+        ///   being sent will fit in a batch, use <see cref="ServiceBusSender.SendMessagesAsync(ServiceBusMessageBatch,CancellationToken)" /> instead.
+        /// </summary>
+        /// <param name="sender">The Azure Service Bus sender when sending the <paramref name="messageBodies"/>.</param>
+        /// <param name="messageBodies">The set of message bodies to send as Azure Service Bus messages.</param>
+        /// <param name="correlationInfo">The message correlation instance to enrich the to-be-created messages with.</param>
+        /// <param name="logger">The logger instance to track the Azure Service Bus dependency.</param>
+        /// <param name="configureOptions">The function to configure additional options to the correlated messages.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="sender"/>, <paramref name="messageBodies"/>, or <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="messageBodies"/> doesn't contain any elements or has any <c>null</c> elements.</exception>
+        /// <exception cref="ServiceBusException">
+        ///   The set of messages exceeds the maximum size allowed in a single batch, as determined by the Service Bus service.
+        ///   The <see cref="ServiceBusException.Reason" /> will be set to <see cref="ServiceBusFailureReason.MessageSizeExceeded" /> in this case.
+        ///   For more information on service limits, see
+        ///   <see href="https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas#messaging-quotas" />.
+        /// </exception>
+        public static async Task SendMessagesAsync(
+            this ServiceBusSender sender,
+            IEnumerable<object> messageBodies,
+            MessageCorrelationInfo correlationInfo,
+            ILogger logger,
+            Action<ServiceBusSenderMessageCorrelationOptions> configureOptions,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Guard.NotNull(sender, nameof(sender), "Requires an Azure Service Bus sender to while sending a correlated message");
+            Guard.NotNull(messageBodies, nameof(messageBodies), "Requires a series of Azure Service Bus messages to send as correlated messages");
+            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a message correlation instance to include the transaction ID in the send out messages");
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure Service Bus dependency while sending the correlated messages");
+            Guard.NotAny(messageBodies, nameof(messageBodies), "Requires at least a single message to send to Azure Service Bus");
+            Guard.For(() => messageBodies.Any(message => message is null), new ArgumentException("Requires non-null items in Azure Service Bus message sequence", nameof(messageBodies)));
+
+            ServiceBusMessage[] messages =
+                messageBodies.Select(messageBody => ServiceBusMessageBuilder.CreateForBody(messageBody).Build())
+                             .ToArray();
+
+            await SendMessagesAsync(sender, messages, correlationInfo, logger, configureOptions, cancellationToken);
+        }
+
+        /// <summary>
+        ///   Sends a message to the associated entity of Service Bus.
+        /// </summary>
+        /// <param name="sender">The Azure Service Bus sender when sending the <paramref name="message"/></param>
+        /// <param name="message">The message to send.</param>
+        /// <param name="correlationInfo">The message correlation instance to enrich the <paramref name="message"/> with.</param>
+        /// <param name="logger">The logger instance to track the Azure Service Bus dependency.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        /// <exception cref="ServiceBusException">
+        ///   The message exceeds the maximum size allowed, as determined by the Service Bus service.
+        ///   The <see cref="ServiceBusException.Reason" /> will be set to <see cref="ServiceBusFailureReason.MessageSizeExceeded" /> in this case.
+        ///   For more information on service limits, see
+        ///   <see href="https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas#messaging-quotas" />.
+        /// </exception>
+        public static async Task SendMessageAsync(
+            this ServiceBusSender sender,
+            ServiceBusMessage message,
+            MessageCorrelationInfo correlationInfo,
+            ILogger logger,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Guard.NotNull(sender, nameof(sender), "Requires an Azure Service Bus sender to while sending a correlated message");
+            Guard.NotNull(message, nameof(message), "Requires a Azure Service Bus message to send as a correlated message");
+            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a message correlation instance to include the transaction ID in the send out messages");
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure Service Bus dependency while sending the correlated messages");
+
+            await SendMessageAsync(sender, message , correlationInfo, logger, configureOptions: null, cancellationToken);
+        }
+
+        /// <summary>
+        ///   Sends a message to the associated entity of Service Bus.
+        /// </summary>
+        /// <param name="sender">The Azure Service Bus sender when sending the <paramref name="message"/></param>
+        /// <param name="message">The message to send.</param>
+        /// <param name="correlationInfo">The message correlation instance to enrich the <paramref name="message"/> with.</param>
+        /// <param name="logger">The logger instance to track the Azure Service Bus dependency.</param>
+        /// <param name="configureOptions">The function to configure additional options to the correlated <paramref name="message"/>.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        /// <exception cref="ServiceBusException">
+        ///   The message exceeds the maximum size allowed, as determined by the Service Bus service.
+        ///   The <see cref="ServiceBusException.Reason" /> will be set to <see cref="ServiceBusFailureReason.MessageSizeExceeded" /> in this case.
+        ///   For more information on service limits, see
+        ///   <see href="https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas#messaging-quotas" />.
+        /// </exception>
+        public static async Task SendMessageAsync(
+            this ServiceBusSender sender,
+            ServiceBusMessage message,
+            MessageCorrelationInfo correlationInfo,
+            ILogger logger,
+            Action<ServiceBusSenderMessageCorrelationOptions> configureOptions,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Guard.NotNull(sender, nameof(sender), "Requires an Azure Service Bus sender to while sending a correlated message");
+            Guard.NotNull(message, nameof(message), "Requires a Azure Service Bus message to send as a correlated message");
+            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a message correlation instance to include the transaction ID in the send out messages");
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure Service Bus dependency while sending the correlated messages");
+
+            await SendMessagesAsync(sender, new[] { message }, correlationInfo, logger, configureOptions, cancellationToken);
+        }
+
+        /// <summary>
+        ///   Sends a set of messages to the associated Service Bus entity using a batched approach.
+        ///   If the size of the messages exceed the maximum size of a single batch,
+        ///   an exception will be triggered and the send will fail. In order to ensure that the messages
+        ///   being sent will fit in a batch, use <see cref="ServiceBusSender.SendMessagesAsync(ServiceBusMessageBatch,CancellationToken)" /> instead.
+        /// </summary>
+        /// <param name="sender">The Azure Service Bus sender when sending the <paramref name="messages"/>.</param>
+        /// <param name="messages">The set of messages to send.</param>
+        /// <param name="correlationInfo">The message correlation instance to enrich the <paramref name="messages"/> with.</param>
+        /// <param name="logger">The logger instance to track the Azure Service Bus dependency.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="sender"/>, <paramref name="messages"/>, or <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="messages"/> doesn't contain any elements or has any <c>null</c> elements.</exception>
+        /// <exception cref="ServiceBusException">
+        ///   The set of messages exceeds the maximum size allowed in a single batch, as determined by the Service Bus service.
+        ///   The <see cref="ServiceBusException.Reason" /> will be set to <see cref="ServiceBusFailureReason.MessageSizeExceeded" /> in this case.
+        ///   For more information on service limits, see
+        ///   <see href="https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas#messaging-quotas" />.
+        /// </exception>
+        public static async Task SendMessagesAsync(
+            this ServiceBusSender sender,
+            IEnumerable<ServiceBusMessage> messages,
+            MessageCorrelationInfo correlationInfo,
+            ILogger logger,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Guard.NotNull(sender, nameof(sender), "Requires an Azure Service Bus sender to while sending a correlated message");
+            Guard.NotNull(messages, nameof(messages), "Requires a series of Azure Service Bus messages to send as correlated messages");
+            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a message correlation instance to include the transaction ID in the send out messages");
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure Service Bus dependency while sending the correlated messages");
+            Guard.NotAny(messages, nameof(messages), "Requires at least a single message to send to Azure Service Bus");
+            Guard.For(() => messages.Any(message => message is null), new ArgumentException("Requires non-null items in Azure Service Bus message sequence", nameof(messages)));
+
+            await SendMessagesAsync(sender, messages, correlationInfo, logger, configureOptions: null, cancellationToken);
+        }
+
+        /// <summary>
+        ///   Sends a set of messages to the associated Service Bus entity using a batched approach.
+        ///   If the size of the messages exceed the maximum size of a single batch,
+        ///   an exception will be triggered and the send will fail. In order to ensure that the messages
+        ///   being sent will fit in a batch, use <see cref="ServiceBusSender.SendMessagesAsync(ServiceBusMessageBatch,CancellationToken)" /> instead.
+        /// </summary>
+        /// <param name="sender">The Azure Service Bus sender when sending the <paramref name="messages"/>.</param>
+        /// <param name="messages">The set of messages to send.</param>
+        /// <param name="correlationInfo">The message correlation instance to enrich the <paramref name="messages"/> with.</param>
+        /// <param name="logger">The logger instance to track the Azure Service Bus dependency.</param>
+        /// <param name="configureOptions">The function to configure additional options to the correlated <paramref name="messages"/>.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="sender"/>, <paramref name="messages"/>, or <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="messages"/> doesn't contain any elements or has any <c>null</c> elements.</exception>
+        /// <exception cref="ServiceBusException">
+        ///   The set of messages exceeds the maximum size allowed in a single batch, as determined by the Service Bus service.
+        ///   The <see cref="ServiceBusException.Reason" /> will be set to <see cref="ServiceBusFailureReason.MessageSizeExceeded" /> in this case.
+        ///   For more information on service limits, see
+        ///   <see href="https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas#messaging-quotas" />.
+        /// </exception>
+        public static async Task SendMessagesAsync(
+            this ServiceBusSender sender, 
+            IEnumerable<ServiceBusMessage> messages, 
+            MessageCorrelationInfo correlationInfo,
+            ILogger logger,
+            Action<ServiceBusSenderMessageCorrelationOptions> configureOptions,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Guard.NotNull(sender, nameof(sender), "Requires an Azure Service Bus sender to while sending a correlated message");
+            Guard.NotNull(messages, nameof(messages), "Requires a series of Azure Service Bus messages to send as correlated messages");
+            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a message correlation instance to include the transaction ID in the send out messages");
+            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure Service Bus dependency while sending the correlated messages");
+            Guard.NotAny(messages, nameof(messages), "Requires at least a single message to send to Azure Service Bus");
+            Guard.For(() => messages.Any(message => message is null), new ArgumentException("Requires non-null items in Azure Service Bus message sequence", nameof(messages)));
+
+            var options = new ServiceBusSenderMessageCorrelationOptions();
+            configureOptions?.Invoke(options);
+
+            string dependencyId = options.GenerateDependencyId();
+
+            messages = messages.ToArray();
+            foreach (ServiceBusMessage message in messages)
+            {
+                message.ApplicationProperties[options.TransactionIdPropertyName] = correlationInfo.TransactionId;
+                message.ApplicationProperties[options.UpstreamServicePropertyName] = dependencyId;
+            }
+
+            bool isSuccessful = false;
+            using (var measurement = DurationMeasurement.Start()) 
+            {
+                try
+                {
+                    await sender.SendMessagesAsync(messages, cancellationToken);
+                    isSuccessful = true;
+                }
+                finally
+               {
+                   logger.LogServiceBusDependency(sender.FullyQualifiedNamespace, sender.EntityPath, isSuccessful, measurement, dependencyId, options.EntityType);
+               }
+            }
+        }
+    }
+}

--- a/src/Arcus.Messaging.ServiceBus.Core/ServiceBusSenderMessageCorrelationOptions.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/ServiceBusSenderMessageCorrelationOptions.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Threading;
+using Arcus.Messaging.Abstractions;
+using Azure.Messaging.ServiceBus;
+using GuardNet;
+using Microsoft.Extensions.Logging;
+
+namespace Arcus.Messaging.ServiceBus.Core
+{
+    /// <summary>
+    /// Represents the user-configurable options to influence the message correlation tracking behavior of the <see cref="ServiceBusSenderExtensions.SendMessageAsync(ServiceBusSender,ServiceBusMessage,MessageCorrelationInfo,ILogger,Action{ServiceBusSenderMessageCorrelationOptions},CancellationToken)"/> extensions.
+    /// </summary>
+    public class ServiceBusSenderMessageCorrelationOptions
+    {
+        private string _transactionIdPropertyName = PropertyNames.TransactionId;
+        private string _upstreamServicePropertyName = PropertyNames.OperationParentId;
+        private Func<string> _generateDependencyId = () => Guid.NewGuid().ToString();
+
+        /// <summary>
+        /// Gets or sets the Azure Service Bus message application property name
+        /// where the correlation transaction ID should be added when tracking Azure Service Bus dependencies.
+        /// </summary>
+        public string TransactionIdPropertyName
+        {
+            get => _transactionIdPropertyName;
+            set
+            {
+                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank value for the message correlation transaction ID Azure Service Bus application property name");
+                _transactionIdPropertyName = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the Azure Service Bus message application property name
+        /// where the dependency ID (generated via <see cref="GenerateDependencyId"/>) should be added when tracking Azure Service Bus dependencies.
+        /// </summary>
+        public string UpstreamServicePropertyName
+        {
+            get => _upstreamServicePropertyName;
+            set
+            {
+                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank value for the message correlation upstream service Azure Service Bus application property name");
+                _upstreamServicePropertyName = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the type of the Azure Service Bus entity when tracking Azure Service Bus dependencies.
+        /// </summary>
+        public ServiceBusEntityType EntityType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the function to generate the dependency ID used when tracking Azure Service Bus dependencies.
+        /// </summary>
+        public Func<string> GenerateDependencyId
+        {
+            get => _generateDependencyId;
+            set
+            {
+                Guard.NotNull(value, nameof(value), "Requires a function to generate the dependency ID used when tracking Azure Service Bus dependencies");
+                _generateDependencyId = value;
+            }
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/ServiceBus/ServiceBusSenderExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/ServiceBus/ServiceBusSenderExtensionsTests.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.ServiceBus;
+using Arcus.Messaging.Tests.Core.Generators;
+using Arcus.Messaging.Tests.Core.Messages.v1;
+using Arcus.Messaging.Tests.Integration.Fixture;
+using Arcus.Testing.Logging;
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
+using Polly;
+using Polly.Wrap;
+using Serilog.Core;
+using Xunit;
+using static Arcus.Observability.Telemetry.Core.ContextProperties;
+
+namespace Arcus.Messaging.Tests.Integration.ServiceBus
+{
+    public class ServiceBusSenderExtensionsTests
+    {
+        private const string DependencyIdPattern = @"with ID [a-z0-9]{8}\-[a-z0-9]{4}\-[a-z0-9]{4}\-[a-z0-9]{4}\-[a-z0-9]{12}";
+
+        private readonly TestConfig _config;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ServiceBusSenderExtensionsTests" /> class.
+        /// </summary>
+        public ServiceBusSenderExtensionsTests()
+        {
+            _config = TestConfig.Create();
+        }
+
+        [Fact]
+        public async Task SendMessage_WithMessageCorrelation_TracksMessage()
+        {
+            // Arrange
+            Order order = OrderGenerator.Generate();
+            MessageCorrelationInfo correlation = GenerateMessageCorrelationInfo();
+            var logger = new InMemoryLogger();
+
+            string connectionString = _config.GetServiceBusQueueConnectionString();
+            var connectionStringProperties = ServiceBusConnectionStringProperties.Parse(connectionString);
+
+            await using (var client = new ServiceBusClient(connectionString))
+            {
+                await using (ServiceBusSender sender = client.CreateSender(connectionStringProperties.EntityPath))
+                {
+                    // Act
+                    await sender.SendMessageAsync(order, correlation, logger);
+                }
+
+                // Assert
+               await RetryAssertUntilServiceBusMessageIsAvailableAsync(client, connectionStringProperties.EntityPath, message =>
+               {
+                   var actual = message.Body.ToObjectFromJson<Order>();
+                   Assert.Equal(order.Id, actual.Id);
+
+                   Assert.Equal(message.ApplicationProperties[PropertyNames.TransactionId], correlation.TransactionId);
+                   Assert.False(string.IsNullOrWhiteSpace(message.ApplicationProperties[PropertyNames.OperationParentId].ToString()));
+
+                   string logMessage = Assert.Single(logger.Messages);
+                   Assert.Contains("Dependency", logMessage);
+                   Assert.Matches(DependencyIdPattern, logMessage);
+               });
+            }
+        }
+
+        [Fact]
+        public async Task SendMessage_WithCustomOptions_TracksMessage()
+        {
+            // Arrange
+            Order order = OrderGenerator.Generate();
+            MessageCorrelationInfo correlation = GenerateMessageCorrelationInfo();
+            var dependencyId = $"parent-{Guid.NewGuid()}";
+            string transactionIdPropertyName = "My-Transaction-Id", upstreamServicePropertyName = "My-UpstreamService-Id";
+            var logger = new InMemoryLogger();
+
+            string connectionString = _config.GetServiceBusQueueConnectionString();
+            var connectionStringProperties = ServiceBusConnectionStringProperties.Parse(connectionString);
+
+            await using (var client = new ServiceBusClient(connectionString))
+            {
+                await using (ServiceBusSender sender = client.CreateSender(connectionStringProperties.EntityPath))
+                {
+                    // Act
+                    await sender.SendMessageAsync(order, correlation, logger, options =>
+                    {
+                        options.TransactionIdPropertyName = transactionIdPropertyName;
+                        options.UpstreamServicePropertyName = upstreamServicePropertyName;
+                        options.GenerateDependencyId = () => dependencyId;
+                    });
+                }
+
+                // Assert
+                await RetryAssertUntilServiceBusMessageIsAvailableAsync(client, connectionStringProperties.EntityPath, message =>
+                {
+                    var actual = message.Body.ToObjectFromJson<Order>();
+                    Assert.Equal(order.Id, actual.Id);
+
+                    Assert.Equal(correlation.TransactionId, message.ApplicationProperties[transactionIdPropertyName]);
+                    Assert.Equal(dependencyId, message.ApplicationProperties[upstreamServicePropertyName]);
+
+                    string logMessage = Assert.Single(logger.Messages);
+                    Assert.Contains("Dependency", logMessage);
+                    Assert.Matches($"with ID {dependencyId}", logMessage);
+                });
+            }
+        }
+
+        private static MessageCorrelationInfo GenerateMessageCorrelationInfo()
+        {
+            return new MessageCorrelationInfo(
+                $"operation-{Guid.NewGuid()}",
+                $"transaction-{Guid.NewGuid()}",
+                $"parent-{Guid.NewGuid()}");
+        }
+
+        private static async Task RetryAssertUntilServiceBusMessageIsAvailableAsync(ServiceBusClient client, string entityPath, Action<ServiceBusReceivedMessage> assertion)
+        {
+            AsyncPolicyWrap policy =
+                Policy.TimeoutAsync(TimeSpan.FromSeconds(30))
+                      .WrapAsync(Policy.Handle<Exception>()
+                                       .WaitAndRetryForeverAsync(index => TimeSpan.FromMilliseconds(500)));
+
+            await using (ServiceBusReceiver receiver = client.CreateReceiver(entityPath))
+            {
+                await policy.ExecuteAsync(async () =>
+                {
+                    IAsyncEnumerable<ServiceBusReceivedMessage> messages = receiver.ReceiveMessagesAsync();
+                    var exceptions = new Collection<Exception>();
+
+                    await foreach (ServiceBusReceivedMessage message in messages)
+                    {
+                        try
+                        {
+                            assertion(message);
+                            await receiver.CompleteMessageAsync(message);
+                            
+                            return;
+                        }
+                        catch (Exception exception)
+                        {
+                            exceptions.Add(exception);
+                        }
+                    }
+
+                    throw exceptions.Count == 1 ? exceptions[0] : new AggregateException(exceptions);
+                });
+            }
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Unit/Arcus.Messaging.Tests.Unit.csproj
+++ b/src/Arcus.Messaging.Tests.Unit/Arcus.Messaging.Tests.Unit.csproj
@@ -1,20 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.8" />
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Arcus.EventGrid.Testing" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Moq" Version="4.13.1" />

--- a/src/Arcus.Messaging.Tests.Unit/ServiceBus/Fixture/InMemoryServiceBusSender.cs
+++ b/src/Arcus.Messaging.Tests.Unit/ServiceBus/Fixture/InMemoryServiceBusSender.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
+
+namespace Arcus.Messaging.Tests.Unit.ServiceBus.Fixture
+{
+    public class InMemoryServiceBusSender : ServiceBusSender
+    {
+        private readonly ConcurrentQueue<ServiceBusMessage> _messages = new ConcurrentQueue<ServiceBusMessage>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InMemoryServiceBusSender" /> class.
+        /// </summary>
+        public InMemoryServiceBusSender()
+        {
+            FullyQualifiedNamespace = "inmemory.servicebus.windows.net";
+            EntityPath = "in-memory";
+        }
+
+        /// <summary>
+        ///   The fully qualified Service Bus namespace that the producer is associated with.  This is likely
+        ///   to be similar to <c>{yournamespace}.servicebus.windows.net</c>.
+        /// </summary>
+        public override string FullyQualifiedNamespace { get; }
+
+        /// <summary>
+        ///   The path of the entity that the sender is connected to, specific to the
+        ///   Service Bus namespace that contains it.
+        /// </summary>
+        public override string EntityPath { get; } 
+
+        public IEnumerable<ServiceBusMessage> Messages => _messages.ToArray();
+
+        /// <summary>
+        ///   Sends a set of messages to the associated Service Bus entity using a batched approach.
+        ///   If the size of the messages exceed the maximum size of a single batch,
+        ///   an exception will be triggered and the send will fail. In order to ensure that the messages
+        ///   being sent will fit in a batch, use <see cref="M:Azure.Messaging.ServiceBus.ServiceBusSender.SendMessagesAsync(Azure.Messaging.ServiceBus.ServiceBusMessageBatch,System.Threading.CancellationToken)" /> instead.
+        /// </summary>
+        /// <param name="messages">The set of messages to send.</param>
+        /// <param name="cancellationToken">An optional <see cref="T:System.Threading.CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        /// <exception cref="T:Azure.Messaging.ServiceBus.ServiceBusException">
+        ///   The set of messages exceeds the maximum size allowed in a single batch, as determined by the Service Bus service.
+        ///   The <see cref="P:Azure.Messaging.ServiceBus.ServiceBusException.Reason" /> will be set to <see cref="F:Azure.Messaging.ServiceBus.ServiceBusFailureReason.MessageSizeExceeded" /> in this case.
+        ///   For more information on service limits, see
+        ///   <see href="https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas#messaging-quotas" />.
+        /// </exception>
+        public override Task SendMessagesAsync(IEnumerable<ServiceBusMessage> messages, CancellationToken cancellationToken = new CancellationToken())
+        {
+            foreach (ServiceBusMessage message in messages)
+            {
+                _messages.Enqueue(message);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Unit/ServiceBus/ServiceBusSenderExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/ServiceBus/ServiceBusSenderExtensionsTests.cs
@@ -117,7 +117,6 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
                 item => AssertEnrichedServiceBusMessage(item.First, item.Second, correlation));
         }
 
-        
         [Fact]
         public async Task SendMessagesBodyWithoutOptions_WithCustomDependencyId_Succeeds()
         {
@@ -286,7 +285,6 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
                 item => AssertEnrichedServiceBusMessage(item.First, item.Second, correlation));
         }
 
-        
         [Fact]
         public async Task SendMessagesWithoutOptions_WithCustomDependencyId_Succeeds()
         {

--- a/src/Arcus.Messaging.Tests.Unit/ServiceBus/ServiceBusSenderExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/ServiceBus/ServiceBusSenderExtensionsTests.cs
@@ -1,0 +1,720 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Tests.Core.Generators;
+using Arcus.Messaging.Tests.Core.Messages.v1;
+using Arcus.Messaging.Tests.Unit.ServiceBus.Fixture;
+using Arcus.Testing.Logging;
+using Azure.Messaging.ServiceBus;
+using Bogus;
+using Moq;
+using Xunit;
+
+namespace Arcus.Messaging.Tests.Unit.ServiceBus
+{
+    public class ServiceBusSenderExtensionsTests
+    {
+        private const string DependencyIdPattern = @"with ID [a-z0-9]{8}\-[a-z0-9]{4}\-[a-z0-9]{4}\-[a-z0-9]{4}\-[a-z0-9]{12}";
+
+        private static readonly Faker BogusGenerator = new Faker();
+
+        [Fact]
+        public async Task SendMessageBodyWithoutOptions_WithMessageCorrelation_Succeeds()
+        {
+            // Arrange
+            var spySender = new InMemoryServiceBusSender();
+            var expectedOrder = OrderGenerator.Generate();
+            MessageCorrelationInfo correlation = GenerateMessageCorrelationInfo();
+            var logger = new InMemoryLogger();
+
+            // Act
+            await spySender.SendMessageAsync(expectedOrder, correlation, logger);
+
+            // Assert
+            AssertDependencyTelemetry(logger);
+
+            ServiceBusMessage message = Assert.Single(spySender.Messages);
+            AssertEnrichedServiceBusMessage(message, expectedOrder, correlation);
+        }
+
+        [Fact]
+        public async Task SendMessageBodyWithoutOptions_WithCustomDependencyId_Succeeds()
+        {
+            // Arrange
+            var spySender = new InMemoryServiceBusSender();
+            var expectedOrder = OrderGenerator.Generate();
+            var dependencyId = $"dependency-{Guid.NewGuid()}";
+            MessageCorrelationInfo correlation = GenerateMessageCorrelationInfo();
+            var logger = new InMemoryLogger();
+
+            // Act
+            await spySender.SendMessageAsync(expectedOrder, correlation, logger, options => options.GenerateDependencyId = () => dependencyId);
+
+            // Assert
+            AssertDependencyTelemetry(logger, dependencyId);
+
+            ServiceBusMessage message = Assert.Single(spySender.Messages);
+            AssertEnrichedServiceBusMessageWithDependencyId(message, expectedOrder, correlation, dependencyId);
+        }
+
+        [Fact]
+        public async Task SendMessageBodyWithoutOptions_WithCustomTransactionIdPropertyName_Succeeds()
+        {
+            // Arrange
+            var spySender = new InMemoryServiceBusSender();
+            var expectedOrder = OrderGenerator.Generate();
+            var transactionIdPropertyName = "My-Transaction-Id";
+            MessageCorrelationInfo correlation = GenerateMessageCorrelationInfo();
+            var logger = new InMemoryLogger();
+
+            // Act
+            await spySender.SendMessageAsync(expectedOrder, correlation, logger, options => options.TransactionIdPropertyName = transactionIdPropertyName);
+
+            // Assert
+            AssertDependencyTelemetry(logger);
+
+            ServiceBusMessage message = Assert.Single(spySender.Messages);
+            AssertEnrichedServiceBusMessage(message, expectedOrder, correlation, transactionIdPropertyName: transactionIdPropertyName);
+        }
+
+        [Fact]
+        public async Task SendMessageBodyWithoutOptions_WithCustomUpstreamServicePropertyName_Succeeds()
+        {
+            // Arrange
+            var spySender = new InMemoryServiceBusSender();
+            var expectedOrder = OrderGenerator.Generate();
+            var upstreamServicePropertyName = "My-UpstreamService-Id";
+            MessageCorrelationInfo correlation = GenerateMessageCorrelationInfo();
+            var logger = new InMemoryLogger();
+
+            // Act
+            await spySender.SendMessageAsync(expectedOrder, correlation, logger, options => options.UpstreamServicePropertyName = upstreamServicePropertyName);
+
+            // Assert
+            AssertDependencyTelemetry(logger);
+
+            ServiceBusMessage message = Assert.Single(spySender.Messages);
+            AssertEnrichedServiceBusMessage(message, expectedOrder, correlation, operationParentPropertyName: upstreamServicePropertyName);
+        }
+
+        [Fact]
+        public async Task SendMessagesBodyWithoutOptions_WithMessageCorrelation_Succeeds()
+        {
+            // Arrange
+            var spySender = new InMemoryServiceBusSender();
+            var expectedOrders = BogusGenerator.Make(5, () => OrderGenerator.Generate());
+            MessageCorrelationInfo correlation = GenerateMessageCorrelationInfo();
+            var logger = new InMemoryLogger();
+
+            // Act
+            await spySender.SendMessagesAsync(expectedOrders, correlation, logger);
+
+            // Assert
+            AssertDependencyTelemetry(logger);
+            Assert.All(
+                spySender.Messages.Zip(expectedOrders), 
+                item => AssertEnrichedServiceBusMessage(item.First, item.Second, correlation));
+        }
+
+        
+        [Fact]
+        public async Task SendMessagesBodyWithoutOptions_WithCustomDependencyId_Succeeds()
+        {
+            // Arrange
+            var spySender = new InMemoryServiceBusSender();
+            var expectedOrders = BogusGenerator.Make(5, () => OrderGenerator.Generate());
+            var dependencyId = $"dependency-{Guid.NewGuid()}";
+            MessageCorrelationInfo correlation = GenerateMessageCorrelationInfo();
+            var logger = new InMemoryLogger();
+
+            // Act
+            await spySender.SendMessagesAsync(expectedOrders, correlation, logger, options => options.GenerateDependencyId = () => dependencyId);
+
+            // Assert
+            AssertDependencyTelemetry(logger, dependencyId);
+            Assert.All(
+                spySender.Messages.Zip(expectedOrders), 
+                item => AssertEnrichedServiceBusMessageWithDependencyId(item.First, item.Second, correlation, dependencyId));
+        }
+
+        [Fact]
+        public async Task SendMessagesBodyWithoutOptions_WithCustomTransactionIdPropertyName_Succeeds()
+        {
+            // Arrange
+            var spySender = new InMemoryServiceBusSender();
+            var expectedOrders = BogusGenerator.Make(5, () => OrderGenerator.Generate());
+            var transactionIdPropertyName = "My-Transaction-Id";
+            MessageCorrelationInfo correlation = GenerateMessageCorrelationInfo();
+            var logger = new InMemoryLogger();
+
+            // Act
+            await spySender.SendMessagesAsync(expectedOrders, correlation, logger, options => options.TransactionIdPropertyName = transactionIdPropertyName);
+
+            // Assert
+            AssertDependencyTelemetry(logger);
+            Assert.All(
+                spySender.Messages.Zip(expectedOrders), 
+                item => AssertEnrichedServiceBusMessage(item.First, item.Second, correlation, transactionIdPropertyName: transactionIdPropertyName));
+        }
+
+        [Fact]
+        public async Task SendMessagesBodyWithoutOptions_WithCustomUpstreamServiceIdPropertyName_Succeeds()
+        {
+            // Arrange
+            var spySender = new InMemoryServiceBusSender();
+            var expectedOrders = BogusGenerator.Make(5, () => OrderGenerator.Generate());
+            var upstreamServicePropertyName = "My-UpstreamService-Id";
+            MessageCorrelationInfo correlation = GenerateMessageCorrelationInfo();
+            var logger = new InMemoryLogger();
+
+            // Act
+            await spySender.SendMessagesAsync(expectedOrders, correlation, logger, options => options.UpstreamServicePropertyName = upstreamServicePropertyName);
+
+            // Assert
+            AssertDependencyTelemetry(logger);
+            Assert.All(
+                spySender.Messages.Zip(expectedOrders), 
+                item => AssertEnrichedServiceBusMessage(item.First, item.Second, correlation, operationParentPropertyName: upstreamServicePropertyName));
+        }
+
+         [Fact]
+        public async Task SendMessageWithoutOptions_WithMessageCorrelation_Succeeds()
+        {
+            // Arrange
+            var spySender = new InMemoryServiceBusSender();
+            var expectedOrder = OrderGenerator.Generate();
+            var expected = ServiceBusMessageBuilder.CreateForBody(expectedOrder).Build();
+
+            MessageCorrelationInfo correlation = GenerateMessageCorrelationInfo();
+            var logger = new InMemoryLogger();
+
+            // Act
+            await spySender.SendMessageAsync(expected, correlation, logger);
+
+            // Assert
+            AssertDependencyTelemetry(logger);
+
+            ServiceBusMessage message = Assert.Single(spySender.Messages);
+            AssertEnrichedServiceBusMessage(message, expectedOrder, correlation);
+        }
+
+        [Fact]
+        public async Task SendMessageWithoutOptions_WithCustomDependencyId_Succeeds()
+        {
+            // Arrange
+            var spySender = new InMemoryServiceBusSender();
+            var expectedOrder = OrderGenerator.Generate();
+            var expected = ServiceBusMessageBuilder.CreateForBody(expectedOrder).Build();
+
+            var dependencyId = $"dependency-{Guid.NewGuid()}";
+            MessageCorrelationInfo correlation = GenerateMessageCorrelationInfo();
+            var logger = new InMemoryLogger();
+
+            // Act
+            await spySender.SendMessageAsync(expected, correlation, logger, options => options.GenerateDependencyId = () => dependencyId);
+
+            // Assert
+            AssertDependencyTelemetry(logger, dependencyId);
+
+            ServiceBusMessage message = Assert.Single(spySender.Messages);
+            AssertEnrichedServiceBusMessageWithDependencyId(message, expectedOrder, correlation, dependencyId);
+        }
+
+        [Fact]
+        public async Task SendMessageWithoutOptions_WithCustomTransactionIdPropertyName_Succeeds()
+        {
+            // Arrange
+            var spySender = new InMemoryServiceBusSender();
+            var expectedOrder = OrderGenerator.Generate();
+            var expected = ServiceBusMessageBuilder.CreateForBody(expectedOrder).Build();
+
+            var transactionIdPropertyName = "My-Transaction-Id";
+            MessageCorrelationInfo correlation = GenerateMessageCorrelationInfo();
+            var logger = new InMemoryLogger();
+
+            // Act
+            await spySender.SendMessageAsync(expected, correlation, logger, options => options.TransactionIdPropertyName = transactionIdPropertyName);
+
+            // Assert
+            AssertDependencyTelemetry(logger);
+
+            ServiceBusMessage message = Assert.Single(spySender.Messages);
+            AssertEnrichedServiceBusMessage(message, expectedOrder, correlation, transactionIdPropertyName: transactionIdPropertyName);
+        }
+
+        [Fact]
+        public async Task SendMessageWithoutOptions_WithCustomUpstreamServicePropertyName_Succeeds()
+        {
+            // Arrange
+            var spySender = new InMemoryServiceBusSender();
+            var expectedOrder = OrderGenerator.Generate();
+            var expected = ServiceBusMessageBuilder.CreateForBody(expectedOrder).Build();
+            
+            var upstreamServicePropertyName = "My-UpstreamService-Id";
+            MessageCorrelationInfo correlation = GenerateMessageCorrelationInfo();
+            var logger = new InMemoryLogger();
+
+            // Act
+            await spySender.SendMessageAsync(expected, correlation, logger, options => options.UpstreamServicePropertyName = upstreamServicePropertyName);
+
+            // Assert
+            AssertDependencyTelemetry(logger);
+
+            ServiceBusMessage message = Assert.Single(spySender.Messages);
+            AssertEnrichedServiceBusMessage(message, expectedOrder, correlation, operationParentPropertyName: upstreamServicePropertyName);
+        }
+
+        [Fact]
+        public async Task SendMessagesWithoutOptions_WithMessageCorrelation_Succeeds()
+        {
+            // Arrange
+            var spySender = new InMemoryServiceBusSender();
+            var expectedOrders = BogusGenerator.Make(5, () => OrderGenerator.Generate());
+            var messages = expectedOrders.Select(order => ServiceBusMessageBuilder.CreateForBody(order).Build());
+
+            MessageCorrelationInfo correlation = GenerateMessageCorrelationInfo();
+            var logger = new InMemoryLogger();
+
+            // Act
+            await spySender.SendMessagesAsync(messages, correlation, logger);
+
+            // Assert
+            AssertDependencyTelemetry(logger);
+            Assert.All(
+                spySender.Messages.Zip(expectedOrders), 
+                item => AssertEnrichedServiceBusMessage(item.First, item.Second, correlation));
+        }
+
+        
+        [Fact]
+        public async Task SendMessagesWithoutOptions_WithCustomDependencyId_Succeeds()
+        {
+            // Arrange
+            var spySender = new InMemoryServiceBusSender();
+            var expectedOrders = BogusGenerator.Make(5, () => OrderGenerator.Generate());
+            var messages = expectedOrders.Select(order => ServiceBusMessageBuilder.CreateForBody(order).Build());
+
+            var dependencyId = $"dependency-{Guid.NewGuid()}";
+            MessageCorrelationInfo correlation = GenerateMessageCorrelationInfo();
+            var logger = new InMemoryLogger();
+
+            // Act
+            await spySender.SendMessagesAsync(messages, correlation, logger, options => options.GenerateDependencyId = () => dependencyId);
+
+            // Assert
+            AssertDependencyTelemetry(logger, dependencyId);
+            Assert.All(
+                spySender.Messages.Zip(expectedOrders), 
+                item => AssertEnrichedServiceBusMessageWithDependencyId(item.First, item.Second, correlation, dependencyId));
+        }
+
+        [Fact]
+        public async Task SendMessagesWithoutOptions_WithCustomTransactionIdPropertyName_Succeeds()
+        {
+            // Arrange
+            var spySender = new InMemoryServiceBusSender();
+            var expectedOrders = BogusGenerator.Make(5, () => OrderGenerator.Generate());
+            var messages = expectedOrders.Select(order => ServiceBusMessageBuilder.CreateForBody(order).Build());
+
+            var transactionIdPropertyName = "My-Transaction-Id";
+            MessageCorrelationInfo correlation = GenerateMessageCorrelationInfo();
+            var logger = new InMemoryLogger();
+
+            // Act
+            await spySender.SendMessagesAsync(messages, correlation, logger, options => options.TransactionIdPropertyName = transactionIdPropertyName);
+
+            // Assert
+            AssertDependencyTelemetry(logger);
+            Assert.All(
+                spySender.Messages.Zip(expectedOrders), 
+                item => AssertEnrichedServiceBusMessage(item.First, item.Second, correlation, transactionIdPropertyName: transactionIdPropertyName));
+        }
+
+        [Fact]
+        public async Task SendMessagesWithoutOptions_WithCustomUpstreamServiceIdPropertyName_Succeeds()
+        {
+            // Arrange
+            var spySender = new InMemoryServiceBusSender();
+            var expectedOrders = BogusGenerator.Make(5, () => OrderGenerator.Generate());
+            var messages = expectedOrders.Select(order => ServiceBusMessageBuilder.CreateForBody(order).Build());
+
+            var upstreamServicePropertyName = "My-UpstreamService-Id";
+            MessageCorrelationInfo correlation = GenerateMessageCorrelationInfo();
+            var logger = new InMemoryLogger();
+
+            // Act
+            await spySender.SendMessagesAsync(messages, correlation, logger, options => options.UpstreamServicePropertyName = upstreamServicePropertyName);
+
+            // Assert
+            AssertDependencyTelemetry(logger);
+            Assert.All(
+                spySender.Messages.Zip(expectedOrders), 
+                item => AssertEnrichedServiceBusMessage(item.First, item.Second, correlation, operationParentPropertyName: upstreamServicePropertyName));
+        }
+
+        private static MessageCorrelationInfo GenerateMessageCorrelationInfo()
+        {
+            return new MessageCorrelationInfo(
+                $"operation-{Guid.NewGuid()}",
+                $"transaction-{Guid.NewGuid()}",
+                $"parent-{Guid.NewGuid()}");
+        }
+
+        private static void AssertDependencyTelemetry(InMemoryLogger logger)
+        {
+            string logMessage = Assert.Single(logger.Messages);
+            Assert.Contains("Dependency", logMessage);
+            Assert.Matches(DependencyIdPattern, logMessage);
+        }
+
+        private static void AssertDependencyTelemetry(InMemoryLogger logger, string dependencyId)
+        {
+            string logMessage = Assert.Single(logger.Messages);
+            Assert.Contains("Dependency", logMessage);
+            Assert.Contains($"with ID {dependencyId}", logMessage);
+        }
+
+        private static void AssertEnrichedServiceBusMessage(
+            ServiceBusMessage message,
+            Order expectedOrder,
+            MessageCorrelationInfo correlation,
+            string transactionIdPropertyName = PropertyNames.TransactionId,
+            string operationParentPropertyName = PropertyNames.OperationParentId)
+        {
+            var actualOrder = message.Body.ToObjectFromJson<Order>();
+            Assert.Equal(expectedOrder.Id, actualOrder.Id);
+
+            Assert.Equal(correlation.TransactionId, Assert.Contains(transactionIdPropertyName, message.ApplicationProperties));
+            var actualOperationParentId = Assert.Contains(operationParentPropertyName, message.ApplicationProperties).ToString();
+            Assert.False(string.IsNullOrWhiteSpace(actualOperationParentId));
+        }
+
+        private static void AssertEnrichedServiceBusMessageWithDependencyId(
+            ServiceBusMessage message,
+            Order expectedOrder,
+            MessageCorrelationInfo correlation,
+            string dependencyId,
+            string transactionIdPropertyName = PropertyNames.TransactionId,
+            string operationParentIdPropertyName = PropertyNames.OperationParentId)
+        {
+            var actualOrder = message.Body.ToObjectFromJson<Order>();
+            Assert.Equal(expectedOrder.Id, actualOrder.Id);
+
+            Assert.Equal(correlation.TransactionId, Assert.Contains(transactionIdPropertyName, message.ApplicationProperties));
+            Assert.Equal(dependencyId, Assert.Contains(operationParentIdPropertyName, message.ApplicationProperties));
+        }
+
+        [Fact]
+        public async Task SendMessageBodyWithoutOptions_WithoutMessageBody_Fails()
+        {
+            // Arrange
+            var sender = Mock.Of<ServiceBusSender>();
+            var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
+            var logger = new InMemoryLogger();
+            
+            // Act
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => sender.SendMessageAsync(messageBody: null, correlation, logger));
+        }
+
+        [Fact]
+        public async Task SendMessageBodyWithoutOptions_WithoutCorrelation_Fails()
+        {
+            // Arrange
+            var sender = Mock.Of<ServiceBusSender>();
+            var order = OrderGenerator.Generate();
+            var logger = new InMemoryLogger();
+            
+            // Act
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => sender.SendMessageAsync(order, correlationInfo: null, logger));
+        }
+
+        [Fact]
+        public async Task SendMessageBodyWithoutOptions_WithoutLogger_Fails()
+        {
+            // Arrange
+            var sender = Mock.Of<ServiceBusSender>();
+            var order = OrderGenerator.Generate();
+            var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
+            
+            // Act
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => sender.SendMessageAsync(order, correlation, logger: null));
+        }
+
+        [Fact]
+        public async Task SendMessageBodyWithOptions_WithoutMessageBody_Fails()
+        {
+            // Arrange
+            var sender = Mock.Of<ServiceBusSender>();
+            var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
+            var logger = new InMemoryLogger();
+            
+            // Act
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => sender.SendMessageAsync(messageBody: null, correlation, logger, options => { }));
+        }
+
+        [Fact]
+        public async Task SendMessageBodyWithOptions_WithoutCorrelation_Fails()
+        {
+            // Arrange
+            var sender = Mock.Of<ServiceBusSender>();
+            var order = OrderGenerator.Generate();
+            var logger = new InMemoryLogger();
+            
+            // Act
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => sender.SendMessageAsync(order, correlationInfo: null, logger, options => { }));
+        }
+
+        [Fact]
+        public async Task SendMessageBodyWithOptions_WithoutLogger_Fails()
+        {
+            // Arrange
+            var sender = Mock.Of<ServiceBusSender>();
+            var order = OrderGenerator.Generate();
+            var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
+            
+            // Act
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => sender.SendMessageAsync(order, correlation, logger: null, options => { }));
+        }
+
+        [Fact]
+        public async Task SendMessagesBodyWithoutOptions_WithoutMessageBody_Fails()
+        {
+            // Arrange
+            var sender = Mock.Of<ServiceBusSender>();
+            var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
+            var logger = new InMemoryLogger();
+            
+            // Act
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => sender.SendMessagesAsync(messageBodies: null, correlation, logger));
+        }
+
+        [Fact]
+        public async Task SendMessageBodiesWithoutOptions_WithoutCorrelation_Fails()
+        {
+            // Arrange
+            var sender = Mock.Of<ServiceBusSender>();
+            var order = OrderGenerator.Generate();
+            var logger = new InMemoryLogger();
+            
+            // Act
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => sender.SendMessagesAsync(new[] { order }, correlationInfo: null, logger));
+        }
+
+        [Fact]
+        public async Task SendMessageBodiesWithoutOptions_WithoutLogger_Fails()
+        {
+            // Arrange
+            var sender = Mock.Of<ServiceBusSender>();
+            var order = OrderGenerator.Generate();
+            var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
+            
+            // Act
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => sender.SendMessagesAsync(new[] { order }, correlation, logger: null));
+        }
+
+        [Fact]
+        public async Task SendMessageBodiesWithOptions_WithoutMessageBody_Fails()
+        {
+            // Arrange
+            var sender = Mock.Of<ServiceBusSender>();
+            var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
+            var logger = new InMemoryLogger();
+            
+            // Act
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => sender.SendMessagesAsync(messageBodies: null, correlation, logger, options => { }));
+        }
+
+        [Fact]
+        public async Task SendMessageBodiesWithOptions_WithoutCorrelation_Fails()
+        {
+            // Arrange
+            var sender = Mock.Of<ServiceBusSender>();
+            var order = OrderGenerator.Generate();
+            var logger = new InMemoryLogger();
+            
+            // Act
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => sender.SendMessagesAsync(new[] { order }, correlationInfo: null, logger, options => { }));
+        }
+
+        [Fact]
+        public async Task SendMessageBodiesWithOptions_WithoutLogger_Fails()
+        {
+            // Arrange
+            var sender = Mock.Of<ServiceBusSender>();
+            var order = OrderGenerator.Generate();
+            var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
+            
+            // Act
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => sender.SendMessagesAsync(new[] { order }, correlation, logger: null, options => { }));
+        }
+
+        [Fact]
+        public async Task SendMessageWithoutOptions_WithoutMessageBody_Fails()
+        {
+            // Arrange
+            var sender = Mock.Of<ServiceBusSender>();
+            var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
+            var logger = new InMemoryLogger();
+            
+            // Act
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => sender.SendMessageAsync(message: null, correlation, logger));
+        }
+
+        [Fact]
+        public async Task SendMessageWithoutOptions_WithoutCorrelation_Fails()
+        {
+            // Arrange
+            var sender = Mock.Of<ServiceBusSender>();
+            var order = ServiceBusMessageBuilder.CreateForBody(OrderGenerator.Generate()).Build();
+            var logger = new InMemoryLogger();
+            
+            // Act
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => sender.SendMessageAsync(order, correlationInfo: null, logger));
+        }
+
+        [Fact]
+        public async Task SendMessageWithoutOptions_WithoutLogger_Fails()
+        {
+            // Arrange
+            var sender = Mock.Of<ServiceBusSender>();
+            var order = ServiceBusMessageBuilder.CreateForBody(OrderGenerator.Generate()).Build();
+            var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
+            
+            // Act
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => sender.SendMessageAsync(order, correlation, logger: null));
+        }
+
+        [Fact]
+        public async Task SendMessageWithOptions_WithoutMessageBody_Fails()
+        {
+            // Arrange
+            var sender = Mock.Of<ServiceBusSender>();
+            var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
+            var logger = new InMemoryLogger();
+            
+            // Act
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => sender.SendMessageAsync(message: null, correlation, logger, options => { }));
+        }
+
+        [Fact]
+        public async Task SendMessageWithOptions_WithoutCorrelation_Fails()
+        {
+            // Arrange
+            var sender = Mock.Of<ServiceBusSender>();
+            var order = ServiceBusMessageBuilder.CreateForBody(OrderGenerator.Generate()).Build();
+            var logger = new InMemoryLogger();
+            
+            // Act
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => sender.SendMessageAsync(order, correlationInfo: null, logger, options => { }));
+        }
+
+        [Fact]
+        public async Task SendMessageWithOptions_WithoutLogger_Fails()
+        {
+            // Arrange
+            var sender = Mock.Of<ServiceBusSender>();
+            var order = ServiceBusMessageBuilder.CreateForBody(OrderGenerator.Generate()).Build();
+            var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
+            
+            // Act
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => sender.SendMessageAsync(order, correlation, logger: null, options => { }));
+        }
+
+        [Fact]
+        public async Task SendMessagesWithoutOptions_WithoutMessageBody_Fails()
+        {
+            // Arrange
+            var sender = Mock.Of<ServiceBusSender>();
+            var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
+            var logger = new InMemoryLogger();
+            
+            // Act
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => sender.SendMessagesAsync(messages: null, correlation, logger));
+        }
+
+        [Fact]
+        public async Task SendMessagesWithoutOptions_WithoutCorrelation_Fails()
+        {
+            // Arrange
+            var sender = Mock.Of<ServiceBusSender>();
+            var order = ServiceBusMessageBuilder.CreateForBody(OrderGenerator.Generate()).Build();
+            var logger = new InMemoryLogger();
+            
+            // Act
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => sender.SendMessagesAsync(new[] { order }, correlationInfo: null, logger));
+        }
+
+        [Fact]
+        public async Task SendMessagesWithoutOptions_WithoutLogger_Fails()
+        {
+            // Arrange
+            var sender = Mock.Of<ServiceBusSender>();
+            var order = ServiceBusMessageBuilder.CreateForBody(OrderGenerator.Generate()).Build();
+            var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
+            
+            // Act
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => sender.SendMessagesAsync(new[] { order }, correlation, logger: null));
+        }
+
+        [Fact]
+        public async Task SendMessagesWithOptions_WithoutMessageBody_Fails()
+        {
+            // Arrange
+            var sender = Mock.Of<ServiceBusSender>();
+            var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
+            var logger = new InMemoryLogger();
+            
+            // Act
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => sender.SendMessagesAsync(messages: null, correlation, logger, options => { }));
+        }
+
+        [Fact]
+        public async Task SendMessagesWithOptions_WithoutCorrelation_Fails()
+        {
+            // Arrange
+            var sender = Mock.Of<ServiceBusSender>();
+            var order = ServiceBusMessageBuilder.CreateForBody(OrderGenerator.Generate()).Build();
+            var logger = new InMemoryLogger();
+            
+            // Act
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => sender.SendMessagesAsync(new[] { order }, correlationInfo: null, logger, options => { }));
+        }
+
+        [Fact]
+        public async Task SendMessagesWithOptions_WithoutLogger_Fails()
+        {
+            // Arrange
+            var sender = Mock.Of<ServiceBusSender>();
+            var order = ServiceBusMessageBuilder.CreateForBody(OrderGenerator.Generate()).Build();
+            var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
+            
+            // Act
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => sender.SendMessagesAsync(new[] { order }, correlation, logger: null, options => { }));
+        }
+    }
+}


### PR DESCRIPTION
Add extensions on the Azure Service Bus `ServiceBusSender` model to more easily send and track correlated messages that support service-to-service correlation.

Closes #309