### PR TITLE
fix: use general correlation model in sender extensions

### DIFF
--- a/src/Arcus.Messaging.EventHubs.Core/EventHubProducerClientMessageCorrelationOptions.cs
+++ b/src/Arcus.Messaging.EventHubs.Core/EventHubProducerClientMessageCorrelationOptions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using Arcus.Messaging.Abstractions;
+using Arcus.Observability.Correlation;
 using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Producer;
 using GuardNet;
@@ -10,7 +11,7 @@ using Microsoft.Extensions.Logging;
 namespace Arcus.Messaging.EventHubs.Core
 {
     /// <summary>
-    /// Represents the user-configurable options to influence the message correlation tracking behavior of the <see cref="EventHubProducerClientExtensions.SendAsync(EventHubProducerClient,IEnumerable{EventData},MessageCorrelationInfo,ILogger,SendEventOptions,Action{EventHubProducerClientMessageCorrelationOptions},CancellationToken)"/> extensions.
+    /// Represents the user-configurable options to influence the message correlation tracking behavior of the <see cref="EventHubProducerClientExtensions.SendAsync(EventHubProducerClient,IEnumerable{EventData},CorrelationInfo,ILogger,SendEventOptions,Action{EventHubProducerClientMessageCorrelationOptions},CancellationToken)"/> extensions.
     /// </summary>
     public class EventHubProducerClientMessageCorrelationOptions
     {

--- a/src/Arcus.Messaging.EventHubs.Core/Extensions/EventHubProducerClientExtensions.cs
+++ b/src/Arcus.Messaging.EventHubs.Core/Extensions/EventHubProducerClientExtensions.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.EventHubs.Core;
+using Arcus.Observability.Correlation;
 using Arcus.Observability.Telemetry.Core;
 using GuardNet;
 using Microsoft.Extensions.Logging;
@@ -50,7 +51,7 @@ namespace Azure.Messaging.EventHubs.Producer
         public static async Task SendAsync(
             this EventHubProducerClient client,
             IEnumerable<object> eventBatch,
-            MessageCorrelationInfo correlationInfo,
+            CorrelationInfo correlationInfo,
             ILogger logger,
             CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -97,7 +98,7 @@ namespace Azure.Messaging.EventHubs.Producer
         public static async Task SendAsync(
             this EventHubProducerClient client,
             IEnumerable<object> eventBatch,
-            MessageCorrelationInfo correlationInfo,
+            CorrelationInfo correlationInfo,
             ILogger logger,
             Action<EventHubProducerClientMessageCorrelationOptions> configureOptions,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -146,7 +147,7 @@ namespace Azure.Messaging.EventHubs.Producer
         public static async Task SendAsync(
             this EventHubProducerClient client,
             IEnumerable<object> eventBatch,
-            MessageCorrelationInfo correlationInfo,
+            CorrelationInfo correlationInfo,
             ILogger logger,
             SendEventOptions sendEventOptions,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -196,7 +197,7 @@ namespace Azure.Messaging.EventHubs.Producer
         public static async Task SendAsync(
             this EventHubProducerClient client,
             IEnumerable<object> eventBatch,
-            MessageCorrelationInfo correlationInfo,
+            CorrelationInfo correlationInfo,
             ILogger logger,
             SendEventOptions sendEventOptions,
             Action<EventHubProducerClientMessageCorrelationOptions> configureOptions,
@@ -238,7 +239,7 @@ namespace Azure.Messaging.EventHubs.Producer
         public static async Task SendAsync(
             this EventHubProducerClient client,
             IEnumerable<EventData> eventBatch,
-            MessageCorrelationInfo correlationInfo,
+            CorrelationInfo correlationInfo,
             ILogger logger,
             CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -285,7 +286,7 @@ namespace Azure.Messaging.EventHubs.Producer
         public static async Task SendAsync(
             this EventHubProducerClient client,
             IEnumerable<EventData> eventBatch,
-            MessageCorrelationInfo correlationInfo,
+            CorrelationInfo correlationInfo,
             ILogger logger,
             Action<EventHubProducerClientMessageCorrelationOptions> configureOptions,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -334,7 +335,7 @@ namespace Azure.Messaging.EventHubs.Producer
         public static async Task SendAsync(
             this EventHubProducerClient client,
             IEnumerable<EventData> eventBatch,
-            MessageCorrelationInfo correlationInfo,
+            CorrelationInfo correlationInfo,
             ILogger logger,
             SendEventOptions sendEventOptions,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -384,7 +385,7 @@ namespace Azure.Messaging.EventHubs.Producer
         public static async Task SendAsync(
             this EventHubProducerClient client, 
             IEnumerable<EventData> eventBatch,
-            MessageCorrelationInfo correlationInfo,
+            CorrelationInfo correlationInfo,
             ILogger logger,
             SendEventOptions sendEventOptions,
             Action<EventHubProducerClientMessageCorrelationOptions> configureOptions,

--- a/src/Arcus.Messaging.ServiceBus.Core/Extensions/ServiceBusSenderExtensions.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/Extensions/ServiceBusSenderExtensions.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.ServiceBus.Core;
+using Arcus.Observability.Correlation;
 using Arcus.Observability.Telemetry.Core;
 using GuardNet;
 using Microsoft.Extensions.Logging;
@@ -35,7 +36,7 @@ namespace Azure.Messaging.ServiceBus
         public static async Task SendMessageAsync(
             this ServiceBusSender sender,
             object messageBody,
-            MessageCorrelationInfo correlationInfo,
+            CorrelationInfo correlationInfo,
             ILogger logger,
             CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -66,7 +67,7 @@ namespace Azure.Messaging.ServiceBus
         public static async Task SendMessageAsync(
             this ServiceBusSender sender,
             object messageBody,
-            MessageCorrelationInfo correlationInfo,
+            CorrelationInfo correlationInfo,
             ILogger logger,
             Action<ServiceBusSenderMessageCorrelationOptions> configureOptions,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -102,7 +103,7 @@ namespace Azure.Messaging.ServiceBus
         public static async Task SendMessagesAsync(
             this ServiceBusSender sender,
             IEnumerable<object> messageBodies,
-            MessageCorrelationInfo correlationInfo,
+            CorrelationInfo correlationInfo,
             ILogger logger,
             CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -140,7 +141,7 @@ namespace Azure.Messaging.ServiceBus
         public static async Task SendMessagesAsync(
             this ServiceBusSender sender,
             IEnumerable<object> messageBodies,
-            MessageCorrelationInfo correlationInfo,
+            CorrelationInfo correlationInfo,
             ILogger logger,
             Action<ServiceBusSenderMessageCorrelationOptions> configureOptions,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -177,7 +178,7 @@ namespace Azure.Messaging.ServiceBus
         public static async Task SendMessageAsync(
             this ServiceBusSender sender,
             ServiceBusMessage message,
-            MessageCorrelationInfo correlationInfo,
+            CorrelationInfo correlationInfo,
             ILogger logger,
             CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -208,7 +209,7 @@ namespace Azure.Messaging.ServiceBus
         public static async Task SendMessageAsync(
             this ServiceBusSender sender,
             ServiceBusMessage message,
-            MessageCorrelationInfo correlationInfo,
+            CorrelationInfo correlationInfo,
             ILogger logger,
             Action<ServiceBusSenderMessageCorrelationOptions> configureOptions,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -244,7 +245,7 @@ namespace Azure.Messaging.ServiceBus
         public static async Task SendMessagesAsync(
             this ServiceBusSender sender,
             IEnumerable<ServiceBusMessage> messages,
-            MessageCorrelationInfo correlationInfo,
+            CorrelationInfo correlationInfo,
             ILogger logger,
             CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -282,7 +283,7 @@ namespace Azure.Messaging.ServiceBus
         public static async Task SendMessagesAsync(
             this ServiceBusSender sender, 
             IEnumerable<ServiceBusMessage> messages, 
-            MessageCorrelationInfo correlationInfo,
+            CorrelationInfo correlationInfo,
             ILogger logger,
             Action<ServiceBusSenderMessageCorrelationOptions> configureOptions,
             CancellationToken cancellationToken = default(CancellationToken))

--- a/src/Arcus.Messaging.ServiceBus.Core/ServiceBusSenderMessageCorrelationOptions.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/ServiceBusSenderMessageCorrelationOptions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using Arcus.Messaging.Abstractions;
+using Arcus.Observability.Correlation;
 using Azure.Messaging.ServiceBus;
 using GuardNet;
 using Microsoft.Extensions.Logging;
@@ -9,7 +10,7 @@ using Microsoft.Extensions.Logging;
 namespace Arcus.Messaging.ServiceBus.Core
 {
     /// <summary>
-    /// Represents the user-configurable options to influence the message correlation tracking behavior of the <see cref="ServiceBusSenderExtensions.SendMessageAsync(ServiceBusSender,ServiceBusMessage,MessageCorrelationInfo,ILogger,Action{ServiceBusSenderMessageCorrelationOptions},CancellationToken)"/> extensions.
+    /// Represents the user-configurable options to influence the message correlation tracking behavior of the <see cref="ServiceBusSenderExtensions.SendMessageAsync(ServiceBusSender,ServiceBusMessage,CorrelationInfo,ILogger,Action{ServiceBusSenderMessageCorrelationOptions},CancellationToken)"/> extensions.
     /// </summary>
     public class ServiceBusSenderMessageCorrelationOptions
     {


### PR DESCRIPTION
Changes the messaging-specific correlation model `MessageCorrelationInfo` with the general `CorrelationInfo` so that application from other environments (ex. HTTP) can also benefit from these extensions without having to convert to the messaging-specific model.