### PR TITLE
feat: add telemetrycontext in sender correlation options

### DIFF
--- a/docs/preview/02-Features/04-service-bus-extensions.md
+++ b/docs/preview/02-Features/04-service-bus-extensions.md
@@ -61,6 +61,12 @@ await sender.SendMessageAsync(order, correlation, logger, options =>
     // The Azure Service Bus application function to generate a dependency ID which will be added to both the message as the dependency tracking.
     // Default: GUID generation.
     options.GenerateDependencyId = () => $"dependency-{Guid.NewGuid()}";
+
+    // The dictionary containing any additional contextual inforamtion that will be used when tracking the Azure Service Bus dependency (Default: empty dictionary).
+    options.AddTelemetryContext(new Dictionary<string, object>
+    {
+        ["My-ServiceBus-custom-key"] = "Any additional information"
+    });
 });
 
 ServiceBusMessage message = ...

--- a/src/Arcus.Messaging.ServiceBus.Core/Extensions/ServiceBusSenderExtensions.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/Extensions/ServiceBusSenderExtensions.cs
@@ -315,9 +315,9 @@ namespace Azure.Messaging.ServiceBus
                     isSuccessful = true;
                 }
                 finally
-               {
-                   logger.LogServiceBusDependency(sender.FullyQualifiedNamespace, sender.EntityPath, isSuccessful, measurement, dependencyId, options.EntityType);
-               }
+                {
+                    logger.LogServiceBusDependency(sender.FullyQualifiedNamespace, sender.EntityPath, isSuccessful, measurement, dependencyId, options.EntityType, options.TelemetryContext);
+                }
             }
         }
     }

--- a/src/Arcus.Messaging.ServiceBus.Core/ServiceBusSenderMessageCorrelationOptions.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/ServiceBusSenderMessageCorrelationOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using Arcus.Messaging.Abstractions;
 using Azure.Messaging.ServiceBus;
@@ -60,6 +61,22 @@ namespace Arcus.Messaging.ServiceBus.Core
                 Guard.NotNull(value, nameof(value), "Requires a function to generate the dependency ID used when tracking Azure Service Bus dependencies");
                 _generateDependencyId = value;
             }
+        }
+
+        /// <summary>
+        /// Gets the telemetry context used during HTTP dependency tracking.
+        /// </summary>
+        internal Dictionary<string, object> TelemetryContext { get; private set; } = new Dictionary<string, object>();
+
+        /// <summary>
+        /// Adds a telemetry context while tracking the Azure Service Bus dependency.
+        /// </summary>
+        /// <param name="telemetryContext">The dictionary with contextual information about the dependency telemetry.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="telemetryContext"/> is <c>null</c>.</exception>
+        public void AddTelemetryContext(Dictionary<string, object> telemetryContext)
+        {
+            Guard.NotNull(telemetryContext, nameof(telemetryContext), "Requires a telemetry context dictionary to add to the Azure Service Bus dependency tracking");
+            TelemetryContext = telemetryContext;
         }
     }
 }

--- a/src/Arcus.Messaging.ServiceBus.Core/ServiceBusSenderMessageCorrelationOptions.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/ServiceBusSenderMessageCorrelationOptions.cs
@@ -66,7 +66,7 @@ namespace Arcus.Messaging.ServiceBus.Core
         /// <summary>
         /// Gets the telemetry context used during HTTP dependency tracking.
         /// </summary>
-        internal Dictionary<string, object> TelemetryContext { get; private set; } = new Dictionary<string, object>();
+        internal Dictionary<string, object> TelemetryContext { get; } = new Dictionary<string, object>();
 
         /// <summary>
         /// Adds a telemetry context while tracking the Azure Service Bus dependency.
@@ -76,7 +76,10 @@ namespace Arcus.Messaging.ServiceBus.Core
         public void AddTelemetryContext(Dictionary<string, object> telemetryContext)
         {
             Guard.NotNull(telemetryContext, nameof(telemetryContext), "Requires a telemetry context dictionary to add to the Azure Service Bus dependency tracking");
-            TelemetryContext = telemetryContext;
+            foreach (KeyValuePair<string, object> item in telemetryContext)
+            {
+                TelemetryContext[item.Key] = item.Value;
+            }
         }
     }
 }

--- a/src/Arcus.Messaging.Tests.Unit/ServiceBus/ServiceBusSenderExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/ServiceBus/ServiceBusSenderExtensionsTests.cs
@@ -362,7 +362,6 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             string key = BogusGenerator.Lorem.Word(), value = BogusGenerator.Lorem.Word();
             var telemetryContext = new Dictionary<string, object> { [key] = value };
             
-            var upstreamServicePropertyName = "My-UpstreamService-Id";
             MessageCorrelationInfo correlation = GenerateMessageCorrelationInfo();
             var logger = new InMemoryLogger();
 
