### PR TITLE
feat: generalize restartable message pumps

### DIFF
--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageHandlerCollection.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageHandlerCollection.cs
@@ -20,6 +20,12 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             Guard.NotNull(services, nameof(services), "Requires a collection of services to register the message handling logic into");
             Services = services;
         }
+
+        /// <summary>
+        /// Gets or sets the unique message pump ID to identify the message pump throughout the application.
+        /// This ID can be used to get a reference of the previously registered message pump for which a message handler is registered.
+        /// </summary>
+        public string JobId { get; set; }
         
         /// <summary>
         /// Gets the current available collection of services to register the message handling logic into.

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageHandlerCollection.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageHandlerCollection.cs
@@ -22,8 +22,8 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         }
 
         /// <summary>
-        /// Gets or sets the unique message pump ID to identify the message pump throughout the application.
-        /// This ID can be used to get a reference of the previously registered message pump for which a message handler is registered.
+        /// Gets or sets the unique ID to identify the job that runs a message pump during the lifetime of the application.
+        /// This ID can be used to get a reference of the previously registered message pump while registering message handlers and other functionality related to the message pump.
         /// </summary>
         public string JobId { get; set; }
         

--- a/src/Arcus.Messaging.Pumps.Abstractions/IRestartableMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/IRestartableMessagePump.cs
@@ -1,0 +1,23 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+
+namespace Arcus.Messaging.Pumps.Abstractions
+{
+    /// <summary>
+    /// Represents an <see cref="MessagePump"/> that can be restarted programmatically.
+    /// </summary>
+    public interface IRestartableMessagePump : IHostedService
+    {
+        /// <summary>
+        /// Gets the unique message pump ID to identify the pump that needs to be restarted.
+        /// </summary>
+        public string JobId { get; }
+
+        /// <summary>
+        /// Programmatically restart the message pump.
+        /// </summary>
+        /// <param name="cancellationToken">The token to cancel the restart process.</param>
+        Task RestartAsync(CancellationToken cancellationToken);
+    }
+}

--- a/src/Arcus.Messaging.Pumps.Abstractions/IRestartableMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/IRestartableMessagePump.cs
@@ -12,7 +12,7 @@ namespace Arcus.Messaging.Pumps.Abstractions
         /// <summary>
         /// Gets the unique message pump ID to identify the pump that needs to be restarted.
         /// </summary>
-        public string JobId { get; }
+        string JobId { get; }
 
         /// <summary>
         /// Programmatically restart the message pump.

--- a/src/Arcus.Messaging.Pumps.EventHubs/AzureEventHubsMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.EventHubs/AzureEventHubsMessagePump.cs
@@ -64,9 +64,7 @@ namespace Arcus.Messaging.Pumps.EventHubs
         private string ConsumerGroup => _eventProcessor?.ConsumerGroup;
         private string Namespace => _eventProcessor?.FullyQualifiedNamespace;
 
-        /// <summary>
-        /// Gets the unique message pump ID to identify the pump that needs to be restarted.
-        /// </summary>
+        /// <inheritdoc/>
         public string JobId { get; }
 
         /// <summary>

--- a/src/Arcus.Messaging.Pumps.EventHubs/Configuration/AzureEventHubsMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.EventHubs/Configuration/AzureEventHubsMessagePumpOptions.cs
@@ -9,7 +9,8 @@ namespace Arcus.Messaging.Pumps.EventHubs.Configuration
     /// </summary>
     public class AzureEventHubsMessagePumpOptions
     {
-        private string _consumerGroup = "$Default";
+        private string _consumerGroup = "$Default",
+                      _jobId = Guid.NewGuid().ToString();
 
         /// <summary>
         /// Gets or sets the name of the consumer group this processor is associated with. Events are read in the context of this group. (Default: <c>"$Default"</c>).
@@ -22,6 +23,20 @@ namespace Arcus.Messaging.Pumps.EventHubs.Configuration
             {
                 Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank Azure EventHubs consumer group to consume event messages from");
                 _consumerGroup = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the unique identifier for this background job to distinguish this job instance in a multi-instance deployment.
+        /// </summary>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="value"/> is blank.</exception>
+        public string JobId
+        {
+            get => _jobId;
+            set
+            {
+                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank job identifier for the Azure EventHubs message pump");
+                _jobId = value;
             }
         }
 

--- a/src/Arcus.Messaging.Pumps.EventHubs/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.EventHubs/Extensions/IServiceCollectionExtensions.cs
@@ -112,7 +112,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 var logger = provider.GetService<ILogger<AzureEventHubsMessageRouter>>();
                 return new AzureEventHubsMessageRouter(provider, options.Routing, logger);
             });
