### PR TITLE
feat: add eventhubs message context extension

### DIFF
--- a/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/EventDataExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/EventDataExtensions.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using Arcus.Messaging.Abstractions.EventHubs;
+using GuardNet;
+
+// ReSharper disable once CheckNamespace
+namespace Azure.Messaging.EventHubs
+{
+    /// <summary>
+    /// Extensions on the <see cref="EventData"/> related to message handling.
+    /// </summary>
+    public static class EventDataExtensions
+    {
+        /// <summary>
+        /// Gets the message contextual information from the received <paramref name="message"/>.
+        /// </summary>
+        /// <param name="message">The consumed Azure EventHubs event to describe the messaging context.</param>
+        /// <param name="eventProcessor">The Azure EventHubs processor that received the <paramref name="message"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> or the <paramref name="eventProcessor"/> is <c>null</c>.</exception>
+        public static AzureEventHubsMessageContext GetMessageContext(this EventData message, EventProcessorClient eventProcessor)
+        {
+            Guard.NotNull(message, nameof(message), "Requires an event data to retrieve the Azure EventHubs message context");
+            Guard.NotNull(eventProcessor, nameof(eventProcessor), "Requires an Azure EventHubs event processor to retrieve the information to create a messaging context for the consumed event");
+
+            return AzureEventHubsMessageContext.CreateFrom(message, eventProcessor);
+        }
+        
+        /// <summary>
+        /// Gets the message contextual information from the received <paramref name="message"/>.
+        /// </summary>
+        /// <param name="message">The consumed Azure EventHubs event to describe the messaging context.</param>
+        /// <param name="eventHubsNamespace">
+        ///     The fully qualified Event Hubs namespace that the processor is associated with.
+        ///     This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.
+        /// </param>
+        /// <param name="eventHubsName"> The name of the Event Hub that the processor is connected to, specific to the EventHubs namespace that contains it.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="eventHubsNamespace"/>, or <paramref name="eventHubsName"/> is blank.
+        /// </exception>
+        public static AzureEventHubsMessageContext GetMessageContext(this EventData message, string eventHubsNamespace, string eventHubsName)
+        {
+            Guard.NotNull(message, nameof(message), "Requires an event data to retrieve the Azure EventHubs message context");
+            Guard.NotNullOrWhitespace(eventHubsNamespace, nameof(eventHubsNamespace), "Requires an Azure EventHubs namespace to built-up the message context");
+            Guard.NotNullOrWhitespace(eventHubsName, nameof(eventHubsName), "Requires an Azure EventHubs name to built-up the message context");
+
+            return GetMessageContext(message, eventHubsNamespace, eventHubsName, "$Default");
+        }
+
+        /// <summary>
+        /// Gets the message contextual information from the received <paramref name="message"/>.
+        /// </summary>
+        /// <param name="message">The consumed Azure EventHubs event to describe the messaging context.</param>
+        /// <param name="eventHubsNamespace">
+        ///     The fully qualified Event Hubs namespace that the processor is associated with.
+        ///     This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.
+        /// </param>
+        /// <param name="eventHubsName"> The name of the Event Hub that the processor is connected to, specific to the EventHubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group this event processor is associated with.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="eventHubsNamespace"/>, <paramref name="consumerGroup"/>, or <paramref name="eventHubsName"/> is blank.
+        /// </exception>
+        public static AzureEventHubsMessageContext GetMessageContext(this EventData message, string eventHubsNamespace, string eventHubsName, string consumerGroup)
+        {
+            Guard.NotNull(message, nameof(message), "Requires an event data to retrieve the Azure EventHubs message context");
+            Guard.NotNullOrWhitespace(eventHubsNamespace, nameof(eventHubsNamespace), "Requires an Azure EventHubs namespace to built-up the message context");
+            Guard.NotNullOrWhitespace(eventHubsName, nameof(eventHubsName), "Requires an Azure EventHubs name to built-up the message context");
+            Guard.NotNullOrWhitespace(consumerGroup, nameof(consumerGroup), "Requires an Azure EventHubs consumer group to built-up the message context");
+
+            return AzureEventHubsMessageContext.CreateFrom(message, eventHubsNamespace, consumerGroup, eventHubsName);
+        }
+    }
+}

