### PR TITLE
feat: add eventhubs producer client secretstore extension overload

### DIFF
--- a/src/Arcus.Messaging.EventHubs.Core/Arcus.Messaging.EventHubs.Core.csproj
+++ b/src/Arcus.Messaging.EventHubs.Core/Arcus.Messaging.EventHubs.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.1;netcoreapp3.1</TargetFrameworks>
@@ -26,7 +26,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Arcus.Security.Core" Version="[1.7.0,2.0.0)" />
     <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.7.1" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Messaging.EventHubs.Core/Extensions/AzureClientFactoryBuilderExtensions.cs
+++ b/src/Arcus.Messaging.EventHubs.Core/Extensions/AzureClientFactoryBuilderExtensions.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using Arcus.Security.Core;
+using Azure.Core.Extensions;
+using Azure.Messaging.EventHubs.Producer;
+using GuardNet;
+using Microsoft.Extensions.DependencyInjection;
+
+// ReSharper disable once CheckNamespace
+namespace  Microsoft.Extensions.Azure
+{
+    /// <summary>
+    /// Extensions on the <see cref="IAzureClientFactoryBuilder"/> to add more easily Azure EventHubs producer clients with Arcus components.
+    /// </summary>
+    public static class AzureClientFactoryBuilderExtensions
+    {
+        /// <summary>
+        /// Registers a <see cref="EventHubProducerClient" /> instance into the Azure client factory <paramref name="builder"/>
+        /// via a connection string available via the <paramref name="connectionStringSecretName"/> in the Arcus secret store.
+        /// </summary>
+        /// <remarks>
+        ///   <para>
+        ///     Make sure that the Arcus secret store is registered in the application before using this extension (<a href="https://security.arcus-azure.net/features/secret-store">more info</a>)
+        ///     as the Azure EventHubs connection string will be retrieved via the <paramref name="connectionStringSecretName"/>.
+        ///   </para>
+        ///   <para>
+        ///     If the connection string is copied from the Event Hubs namespace, it will likely not contain the name of the desired Event Hub, which is needed.
+        ///     In this case, the name can be added manually by adding ";EntityPath=[[ EVENT HUB NAME ]]" to the end of the connection string. For example, ";EntityPath=telemetry-hub".
+        ///     If you have defined a shared access policy directly on the Event Hub itself, then copying the connection string from that Event Hub will result in a connection string that contains the name.
+        ///     <a href="https://docs.microsoft.com/azure/event-hubs/event-hubs-get-connection-string">How to get an Event Hubs connection string</a>
+        ///   </para>
+        /// </remarks>
+        /// <param name="builder">The Azure client factory builder to add the Azure EventHubs producer client.</param>
+        /// <param name="connectionStringSecretName">The secret name that corresponds with the Azure EventHubs connection string that is registered in the Arcus secret store.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionStringSecretName"/> is blank.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the Arcus secret store is not registered.</exception>
+        public static IAzureClientBuilder<EventHubProducerClient, EventHubProducerClientOptions> AddEventHubProducerClient(
+            this AzureClientFactoryBuilder builder,
+            string connectionStringSecretName)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires an Azure client factory builder to add the Azure EventHubs producer client");
+            Guard.NotNullOrWhitespace(connectionStringSecretName, nameof(connectionStringSecretName), "Requires a non-blank secret name to retrieve the Azure EventHubs connection string from the Arcus secret store");
+
+            return AddEventHubProducerClient(builder, connectionStringSecretName: connectionStringSecretName, configureOptions: null);
+        }
+
+        /// <summary>
+        /// Registers a <see cref="EventHubProducerClient" /> instance into the Azure client factory <paramref name="builder"/>
+        /// via a connection string available via the <paramref name="connectionStringSecretName"/> in the Arcus secret store.
+        /// </summary>
+        /// <remarks>
+        ///   <para>
+        ///     Make sure that the Arcus secret store is registered in the application before using this extension (<a href="https://security.arcus-azure.net/features/secret-store">more info</a>)
+        ///     as the Azure EventHubs connection string will be retrieved via the <paramref name="connectionStringSecretName"/>.
+        ///   </para>
+        ///   <para>
+        ///     If the connection string is copied from the Event Hubs namespace, it will likely not contain the name of the desired Event Hub, which is needed.
+        ///     In this case, the name can be added manually by adding ";EntityPath=[[ EVENT HUB NAME ]]" to the end of the connection string. For example, ";EntityPath=telemetry-hub".
+        ///     If you have defined a shared access policy directly on the Event Hub itself, then copying the connection string from that Event Hub will result in a connection string that contains the name.
+        ///     <a href="https://docs.microsoft.com/azure/event-hubs/event-hubs-get-connection-string">How to get an Event Hubs connection string</a>
+        ///   </para>
+        /// </remarks>
+        /// <param name="builder">The Azure client factory builder to add the Azure EventHubs producer client.</param>
+        /// <param name="connectionStringSecretName">The secret name that corresponds with the Azure EventHubs connection string that is registered in the Arcus secret store.</param>
+        /// <param name="configureOptions">The function to configure additional user option that alters the behavior of the Azure EventHubs interaction.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionStringSecretName"/> is blank.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the Arcus secret store is not registered.</exception>
+        public static IAzureClientBuilder<EventHubProducerClient, EventHubProducerClientOptions> AddEventHubProducerClient(
+            this AzureClientFactoryBuilder builder,
+            string connectionStringSecretName,
+            Action<EventHubProducerClientOptions> configureOptions)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires an Azure client factory builder to add the Azure EventHubs producer client");
+            Guard.NotNullOrWhitespace(connectionStringSecretName, nameof(connectionStringSecretName), "Requires a non-blank secret name to retrieve the Azure EventHubs connection string from the Arcus secret store");
+
+            return builder.AddClient<EventHubProducerClient, EventHubProducerClientOptions>((options, serviceProvider) =>
+            {
+                string connectionString = GetEventHubsConnectionString(connectionStringSecretName, serviceProvider);
+                configureOptions?.Invoke(options);
+
+                return new EventHubProducerClient(connectionString, options);
+            });
+        }
+
+         /// <summary>
+        /// Registers a <see cref="EventHubProducerClient" /> instance into the Azure client factory <paramref name="builder"/>
+        /// via a connection string available via the <paramref name="connectionStringSecretName"/> in the Arcus secret store.
+        /// </summary>
+        /// <remarks>
+        ///   <para>
+        ///     Make sure that the Arcus secret store is registered in the application before using this extension (<a href="https://security.arcus-azure.net/features/secret-store">more info</a>)
+        ///     as the Azure EventHubs connection string will be retrieved via the <paramref name="connectionStringSecretName"/>.
+        ///   </para>
+        ///   <para>
+        ///     If the connection string is copied from the Event Hub itself, it will contain the name of the desired Event Hub,
+        ///     and can be used directly without passing the <paramref name="eventHubName" />.
+        ///     The name of the Event Hub should be passed only once, either as part of the connection string or separately.
+        ///     <a href="https://docs.microsoft.com/azure/event-hubs/event-hubs-get-connection-string">How to get an Event Hubs connection string</a>.
+        ///   </para>
+        /// </remarks>
+        /// <param name="builder">The Azure client factory builder to add the Azure EventHubs producer client.</param>
+        /// <param name="connectionStringSecretName">The secret name that corresponds with the Azure EventHubs connection string that is registered in the Arcus secret store.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub to associate the producer with.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionStringSecretName"/> is blank.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the Arcus secret store is not registered.</exception>
+        public static IAzureClientBuilder<EventHubProducerClient, EventHubProducerClientOptions> AddEventHubProducerClient(
+            this AzureClientFactoryBuilder builder,
+            string connectionStringSecretName,
+            string eventHubName)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires an Azure client factory builder to add the Azure EventHubs producer client");
+            Guard.NotNullOrWhitespace(connectionStringSecretName, nameof(connectionStringSecretName), "Requires a non-blank secret name to retrieve the Azure EventHubs connection string from the Arcus secret store");
+            Guard.NotNullOrWhitespace(eventHubName, nameof(eventHubName), "Requires a non-blank Azure EventHubs name to register the Azure EventHubs producer client");
+
+            return AddEventHubProducerClient(builder, connectionStringSecretName: connectionStringSecretName, eventHubName, configureOptions: null);
+        }
+
+        /// <summary>
+        /// Registers a <see cref="EventHubProducerClient" /> instance into the Azure client factory <paramref name="builder"/>
+        /// via a connection string available via the <paramref name="connectionStringSecretName"/> in the Arcus secret store.
+        /// </summary>
+        /// <remarks>
+        ///   <para>
+        ///     Make sure that the Arcus secret store is registered in the application before using this extension (<a href="https://security.arcus-azure.net/features/secret-store">more info</a>)
+        ///     as the Azure EventHubs connection string will be retrieved via the <paramref name="connectionStringSecretName"/>.
+        ///   </para>
+        ///   <para>
+        ///     If the connection string is copied from the Event Hub itself, it will contain the name of the desired Event Hub,
+        ///     and can be used directly without passing the <paramref name="eventHubName" />.
+        ///     The name of the Event Hub should be passed only once, either as part of the connection string or separately.
+        ///     <a href="https://docs.microsoft.com/azure/event-hubs/event-hubs-get-connection-string">How to get an Event Hubs connection string</a>.
+        ///   </para>
+        /// </remarks>
+        /// <param name="builder">The Azure client factory builder to add the Azure EventHubs producer client.</param>
+        /// <param name="connectionStringSecretName">The secret name that corresponds with the Azure EventHubs connection string that is registered in the Arcus secret store.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub to associate the producer with.</param>
+        /// <param name="configureOptions">The function to configure additional user option that alters the behavior of the Azure EventHubs interaction.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionStringSecretName"/> is blank.</exception>
+        /// <exception cref="InvalidOperationException">Thrown when the Arcus secret store is not registered.</exception>
+        public static IAzureClientBuilder<EventHubProducerClient, EventHubProducerClientOptions> AddEventHubProducerClient(
+            this AzureClientFactoryBuilder builder,
+            string connectionStringSecretName,
+            string eventHubName,
+            Action<EventHubProducerClientOptions> configureOptions)
+        {
+            Guard.NotNull(builder, nameof(builder), "Requires an Azure client factory builder to add the Azure EventHubs producer client");
+            Guard.NotNullOrWhitespace(connectionStringSecretName, nameof(connectionStringSecretName), "Requires a non-blank secret name to retrieve the Azure EventHubs connection string from the Arcus secret store");
+            Guard.NotNullOrWhitespace(eventHubName, nameof(eventHubName), "Requires a non-blank Azure EventHubs name to register the Azure EventHubs producer client");
+
+            return builder.AddClient<EventHubProducerClient, EventHubProducerClientOptions>((options, serviceProvider) =>
+            {
+                string connectionString = GetEventHubsConnectionString(connectionStringSecretName, serviceProvider);
+                configureOptions?.Invoke(options);
+
+                return new EventHubProducerClient(connectionString, eventHubName, options);
+            });
+        }
+
+        private static string GetEventHubsConnectionString(string connectionStringSecretName, IServiceProvider serviceProvider)
+        {
+            var secretProvider = serviceProvider.GetService<ISecretProvider>();
+            if (secretProvider is null)
+            {
+                throw new InvalidOperationException(
+                    "Requires an Arcus secret store registration to retrieve the connection string to authenticate with Azure EventHubs while creating an EventHubs producer client instance,"
+                    + "please use the 'services.AddSecretStore(...)' or 'host.ConfigureSecretStore(...)' (https://security.arcus-azure.net/features/secret-store)");
+            }
+
+            string connectionString = secretProvider.GetRawSecretAsync(connectionStringSecretName).GetAwaiter().GetResult();
+            return connectionString;
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Core/Generators/SensorReadingGenerator.cs
+++ b/src/Arcus.Messaging.Tests.Core/Generators/SensorReadingGenerator.cs
@@ -1,0 +1,18 @@
+﻿using Arcus.Messaging.Tests.Core.Messages.v1;
+using Bogus;
+
+namespace Arcus.Messaging.Tests.Core.Generators
+{
+    public static class SensorReadingGenerator
+    {
+        public static SensorReading Generate()
+        {
+            return new Faker<SensorReading>()
+                .RuleFor(r => r.SensorId, f => f.Random.Guid().ToString())
+                .RuleFor(r => r.SensorValue, f => f.Random.Double())
+                .RuleFor(r => r.SensorStatus, f => f.PickRandom<SensorStatus>())
+                .RuleFor(r => r.Timestamp, f => f.Date.RecentOffset())
+                .Generate();
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Core/Messages/v1/SensorReading.cs
+++ b/src/Arcus.Messaging.Tests.Core/Messages/v1/SensorReading.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Arcus.Messaging.Tests.Core.Messages.v1
+{
+    public class SensorReading
+    {
+        public string SensorId { get; set; }
+        public double SensorValue { get; set; }
+        public SensorStatus SensorStatus { get; set; }
+        public DateTimeOffset Timestamp { get; set; }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Core/Messages/v1/SensorStatus.cs
+++ b/src/Arcus.Messaging.Tests.Core/Messages/v1/SensorStatus.cs
@@ -1,0 +1,4 @@
+﻿namespace Arcus.Messaging.Tests.Core.Messages.v1
+{
+    public enum SensorStatus { Idle, Active }
+}

--- a/src/Arcus.Messaging.Tests.Integration/EventHubs/AzureClientFactoryBuilderExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/EventHubs/AzureClientFactoryBuilderExtensionsTests.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Arcus.Messaging.Tests.Core.Generators;
+using Arcus.Messaging.Tests.Core.Messages.v1;
+using Arcus.Messaging.Tests.Integration.Fixture;
+using Arcus.Messaging.Tests.Integration.MessagePump.EventHubs;
+using Arcus.Testing.Logging;
+using Azure.Messaging.EventHubs;
+using Azure.Messaging.EventHubs.Producer;
+using Azure.Storage.Blobs;
+using Microsoft.Azure.Management.ServiceBus.Models;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Polly;
+using Polly.Wrap;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Arcus.Messaging.Tests.Integration.EventHubs
+{
+    public class AzureClientFactoryBuilderExtensionsTests : IAsyncLifetime
+    {
+        private readonly TestConfig _config;
+        private readonly EventHubsConfig _eventHubsConfig;
+        private readonly ILogger _logger;
+
+        private TemporaryBlobStorageContainer _blobStorageContainer;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureClientFactoryBuilderExtensionsTests" /> class.
+        /// </summary>
+        public AzureClientFactoryBuilderExtensionsTests(ITestOutputHelper outputWriter)
+        {
+            _config = TestConfig.Create();
+            _logger = new XunitTestLogger(outputWriter);
+            _eventHubsConfig = _config.GetEventHubsConfig();
+        }
+
+        private string EventHubsName => _eventHubsConfig.GetEventHubsName(IntegrationTestType.SelfContained);
+
+        [Fact]
+        public async Task AddEventHubProducerClientWithNamespace_SendEvent_Succeeds()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var connectionStringSecretName = "MyConnectionString";
+            EventHubsConfig eventHubsConfig = _config.GetEventHubsConfig();
+            services.AddSecretStore(stores => stores.AddInMemory(connectionStringSecretName, eventHubsConfig.EventHubsConnectionString));
+
+            // Act
+            services.AddAzureClients(clients => clients.AddEventHubProducerClient(connectionStringSecretName, EventHubsName));
+
+            // Assert
+            IServiceProvider provider = services.BuildServiceProvider();
+            var factory = provider.GetRequiredService<IAzureClientFactory<EventHubProducerClient>>();
+            await using (EventHubProducerClient client = factory.CreateClient("Default"))
+            {
+                SensorReading reading = SensorReadingGenerator.Generate();
+                var eventData = new EventData(BinaryData.FromObjectAsJson(reading));
+
+                await client.SendAsync(new[] { eventData });
+                await RetryAssertUntilServiceBusMessageIsAvailableAsync(received =>
+                {
+                    var actual = received.EventBody.ToObjectFromJson<SensorReading>();
+                    Assert.Equal(reading.SensorId, actual.SensorId);
+                });
+            }
+        }
+
+        private async Task RetryAssertUntilServiceBusMessageIsAvailableAsync(Action<EventData> assertion)
+        {
+            PolicyWrap policy = CreateRetryPolicy();
+            EventProcessorClient eventProcessor = CreateEventProcessorClient();
+
+            var isProcessed = false;
+            var exceptions = new Collection<Exception>();
+            eventProcessor.ProcessErrorAsync += args =>
+            {
+                exceptions.Add(args.Exception);
+                return Task.CompletedTask;
+            };
+            eventProcessor.ProcessEventAsync += async args =>
+            {
+                try
+                {
+                    assertion(args.Data);
+                    isProcessed = true;
+                    await args.UpdateCheckpointAsync();
+                }
+                catch (Exception exception)
+                {
+                    exceptions.Add(exception);
+                }
+            };
+            await eventProcessor.StartProcessingAsync();
+
+            try
+            { 
+                policy.Execute(() =>
+                {
+                    if (!isProcessed)
+                    {
+                        if (exceptions.Count == 1)
+                        {
+                            throw exceptions[0];
+                        }
+                
+                        throw new AggregateException(exceptions);
+                    }
+                });
+            }
+            finally
+            {
+                await eventProcessor.StopProcessingAsync();
+            }
+        }
+
+        private EventProcessorClient CreateEventProcessorClient()
+        {
+            var storageClient = new BlobContainerClient(_eventHubsConfig.StorageConnectionString, _blobStorageContainer.ContainerName);
+            var eventProcessor = new EventProcessorClient(storageClient, "$Default", _eventHubsConfig.EventHubsConnectionString, EventHubsName);
+            
+            return eventProcessor;
+        }
+
+        private static PolicyWrap CreateRetryPolicy()
+        {
+            PolicyWrap policy =
+                Policy.Timeout(TimeSpan.FromSeconds(30))
+                      .Wrap(Policy.Handle<Exception>()
+                                  .WaitAndRetryForever(index => TimeSpan.FromMilliseconds(500)));
+            return policy;
+        }
+
+        public async Task InitializeAsync()
+        {
+            _blobStorageContainer = await TemporaryBlobStorageContainer.CreateAsync(_eventHubsConfig.StorageConnectionString, _logger);
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (_blobStorageContainer != null)
+            {
+                await _blobStorageContainer.DisposeAsync();
+            }
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Unit/EventHubs/AzureClientFactoryBuilderExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/EventHubs/AzureClientFactoryBuilderExtensionsTests.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using Azure.Messaging.EventHubs.Producer;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace Arcus.Messaging.Tests.Unit.EventHubs
+{
+    public class AzureClientFactoryBuilderExtensionsTests
+    {
+        private const string ExampleEventHubsConnectionStringWithEntityPath = "Endpoint=sb://arcus-testing-messaging.servicebus.windows.net/;SharedAccessKeyName=KeyName;SharedAccessKey=123;EntityPath=eventhubs-name",
+                             ExampleEventHubsConnectionStringWithoutEntityPath = "Endpoint=sb://arcus-testing-messaging.servicebus.windows.net/;SharedAccessKeyName=KeyName;SharedAccessKey=123";
+
+        [Fact]
+        public void AddEventHubProducerClient_WithEntityConnectionStringInSecretStore_Succeeds()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var secretName = "MyConnectionString";
+            services.AddSecretStore(stores => stores.AddInMemory(secretName, ExampleEventHubsConnectionStringWithEntityPath));
+
+            // Act
+            services.AddAzureClients(clients => clients.AddEventHubProducerClient(secretName));
+
+            // Assert
+            IServiceProvider provider = services.BuildServiceProvider();
+            var factory = provider.GetRequiredService<IAzureClientFactory<EventHubProducerClient>>();
+            Assert.NotNull(factory.CreateClient("Default"));
+        }
+
+        [Fact]
+        public void AddEventHubProducerClient_WithNamespaceConnectionStringInSecretStore_Succeeds()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var secretName = "MyConnectionString";
+            services.AddSecretStore(stores => stores.AddInMemory(secretName, ExampleEventHubsConnectionStringWithoutEntityPath));
+
+            // Act
+            services.AddAzureClients(clients => clients.AddEventHubProducerClient(secretName, "eventhubs-name"));
+
+            // Assert
+            IServiceProvider provider = services.BuildServiceProvider();
+            var factory = provider.GetRequiredService<IAzureClientFactory<EventHubProducerClient>>();
+            Assert.NotNull(factory.CreateClient("Default"));
+        }
+
+        [Fact]
+        public void AddEventHubProducerClientFromEntity_WithoutSecretStore_Fails()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddAzureClients(clients => clients.AddEventHubProducerClient("MySecret", "<eventhubs-name>"));
+
+            // Assert
+            IServiceProvider provider = services.BuildServiceProvider();
+            var factory = provider.GetRequiredService<IAzureClientFactory<EventHubProducerClient>>();
+            Assert.Throws<InvalidOperationException>(() => factory.CreateClient("Default"));
+        }
+
+        [Fact]
+        public void AddEventHubProducerClientFromNamespace_WithoutSecretStore_Fails()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act
+            services.AddAzureClients(clients => clients.AddEventHubProducerClient("MySecret"));
+
+            // Assert
+            IServiceProvider provider = services.BuildServiceProvider();
+            var factory = provider.GetRequiredService<IAzureClientFactory<EventHubProducerClient>>();
+            Assert.Throws<InvalidOperationException>(() => factory.CreateClient("Default"));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddEventHubProducerClient_WithoutEntityConnectionString_Fails(string connectionStringSecretName)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => services.AddAzureClients(clients => clients.AddEventHubProducerClient(connectionStringSecretName: connectionStringSecretName)));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddEventHubProducerClient_WithoutEntityConnectionStringWithOptions_Fails(string connectionStringSecretName)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => services.AddAzureClients(clients => clients.AddEventHubProducerClient(connectionStringSecretName: connectionStringSecretName, options => { })));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddEventHubProducerClient_WithoutNamespaceConnectionString_Fails(string connectionStringSecretName)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => services.AddAzureClients(clients => clients.AddEventHubProducerClient(connectionStringSecretName: connectionStringSecretName, "<eventhubs-name>")));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddEventHubProducerClient_WithoutNamespaceConnectionStringWithOptions_Fails(string connectionStringSecretName)
+        {
+            // Arrange
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(
+                () => services.AddAzureClients(clients => clients.AddEventHubProducerClient(connectionStringSecretName: connectionStringSecretName, "<eventhubs-name>", options => { })));
+        }
+    }
+}


### PR DESCRIPTION
Add extension overload to register a `EventHubsProducerClient` via a secret name corresponding with the Azure EventHubs connection string that is registered in the Arcus secret store.

#359