-            
+            collection.JobId = options.JobId;
+
             services.AddHostedService(serviceProvider =>
             {
                 ISecretProvider secretProvider = DetermineSecretProvider(serviceProvider);

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -5,24 +5,20 @@ using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.ServiceBus;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 using Arcus.Messaging.Pumps.Abstractions;
-using Arcus.Messaging.Pumps.Abstractions.Telemetry;
 using Arcus.Messaging.Pumps.ServiceBus.Configuration;
-using Arcus.Observability.Correlation;
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
 using GuardNet;
 using Microsoft.Azure.ServiceBus;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Serilog.Context;
 
 namespace Arcus.Messaging.Pumps.ServiceBus
 {
     /// <summary>
     ///     Message pump for processing messages on an Azure Service Bus entity
     /// </summary>
-    public class AzureServiceBusMessagePump : MessagePump
+    public class AzureServiceBusMessagePump : MessagePump, IRestartableMessagePump
     {
         private readonly IAzureServiceBusMessageRouter _messageRouter;
         private readonly IDisposable _loggingScope;

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
@@ -74,7 +74,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
             get => _jobId;
             set
             {
-                Guard.NotNullOrEmpty(value, nameof(value), "Unique identifier for background job cannot be empty");
+                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank job identifier for the Azure Service Bus message pump");
                 _jobId = value;
             }
         }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
@@ -869,7 +869,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 var logger = provider.GetService<ILogger<AzureServiceBusMessageRouter>>();
                 return new AzureServiceBusMessageRouter(provider, options.Routing, logger);
             });
-            
+            collection.JobId = options.JobId;
+
             services.AddHostedService(serviceProvider =>
             {
                 var logger = serviceProvider.GetRequiredService<ILogger<AzureServiceBusMessagePump>>();

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/EventHubsMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/EventHubsMessagePumpTests.cs
@@ -278,7 +278,9 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             }
         }
 
-        private static EventData CreateOrderEventDataMessage(string transactionIdPropertyName, string operationParentIdPropertyName)
+        private static EventData CreateOrderEventDataMessage(
+            string transactionIdPropertyName = PropertyNames.TransactionId, 
+            string operationParentIdPropertyName = PropertyNames.OperationParentId)
         {
             Order order = OrderGenerator.Generate();
             var eventData = new EventData(JsonConvert.SerializeObject(order));
@@ -293,8 +295,8 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
         private static void AssertReceivedOrderEventData(
             EventData message,
             OrderCreatedEventData receivedEventData,
-            string transactionIdPropertyName,
-            string operationParentIdPropertyName,
+            string transactionIdPropertyName = PropertyNames.TransactionId,
+            string operationParentIdPropertyName = PropertyNames.OperationParentId,
             Encoding encoding = null)
         {
             encoding = encoding ?? Encoding.UTF8;

--- a/src/Arcus.Messaging.Tests.Unit/EventHubs/IServiceCollectionExtensionTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/EventHubs/IServiceCollectionExtensionTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Arcus.Messaging.Abstractions.EventHubs.MessageHandling;
 using Bogus;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -34,6 +35,33 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             IServiceProvider provider = services.BuildServiceProvider();
             var host = provider.GetService<IHostedService>();
             Assert.NotNull(host);
+        }
+
+        [Fact]
+        public void AddWithoutOptions_WithCustomJobId_Succeeds()
+        {
+            // Arrange
+            string eventHubsName = BogusGenerator.Lorem.Word();
+            string eventHubsConnectionStringSecretName = BogusGenerator.Lorem.Word();
+            string blobStorageContainerName = BogusGenerator.Lorem.Word();
+            string storageAccountConnectionStringSecretName = BogusGenerator.Lorem.Word();
+            string jobId = BogusGenerator.Random.Guid().ToString();
+            var services = new ServiceCollection();
+            services.AddSingleton(Mock.Of<IConfiguration>())
+                    .AddLogging()
+                    .AddSecretStore(stores => stores.AddInMemory());
+
+            // Act
+            EventHubsMessageHandlerCollection collection = 
+                services.AddEventHubsMessagePump(
+                    eventHubsName, eventHubsConnectionStringSecretName, blobStorageContainerName, storageAccountConnectionStringSecretName, 
+                    options => options.JobId = jobId);
+
+            // Assert
+            IServiceProvider provider = services.BuildServiceProvider();
+            var host = provider.GetService<IHostedService>();
+            Assert.NotNull(host);
+            Assert.Equal(jobId, collection.JobId);
         }
 
         [Fact]


### PR DESCRIPTION
Generalize restart functionality so that background jobs listening on events can more easily restart message pumps.

Closes #333