--- a/src/Arcus.Messaging.Pumps.EventHubs/AzureEventHubsMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.EventHubs/AzureEventHubsMessagePump.cs
@@ -140,9 +140,7 @@ namespace Arcus.Messaging.Pumps.EventHubs
                 Logger.LogTrace("No operation ID was found on the message '{MessageId}' during processing in the Azure EventHubs message pump '{JobId}'", message.MessageId, JobId);
             }
 
-            // TODO: create extension on `EventData` to retrieve context.
-            var context = AzureEventHubsMessageContext.CreateFrom(args.Data, _eventProcessor);
-            
+            AzureEventHubsMessageContext context = args.Data.GetMessageContext(_eventProcessor);
             MessageCorrelationInfo correlation = args.Data.GetCorrelationInfo(
                 transactionIdPropertyName: _eventHubsConfig.Options.Routing.Correlation.TransactionIdPropertyName,
                 operationParentIdPropertyName: _eventHubsConfig.Options.Routing.Correlation.OperationParentIdPropertyName);

--- a/src/Arcus.Messaging.Tests.Runtimes.AzureFunction.EventHubs/local.settings.json
+++ b/src/Arcus.Messaging.Tests.Runtimes.AzureFunction.EventHubs/local.settings.json
@@ -1,0 +1,7 @@
+{
+    "IsEncrypted": false,
+    "Values": {
+        "AzureWebJobsStorage": "",
+        "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated"
+    }
+}

--- a/src/Arcus.Messaging.Tests.Unit/EventHubs/EventDataBuilderTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/EventHubs/EventDataBuilderTests.cs
@@ -26,7 +26,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             Assert.NotNull(message);
             Assert.NotEmpty(message.Body.ToArray());
             Assert.Equal(messageBody.ToString(), Encoding.UTF8.GetString(message.Body.ToArray()));
-            Encoding encoding = AzureEventHubsMessageContext.CreateFrom(message, "namespace", "consumergroup", "name").GetMessageEncodingProperty();
+            Encoding encoding = message.GetMessageContext("namespace", "consumergroup", "name").GetMessageEncodingProperty();
             Assert.Equal(Encoding.UTF8, encoding);
         }
 
@@ -45,7 +45,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             Assert.NotNull(message);
             Assert.NotEmpty(message.Body.ToArray());
             Assert.Equal(messageBody.ToString(), expectedEncoding.GetString(message.Body.ToArray()));
-            Encoding actualEncoding = AzureEventHubsMessageContext.CreateFrom(message, "namespace", "consumergroup", "name").GetMessageEncodingProperty();
+            Encoding actualEncoding = message.GetMessageContext("namespace", "consumergroup", "name").GetMessageEncodingProperty();
             Assert.Equal(expectedEncoding, actualEncoding);
         }
 

