### PR TITLE
feat: add servicebus client secretstore extension overload

### DIFF
--- a/docs/preview/02-Features/04-service-bus-extensions.md
+++ b/docs/preview/02-Features/04-service-bus-extensions.md
@@ -15,7 +15,7 @@ This features requires to install our NuGet package:
 PM > Install-Package Arcus.Messaging.ServiceBus.Core
 ```
 
-## Using Arcus secret store when Service Bus client
+## Using Arcus secret store when registering the Service Bus client
 
 When registering a `ServiceBusClient` via [Azure's client registration process](https://learn.microsoft.com/en-us/dotnet/api/overview/azure/messaging.servicebus-readme), the library provides an extension to pass-in a secret name instead of directly passing the Azure Service Bus connection string.
 This secret name will correspond with a registered secret in the [Arcus secret store](https://security.arcus-azure.net/features/secret-store) that holds the Azure Service Bus connection string.

--- a/docs/preview/02-Features/04-service-bus-extensions.md
+++ b/docs/preview/02-Features/04-service-bus-extensions.md
@@ -15,6 +15,32 @@ This features requires to install our NuGet package:
 PM > Install-Package Arcus.Messaging.ServiceBus.Core
 ```
 
+## Using Arcus secret store when Service Bus client
+
+When registering a `ServiceBusClient` via [Azure's client registration process](https://learn.microsoft.com/en-us/dotnet/api/overview/azure/messaging.servicebus-readme), the library provides an extension to pass-in a secret name instead of directly passing the Azure Service Bus connection string.
+This secret name will correspond with a registered secret in the [Arcus secret store](https://security.arcus-azure.net/features/secret-store) that holds the Azure Service Bus connection string.
+
+Following example shows how the secret name is passed to this extension overload:
+
+```csharp
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.DependencyInjection;
+
+public class Program
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        // Adding Arcus secret store, more info: https://security.arcus-azure.net/features/secret-store
+        services.AddSecretStore(stores => stores.AddAzureKeyVaultWithManagedIdentity("https://my.vault.azure.net");
+
+        // Adding Service Bus client with secret in Arcus secret store.
+        services.AddAzureClients(clients => clients.AddServiceBusClient(connectionStringSecretName: "<your-secret-name>"));
+    }
+}
+```
+
+🥇 Adding your Azure Service Bus client this way helps separating application configuration from sensitive secrets. For more information on the added-values of the Arcus secret store, see [our dedicated documentation page](https://security.arcus-azure.net/features/secret-store).
+
 ## Automatic tracking and Hierarchical correlating of Service Bus messages
 
 The Arcus message pump/router automatically makes sure that received Azure Service Bus messages are tracked as request telemetry in Application Insights. 

--- a/src/Arcus.Messaging.ServiceBus.Core/Arcus.Messaging.ServiceBus.Core.csproj
+++ b/src/Arcus.Messaging.ServiceBus.Core/Arcus.Messaging.ServiceBus.Core.csproj
@@ -26,11 +26,13 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Arcus.Security.Core" Version="[1.7.0,2.0.0)" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.2.0" />
     <PackageReference Include="Guard.NET" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
+    <PackageReference Include="Arcus.Security.Core" Version="[1.5.0,2.0.0)" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.0.0" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
   </ItemGroup>

--- a/src/Arcus.Messaging.ServiceBus.Core/Extensions/AzureClientFactoryBuilderExtensions.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/Extensions/AzureClientFactoryBuilderExtensions.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Extensions.Azure
         /// <param name="connectionStringSecretName">The secret name that corresponds with the Azure Service Bus connection string that is registered in the Arcus secret store.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionStringSecretName"/> is blank.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the Arcus secret store is not registered.</exception>
         public static IAzureClientBuilder<ServiceBusClient, ServiceBusClientOptions> AddServiceBusClient(
             this AzureClientFactoryBuilder builder,
             string connectionStringSecretName)
@@ -49,6 +50,7 @@ namespace Microsoft.Extensions.Azure
         /// <param name="configureOptions">The function to configure additional user option that alters the behavior of the Azure Service Bus interaction.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionStringSecretName"/> is blank.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the Arcus secret store is not registered.</exception>
         public static IAzureClientBuilder<ServiceBusClient, ServiceBusClientOptions> AddServiceBusClient(
             this AzureClientFactoryBuilder builder,
             string connectionStringSecretName,

--- a/src/Arcus.Messaging.ServiceBus.Core/Extensions/AzureClientFactoryBuilderExtensions.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/Extensions/AzureClientFactoryBuilderExtensions.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using Arcus.Security.Core;
+using Azure.Core.Extensions;
+using Azure.Messaging.ServiceBus;
+using GuardNet;
+using Microsoft.Extensions.DependencyInjection;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.Azure
+{
+    /// <summary>
+    /// Extensions on the <see cref="IAzureClientFactoryBuilder"/> to add more easily Azure Service Bus clients with Arcus components.
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    public static class AzureClientFactoryBuilderExtensions
+    {
+        /// <summary>
+        /// Registers a <see cref="ServiceBusClient" /> instance into the Azure client factory <paramref name="builder"/>
+        /// via a connection string available via the <paramref name="connectionStringSecretName"/> in the Arcus secret store.
+        /// </summary>
+        /// <remarks>
+        ///     Make sure that the Arcus secret store is registered in the application before using this extension (<a href="https://security.arcus-azure.net/features/secret-store">more info</a>)
+        ///     as the Azure Service Bus connection string will be retrieved via the <paramref name="connectionStringSecretName"/>.
+        /// </remarks>
+        /// <param name="builder">The Azure client factory builder to add the Azure Service Bus client.</param>
+        /// <param name="connectionStringSecretName">The secret name that corresponds with the Azure Service Bus connection string that is registered in the Arcus secret store.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionStringSecretName"/> is blank.</exception>
+        public static IAzureClientBuilder<ServiceBusClient, ServiceBusClientOptions> AddServiceBusClient(
+            this AzureClientFactoryBuilder builder,
+            string connectionStringSecretName)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires an Azure client factory builder to add the Azure Service Bus client");
+            Guard.NotNullOrWhitespace(connectionStringSecretName, nameof(connectionStringSecretName), "Requires a non-blank secret name to retrieve the Azure Service Bus connection string from the Arcus secret store");
+
+            return AddServiceBusClient(builder, connectionStringSecretName: connectionStringSecretName, configureOptions: null);
+        }
+
+        /// <summary>
+        /// Registers a <see cref="ServiceBusClient" /> instance into the Azure client factory <paramref name="builder"/>
+        /// via a connection string available via the <paramref name="connectionStringSecretName"/> in the Arcus secret store.
+        /// </summary>
+        /// <remarks>
+        ///     Make sure that the Arcus secret store is registered in the application before using this extension (<a href="https://security.arcus-azure.net/features/secret-store">more info</a>)
+        ///     as the Azure Service Bus connection string will be retrieved via the <paramref name="connectionStringSecretName"/>.
+        /// </remarks>
+        /// <param name="builder">The Azure client factory builder to add the Azure Service Bus client.</param>
+        /// <param name="connectionStringSecretName">The secret name that corresponds with the Azure Service Bus connection string that is registered in the Arcus secret store.</param>
+        /// <param name="configureOptions">The function to configure additional user option that alters the behavior of the Azure Service Bus interaction.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionStringSecretName"/> is blank.</exception>
+        public static IAzureClientBuilder<ServiceBusClient, ServiceBusClientOptions> AddServiceBusClient(
+            this AzureClientFactoryBuilder builder,
+            string connectionStringSecretName,
+            Action<ServiceBusClientOptions> configureOptions)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires an Azure client factory builder to add the Azure Service Bus client");
+            Guard.NotNullOrWhitespace(connectionStringSecretName, nameof(connectionStringSecretName), "Requires a non-blank secret name to retrieve the Azure Service Bus connection string from the Arcus secret store");
+            
+            return builder.AddClient<ServiceBusClient, ServiceBusClientOptions>((options, serviceProvider) =>
+            {
+                var secretProvider = serviceProvider.GetService<ISecretProvider>();
+                if (secretProvider is null)
+                {
+                    throw new InvalidOperationException(
+                        "Requires an Arcus secret store registration to retrieve the connection string to authenticate with Azure Service Bus while creating an Service Bus client instance," 
+                        + "please use the 'services.AddSecretStore(...)' or 'host.ConfigureSecretStore(...)' (https://security.arcus-azure.net/features/secret-store)");
+                }
+
+                string connectionString = secretProvider.GetRawSecretAsync(connectionStringSecretName).GetAwaiter().GetResult();
+                configureOptions?.Invoke(options);
+
+                return new ServiceBusClient(connectionString, options);
+            });
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/ServiceBus/AzureClientFactoryBuilderExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/ServiceBus/AzureClientFactoryBuilderExtensionsTests.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Arcus.Messaging.Tests.Core.Generators;
+using Arcus.Messaging.Tests.Core.Messages.v1;
+using Arcus.Messaging.Tests.Integration.Fixture;
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Polly;
+using Polly.Wrap;
+using Xunit;
+
+namespace Arcus.Messaging.Tests.Integration.ServiceBus
+{
+    public class AzureClientFactoryBuilderExtensionsTests
+    {
+        private readonly TestConfig _config;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureClientFactoryBuilderExtensionsTests" /> class.
+        /// </summary>
+        public AzureClientFactoryBuilderExtensionsTests()
+        {
+            _config = TestConfig.Create();
+        }
+
+        [Fact]
+        public async Task AddServiceBusClient_SendsMessage_Succeeds()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var connectionStringSecretName = "MyConnectionString";
+            string connectionString = _config.GetServiceBusQueueConnectionString();
+            var connectionStringProperties = ServiceBusConnectionStringProperties.Parse(connectionString);
+            services.AddSecretStore(stores => stores.AddInMemory(connectionStringSecretName, connectionString));
+            
+            // Act
+            services.AddAzureClients(clients => clients.AddServiceBusClient(connectionStringSecretName));
+            
+            // Assert
+            IServiceProvider provider = services.BuildServiceProvider();
+            var factory = provider.GetRequiredService<IAzureClientFactory<ServiceBusClient>>();
+            await using (ServiceBusClient client = factory.CreateClient("Default"))
+            await using (ServiceBusSender sender = client.CreateSender(connectionStringProperties.EntityPath))
+            {
+                var order = OrderGenerator.Generate();
+                var message = new ServiceBusMessage(BinaryData.FromObjectAsJson(order));
+                await sender.SendMessageAsync(message);
+
+                await RetryAssertUntilServiceBusMessageIsAvailableAsync(client, connectionStringProperties.EntityPath, msg =>
+                {
+                    var actual = msg.Body.ToObjectFromJson<Order>();
+                    Assert.Equal(order.Id, actual.Id);
+                });
+            }
+        }
+
+        private static async Task RetryAssertUntilServiceBusMessageIsAvailableAsync(ServiceBusClient client, string entityPath, Action<ServiceBusReceivedMessage> assertion)
+        {
+            AsyncPolicyWrap policy =
+                Policy.TimeoutAsync(TimeSpan.FromSeconds(30))
+                      .WrapAsync(Policy.Handle<Exception>()
+                                       .WaitAndRetryForeverAsync(index => TimeSpan.FromMilliseconds(500)));
+
+            await using (ServiceBusReceiver receiver = client.CreateReceiver(entityPath))
+            {
+                await policy.ExecuteAsync(async () =>
+                {
+                    IAsyncEnumerable<ServiceBusReceivedMessage> messages = receiver.ReceiveMessagesAsync();
+                    var exceptions = new Collection<Exception>();
+
+                    await foreach (ServiceBusReceivedMessage message in messages)
+                    {
+                        try
+                        {
+                            assertion(message);
+                            await receiver.CompleteMessageAsync(message);
+                            
+                            return;
+                        }
+                        catch (Exception exception)
+                        {
+                            exceptions.Add(exception);
+                        }
+                    }
+
+                    throw exceptions.Count == 1 ? exceptions[0] : new AggregateException(exceptions);
+                });
+            }
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Unit/ServiceBus/AzureClientFactoryBuilderExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/ServiceBus/AzureClientFactoryBuilderExtensionsTests.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Arcus.Messaging.Tests.Unit.ServiceBus
+{
+    public class AzureClientFactoryBuilderExtensionsTests
+    {
+        private const string ExampleServiceBusConnectionString = "Endpoint=sb://arcus-testing-messaging.servicebus.windows.net/;SharedAccessKeyName=KeyName;SharedAccessKey=123";
+
+        [Fact]
+        public void AddServiceBusClient_WithConnectionStringSecretInSecretStore_Succeeds()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var secretName = "MyConnectionString";
+            services.AddSecretStore(stores => stores.AddInMemory(secretName, ExampleServiceBusConnectionString));
+
+            // Act
+            services.AddAzureClients(clients => clients.AddServiceBusClient(secretName));
+
+            // Assert
+            IServiceProvider provider = services.BuildServiceProvider();
+            var client = provider.GetRequiredService<IAzureClientFactory<ServiceBusClient>>();
+            Assert.NotNull(client.CreateClient("Default"));
+        }
+
+        [Fact]
+        public void AddServiceBusClient_WithConnectionStringSecretInSecretStoreWithOptions_Succeeds()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var secretName = "MyConnectionString";
+            services.AddSecretStore(stores => stores.AddInMemory(secretName, ExampleServiceBusConnectionString));
+
+            // Act
+            services.AddAzureClients(clients => clients.AddServiceBusClient(secretName, configureOptions: options => { }));
+
+            // Assert
+            IServiceProvider provider = services.BuildServiceProvider();
+            var client = provider.GetRequiredService<IAzureClientFactory<ServiceBusClient>>();
+            Assert.NotNull(client.CreateClient("Default"));
+        }
+
+        [Fact]
+        public void AddServiceBusClient_WithoutSecretStore_Fails()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var secretName = "MyConnectionString";
+
+            // Act
+            services.AddAzureClients(clients => clients.AddServiceBusClient(secretName));
+
+            // Assert
+            IServiceProvider provider = services.BuildServiceProvider();
+            var client = provider.GetRequiredService<IAzureClientFactory<ServiceBusClient>>();
+            Assert.Throws<InvalidOperationException>(() => client.CreateClient("Default"));
+        }
+
+        [Fact]
+        public void AddServiceBusClient_WithoutSecretStoreWithOptions_Fails()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var secretName = "MyConnectionString";
+
+            // Act
+            services.AddAzureClients(clients => clients.AddServiceBusClient(secretName, configureOptions: options => { }));
+
+            // Assert
+            IServiceProvider provider = services.BuildServiceProvider();
+            var client = provider.GetRequiredService<IAzureClientFactory<ServiceBusClient>>();
+            Assert.Throws<InvalidOperationException>(() => client.CreateClient("Default"));
+        }
+
+        [Fact]
+        public void AddServiceBusClient_WithoutConnectionStringSecret_Fails()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => services.AddAzureClients(clients => clients.AddServiceBusClient(connectionStringSecretName: null)));
+        }
+
+        [Fact]
+        public void AddServiceBusClient_WithoutConnectionStringSecretWithOptions_Fails()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => services.AddAzureClients(clients => clients.AddServiceBusClient(connectionStringSecretName: null, configureOptions: options => { })));
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Unit/ServiceBus/ServiceBusSenderExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/ServiceBus/ServiceBusSenderExtensionsTests.cs
@@ -360,7 +360,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var expectedOrders = BogusGenerator.Make(5, () => OrderGenerator.Generate());
             var messages = expectedOrders.Select(order => ServiceBusMessageBuilder.CreateForBody(order).Build());
             string key1 = BogusGenerator.Lorem.Word(), value1 = BogusGenerator.Lorem.Word();
-            string key2 = BogusGenerator.Lorem.Word(), value2 = BogusGenerator.Lorem.Word();
+            string key2 = BogusGenerator.Lorem.Word(), value2 = BogusGenerator.Lorem.Letter();
 
             MessageCorrelationInfo correlation = GenerateMessageCorrelationInfo();
             var logger = new InMemoryLogger();


### PR DESCRIPTION
Add extension overload to register a `ServiceBusClient` via a secret name corresponding with the Azure Service Bus connection string that is registered in the Arcus secret store.

Closes #358