@@ -375,7 +374,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             Assert.Contains(value, logMessage);
             Assert.All(
                 spySender.Messages.Zip(expectedOrders), 
-                item => AssertEnrichedServiceBusMessage(item.First, item.Second, correlation, operationParentPropertyName: upstreamServicePropertyName));
+                item => AssertEnrichedServiceBusMessage(item.First, item.Second, correlation));
         }
 
         private static MessageCorrelationInfo GenerateMessageCorrelationInfo()

--- a/src/Arcus.Messaging.Tests.Unit/ServiceBus/ServiceBusSenderMessageCorrelationOptionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/ServiceBus/ServiceBusSenderMessageCorrelationOptionsTests.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using Arcus.Messaging.ServiceBus.Core;
+using Xunit;
+
+namespace Arcus.Messaging.Tests.Unit.ServiceBus
+{
+    public class ServiceBusSenderMessageCorrelationOptionsTests
+    {
+        [Fact]
+        public void TransactionIdPropertyName_WithNoAction_UsesDefault()
+        {
+            // Arrange
+            var options = new ServiceBusSenderMessageCorrelationOptions();
+
+            // Act
+            string headerName = options.TransactionIdPropertyName;
+
+            // Assert
+            Assert.False(string.IsNullOrWhiteSpace(headerName));
+        }
+
+        [Fact]
+        public void TransactionIdPropertyName_SetValue_UsesValue()
+        {
+            // Arrange
+            var options = new ServiceBusSenderMessageCorrelationOptions();
+            string PropertyName = Guid.NewGuid().ToString();
+
+            // Act
+            options.TransactionIdPropertyName = PropertyName;
+
+            // Assert
+            Assert.False(string.IsNullOrWhiteSpace(PropertyName));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void TransactionIdPropertyName_WithoutValue_Fails(string PropertyName)
+        {
+            // Arrange
+            var options = new ServiceBusSenderMessageCorrelationOptions();
+
+            // ACt / Assert
+            Assert.ThrowsAny<ArgumentException>(() => options.TransactionIdPropertyName = PropertyName);
+        }
+
+        [Fact]
+        public void UpstreamServicePropertyName_WithNoAction_UsesDefault()
+        {
+            // Arrange
+            var options = new ServiceBusSenderMessageCorrelationOptions();
+
+            // Act
+            string headerName = options.UpstreamServicePropertyName;
+
+            // Assert
+            Assert.False(string.IsNullOrWhiteSpace(headerName));
+        }
+
+        [Fact]
+        public void UpstreamServicePropertyName_SetValue_UsesValue()
+        {
+            // Arrange
+            var options = new ServiceBusSenderMessageCorrelationOptions();
+            string PropertyName = Guid.NewGuid().ToString();
+
+            // Act
+            options.UpstreamServicePropertyName = PropertyName;
+
+            // Assert
+            Assert.False(string.IsNullOrWhiteSpace(PropertyName));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void UpstreamServicePropertyName_WithoutValue_Fails(string PropertyName)
+        {
+            // Arrange
+            var options = new ServiceBusSenderMessageCorrelationOptions();
+
+            // ACt / Assert
+            Assert.ThrowsAny<ArgumentException>(() => options.UpstreamServicePropertyName = PropertyName);
+        }
+
+        [Fact]
+        public void GenerateDependencyId_WithoutAction_GeneratesDefault()
+        {
+            // Arrange
+            var options = new ServiceBusSenderMessageCorrelationOptions();
+
+            // Act
+            string dependencyId = options.GenerateDependencyId();
+
+            // Assert
+            Assert.False(string.IsNullOrWhiteSpace(dependencyId));
+        }
+
+        [Fact]
+        public void GenerateDependencyId_WithValue_UsesValue()
+        {
+            // Arrange
+            var options = new ServiceBusSenderMessageCorrelationOptions();
+            string dependencyId = Guid.NewGuid().ToString();
+
+            // Act
+            options.GenerateDependencyId = () => dependencyId;
+
+            // Assert
+            Assert.Equal(dependencyId, options.GenerateDependencyId());
+        }
+
+        [Fact]
+        public void GenerateDependencyId_WithoutValue_Fails()
+        {
+            // Arrange
+            var options = new ServiceBusSenderMessageCorrelationOptions();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => options.GenerateDependencyId = null);
+        }
+
+        [Fact]
+        public void AddTelemetryContext_WithoutValue_Fails()
+        {
+            // Arrange
+            var options = new ServiceBusSenderMessageCorrelationOptions();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => options.AddTelemetryContext(telemetryContext: null));
+        }
+    }
+}


### PR DESCRIPTION
Adds contextual information in the form of a telemetry context to the Azure Service Bus sender correlation options so that the tracked Azure Service Bus dependency can be further configured.

Closes #327