--- a/src/Arcus.Messaging.Tests.Unit/EventHubs/EventDataExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/EventHubs/EventDataExtensionsTests.cs
@@ -1,0 +1,73 @@
+﻿using System.Linq;
+using Arcus.Messaging.Abstractions.EventHubs;
+using Azure.Identity;
+using Azure.Messaging.EventHubs;
+using Azure.Storage.Blobs;
+using Bogus;
+using Moq;
+using Xunit;
+
+namespace Arcus.Messaging.Tests.Unit.EventHubs
+{
+    public class EventDataExtensionsTests
+    {
+        private static readonly Faker BogusGenerator = new Faker();
+
+        [Fact]
+        public void GetMessageContextManually_WithValidArguments_Succeeds()
+        {
+            // Arrange
+            var data = new EventData();
+            data.ContentType = BogusGenerator.Random.AlphaNumeric(10);
+            string eventHubsNamespace = BogusGenerator.Random.AlphaNumeric(20);
+            string eventHubsName = BogusGenerator.Random.AlphaNumeric(5);
+            string consumerGroup = BogusGenerator.Random.AlphaNumeric(10);
+
+            // Act
+            AzureEventHubsMessageContext context = data.GetMessageContext(eventHubsNamespace, eventHubsName, consumerGroup);
+
+            // Assert
+            Assert.Equal(eventHubsNamespace, context.EventHubsNamespace);
+            Assert.Equal(eventHubsName, context.EventHubsName);
+            Assert.Equal(consumerGroup, context.ConsumerGroup);
+            Assert.Equal(data.ContentType, context.ContentType);
+            Assert.Equal(data.EnqueuedTime, context.EnqueueTime);
+            Assert.Equal(data.Offset, context.Offset);
+            Assert.Equal(data.PartitionKey, context.PartitionKey);
+            Assert.Equal(data.SequenceNumber, context.SequenceNumber);
+            Assert.True(data.SystemProperties.SequenceEqual(context.SystemProperties));
+        }
+
+        [Fact]
+        public void GetMessageContextViaProcessor_WithValidArguments_Succeeds()
+        {
+            // Arrange
+            var data = new EventData();
+            data.ContentType = BogusGenerator.Random.AlphaNumeric(10);
+            string eventHubsNamespace = BogusGenerator.Random.AlphaNumeric(20);
+            string eventHubsName = BogusGenerator.Random.AlphaNumeric(5);
+            string consumerGroup = BogusGenerator.Random.AlphaNumeric(10);
+
+            var processor = new EventProcessorClient(
+                Mock.Of<BlobContainerClient>(),
+                consumerGroup,
+                eventHubsNamespace,
+                eventHubsName,
+                new DefaultAzureCredential());
+
+            // Act
+            AzureEventHubsMessageContext context = data.GetMessageContext(processor);
+
+            // Assert
+            Assert.Equal(eventHubsNamespace, context.EventHubsNamespace);
+            Assert.Equal(eventHubsName, context.EventHubsName);
+            Assert.Equal(consumerGroup, context.ConsumerGroup);
+            Assert.Equal(data.ContentType, context.ContentType);
+            Assert.Equal(data.EnqueuedTime, context.EnqueueTime);
+            Assert.Equal(data.Offset, context.Offset);
+            Assert.Equal(data.PartitionKey, context.PartitionKey);
+            Assert.Equal(data.SequenceNumber, context.SequenceNumber);
+            Assert.True(data.SystemProperties.SequenceEqual(context.SystemProperties));
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/EventHubs/AzureEventHubsMessageRouterTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/EventHubs/AzureEventHubsMessageRouterTests.cs
@@ -41,7 +41,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.EventHubs
 
             var order = OrderGenerator.Generate();
             var eventData = new EventData(JsonConvert.SerializeObject(order));
-            var context = AzureEventHubsMessageContext.CreateFrom(eventData, "namespace", "consumer-group", "eventhubs name");
+            AzureEventHubsMessageContext context = eventData.GetMessageContext("namespace", "consumergroup", "name");
             var correlation = new MessageCorrelationInfo("operation-id", "transaction-id");
 
             await router.RouteMessageAsync(eventData, context, correlation, CancellationToken.None);
@@ -64,7 +64,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.EventHubs
 
             var order = OrderGenerator.Generate();
             var eventData = new EventData(JsonConvert.SerializeObject(order));
-            var context = AzureEventHubsMessageContext.CreateFrom(eventData, "namespace", "consumer-group", "eventhubs name");
+            AzureEventHubsMessageContext context = eventData.GetMessageContext("namespace", "consumergroup", "name");
             var correlation = new MessageCorrelationInfo("operation-id", "transaction-id");
 
             await Assert.ThrowsAsync<InvalidOperationException>(
@@ -91,7 +91,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.EventHubs
             var order = OrderGenerator.Generate();
             string json = JsonConvert.SerializeObject(order);
             var eventData = new EventData(json);
-            var context = AzureEventHubsMessageContext.CreateFrom(eventData, "namespace", "consumer-group", "eventhubs name");
+            AzureEventHubsMessageContext context = eventData.GetMessageContext("namespace", "consumergroup", "name");
             var correlation = new MessageCorrelationInfo("operation-id", "transaction-id");
 
             await router.RouteMessageAsync(json, context, correlation, CancellationToken.None);
@@ -115,7 +115,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.EventHubs
             var order = OrderGenerator.Generate();
             string json = JsonConvert.SerializeObject(order);
             var eventData = new EventData(json);
-            var context = AzureEventHubsMessageContext.CreateFrom(eventData, "namespace", "consumer-group", "eventhubs name");
+            AzureEventHubsMessageContext context = eventData.GetMessageContext("namespace", "consumergroup", "name");
             var correlation = new MessageCorrelationInfo("operation-id", "transaction-id");
 
             await Assert.ThrowsAsync<InvalidOperationException>(

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/EventHubs/Extensions/MessageContext.EventHubsMessageHandlerCollectionExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/EventHubs/Extensions/MessageContext.EventHubsMessageHandlerCollectionExtensionsTests.cs
@@ -25,7 +25,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.EventHubs.Extensions
             var collection = new EventHubsMessageHandlerCollection(new ServiceCollection());
             var order = OrderGenerator.Generate();
             var eventData = new EventData(JsonConvert.SerializeObject(order));
-            var expectedContext = AzureEventHubsMessageContext.CreateFrom(eventData, "namespace", "consumer-group", "eventhubs name");
+            AzureEventHubsMessageContext expectedContext = eventData.GetMessageContext("namespace", "consumergroup", "name");
             var expectedHandler = new TestEventHubsMessageHandler();
 
             // Act
@@ -67,7 +67,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.EventHubs.Extensions
             var collection = new EventHubsMessageHandlerCollection(new ServiceCollection());
             var order = OrderGenerator.Generate();
             var eventData = new EventData(JsonConvert.SerializeObject(order));
-            var expectedContext = AzureEventHubsMessageContext.CreateFrom(eventData, "namespace", "consumer-group", "eventhubs name");
+            AzureEventHubsMessageContext expectedContext = eventData.GetMessageContext("namespace", "consumergroup", "name");
             var expectedHandler = new TestEventHubsMessageHandler();
 
             // Act

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/EventHubs/Extensions/MessageContext.Message.EventHubsMessageHandlerCollectionExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/EventHubs/Extensions/MessageContext.Message.EventHubsMessageHandlerCollectionExtensionsTests.cs
@@ -26,7 +26,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.EventHubs.Extensions
             var collection = new EventHubsMessageHandlerCollection(new ServiceCollection());
             var expectedMessage = new TestMessage();
             var eventData = new EventData(JsonConvert.SerializeObject(expectedMessage));
-            var expectedContext = AzureEventHubsMessageContext.CreateFrom(eventData, "namespace", "consumer-group", "eventhubs name");
+            AzureEventHubsMessageContext expectedContext = eventData.GetMessageContext("namespace", "consumergroup", "name");
             var expectedHandler = new TestEventHubsMessageHandler();
 
             // Act
@@ -90,7 +90,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.EventHubs.Extensions
             var collection = new EventHubsMessageHandlerCollection(new ServiceCollection());
             var expectedMessage = new TestMessage();
             var eventData = new EventData(JsonConvert.SerializeObject(expectedMessage));
-            var expectedContext = AzureEventHubsMessageContext.CreateFrom(eventData, "namespace", "consumer-group", "eventhubs name");
+            AzureEventHubsMessageContext expectedContext = eventData.GetMessageContext("namespace", "consumergroup", "name");
             var expectedHandler = new TestEventHubsMessageHandler();
 
             // Act

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/EventHubs/Extensions/MessageContext.MessageSerializer.EventHubsMessageHandlerCollectionExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/EventHubs/Extensions/MessageContext.MessageSerializer.EventHubsMessageHandlerCollectionExtensionsTests.cs
@@ -26,7 +26,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.EventHubs.Extensions
             var expectedBody = $"test-message-body-{Guid.NewGuid()}";
             var expectedMessage = new TestMessage();
             var eventData = new EventData(JsonConvert.SerializeObject(expectedMessage));
-            var expectedContext = AzureEventHubsMessageContext.CreateFrom(eventData, "namespace", "consumer-group", "eventhubs name");
+            AzureEventHubsMessageContext expectedContext = eventData.GetMessageContext("namespace", "consumergroup", "name");
             var serializer = new TestMessageBodySerializer(expectedBody, expectedMessage);
 
             // Act
@@ -87,7 +87,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.EventHubs.Extensions
             var expectedBody = $"test-message-body-{Guid.NewGuid()}";
             var expectedMessage = new TestMessage();
             var eventData = new EventData(JsonConvert.SerializeObject(expectedMessage));
-            var expectedContext = AzureEventHubsMessageContext.CreateFrom(eventData, "namespace", "consumer-group", "eventhubs name");
+            AzureEventHubsMessageContext expectedContext = eventData.GetMessageContext("namespace", "consumergroup", "name");
             var serializer = new TestMessageBodySerializer(expectedBody, expectedMessage);
 
             // Act
@@ -148,7 +148,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.EventHubs.Extensions
             var expectedBody = $"test-message-body-{Guid.NewGuid()}";
             var expectedMessage = new TestMessage();
             var eventData = new EventData(JsonConvert.SerializeObject(expectedMessage));
-            var expectedContext = AzureEventHubsMessageContext.CreateFrom(eventData, "namespace", "consumer-group", "eventhubs name");
+            AzureEventHubsMessageContext expectedContext = eventData.GetMessageContext("namespace", "consumergroup", "name");
             var serializer = new TestMessageBodySerializer(expectedBody, expectedMessage);
             var expectedHandler = new TestEventHubsMessageHandler();
 
@@ -228,7 +228,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.EventHubs.Extensions
             var expectedBody = $"test-message-body-{Guid.NewGuid()}";
             var expectedMessage = new TestMessage();
             var eventData = new EventData(JsonConvert.SerializeObject(expectedMessage));
-            var expectedContext = AzureEventHubsMessageContext.CreateFrom(eventData, "namespace", "consumer-group", "eventhubs name");
+            AzureEventHubsMessageContext expectedContext = eventData.GetMessageContext("namespace", "consumergroup", "name");
             var serializer = new TestMessageBodySerializer(expectedBody, expectedMessage);
             var expectedHandler = new TestEventHubsMessageHandler();
 

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/EventHubs/Extensions/MessageContext.MessageSerializer.Message.EventHubsMessageHandlerCollectionExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/EventHubs/Extensions/MessageContext.MessageSerializer.Message.EventHubsMessageHandlerCollectionExtensionsTests.cs
@@ -29,7 +29,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.EventHubs.Extensions
             var expectedBody = $"test-message-body-{Guid.NewGuid()}";
             var expectedMessage = new TestMessage();
             var eventData = new EventData(JsonConvert.SerializeObject(expectedMessage));
-            var expectedContext = AzureEventHubsMessageContext.CreateFrom(eventData, "namespace", "consumer-group", "eventhubs name");
+            AzureEventHubsMessageContext expectedContext = eventData.GetMessageContext("namespace", "consumergroup", "name");
             var serializer = new TestMessageBodySerializer(expectedBody, expectedMessage);
 
             // Act
@@ -113,7 +113,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.EventHubs.Extensions
             var expectedBody = $"test-message-body-{Guid.NewGuid()}";
             var expectedMessage = new TestMessage();
             var eventData = new EventData(JsonConvert.SerializeObject(expectedMessage));
-            var expectedContext = AzureEventHubsMessageContext.CreateFrom(eventData, "namespace", "consumer-group", "eventhubs name");
+            AzureEventHubsMessageContext expectedContext = eventData.GetMessageContext("namespace", "consumergroup", "name");
             var serializer = new TestMessageBodySerializer(expectedBody, expectedMessage);
 
             // Act
@@ -199,7 +199,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.EventHubs.Extensions
             var expectedBody = $"test-message-body-{Guid.NewGuid()}";
             var expectedMessage = new TestMessage();
             var eventData = new EventData(JsonConvert.SerializeObject(expectedMessage));
-            var expectedContext = AzureEventHubsMessageContext.CreateFrom(eventData, "namespace", "consumer-group", "eventhubs name");
+            AzureEventHubsMessageContext expectedContext = eventData.GetMessageContext("namespace", "consumergroup", "name");
             var serializer = new TestMessageBodySerializer(expectedBody, expectedMessage);
             var expectedHandler = new TestEventHubsMessageHandler();
 
@@ -306,7 +306,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.EventHubs.Extensions
             var expectedBody = $"test-message-body-{Guid.NewGuid()}";
             var expectedMessage = new TestMessage();
             var eventData = new EventData(JsonConvert.SerializeObject(expectedMessage));
-            var expectedContext = AzureEventHubsMessageContext.CreateFrom(eventData, "namespace", "consumer-group", "eventhubs name");
+            AzureEventHubsMessageContext expectedContext = eventData.GetMessageContext("namespace", "consumergroup", "name");
             var serializer = new TestMessageBodySerializer(expectedBody, expectedMessage);
             var expectedHandler = new TestEventHubsMessageHandler();
 


### PR DESCRIPTION
Add extension on the `EventData` type to more easily retrieve the message context in EventHubs message handling scenarios.

Closes #345