### PR TITLE
chore: remove deprecated pr config

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,3 +1,0 @@
-# Configuration for Semantic Pull Requests PR validation, see https://github.com/zeke/semantic-pull-requests#configuration for full reference
-# Always validate the PR title, and ignore the commits
-titleOnly: true


### PR DESCRIPTION
We use a different way of PR validation. This file is still for the old deprecated GitHub action.