### PR TITLE
feat: add message pump lifetime

### DIFF
--- a/docs/preview/02-Features/06-general-messaging.md
+++ b/docs/preview/02-Features/06-general-messaging.md
@@ -45,12 +45,12 @@ public class RateLimitService
     public async Task CantKeepUpAnymoreAsync(CancellationToken cancellationToken)
     {
         var duration = TimeSpan.FromSeconds(30);
-        await _pumpLifetime.PauseMessageProcessingAsync("abc-123", duration, cancellationToken);
+        await _pumpLifetime.PauseProcessingMessagesAsync("abc-123", duration, cancellationToken);
     }
 }
 ```
 
-⚡ Besides the `PauseMessageProcessingAsync` method, there also exists `Stop...`/`Start...` variants so that you can control the time dynamically when the pump is allowed to run again.
+⚡ Besides the `PauseProcessingMessagesAsync` method, there also exists `Stop...`/`Start...` variants so that you can control the time dynamically when the pump is allowed to run again.
 
 For more information on message pumps:
 - [Azure Service Bus message pump](./02-message-handling/01-service-bus.md)

--- a/docs/preview/02-Features/06-general-messaging.md
+++ b/docs/preview/02-Features/06-general-messaging.md
@@ -53,5 +53,5 @@ public class RateLimitService
 ⚡ Besides the `PauseMessageProcessingAsync` method, there also exists `Stop...`/`Start...` variants so that you can control the time dynamically when the pump is allowed to run again.
 
 For more information on message pumps:
-- [Azure Service Bus message pump](../02-message-handling/01-service-bus.md)
-- [Azure EventHubs message pump](../02-message-handling/03-event-hubs.md)
+- [Azure Service Bus message pump](./02-message-handling/01-service-bus.md)
+- [Azure EventHubs message pump](./02-message-handling/03-event-hubs.md)

--- a/docs/preview/02-Features/06-general-messaging.md
+++ b/docs/preview/02-Features/06-general-messaging.md
@@ -11,7 +11,7 @@ Both and future systems also support some general functionality that will be exp
 
 ⚡ If you use one of the message-type specific packages like `Arcus.Messaging.Pumps.EventHubs`, you will automatically get this functionality. If you implement your own message pump, please use the `services.AddMessagePump(...)` extension which makes sure that you also registers this functionality.
 
-When messages are being processed by a system that works slower than the rate that messages are being received by the message pump, a rate problem could occur . 
+When messages are being processed by a system that works slower than the rate that messages are being received by the message pump, a rate problem could occur. 
 As a solution to this problem, the Arcus Messaging library registers an `IMessagePumpLifetime` instance in the application services that lets you control the message receiving process and pauses if necessary for the downstream dependency system to keep up.
 
 The following example below shows how a 'rate limit' service gets injected with the `IMessagePumpLifetime` instance and pauses.

--- a/docs/preview/02-Features/06-general-messaging.md
+++ b/docs/preview/02-Features/06-general-messaging.md
@@ -1,0 +1,57 @@
+﻿---
+title: "General messaging"
+layout: default
+---
+
+# General messaging functionality
+The Arcus Messaging library has several messaging systems that can retrieve messages from Azure technology (like Azure Service Bus and Azure EventHubs), and run abstracted message handlers on the received messages.
+Both and future systems also support some general functionality that will be explained here.
+
+## Stop message pump when downstream is unable to keep up
+
+⚡ If you use one of the message-type specific packages like `Arcus.Messaging.Pumps.EventHubs`, you will automatically get this functionality. If you implement your own message pump, please use the `services.AddMessagePump(...)` extension which makes sure that you also registers this functionality.
+
+When messages are being processed by a system that works slower than the rate that messages are being received by the message pump, there could occur a rate problem. 
+As a solution to this problem, the Arcus Messaging library registers an `IMessagePumpLifetime` instance in the application services that let you control the message receiving process and pauses if necessary for the dependency downward system to keep up.
+
+The following example below shows how a 'rate limit' service gets injected with the `IMessagePumpLifetime` instance and pauses.
+Note that the message pumps need to be registered with a unique job ID so that the lifetime component knows which pump it needs to manage.
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Arcus.Messaging.Pumps.Abstractions;
+
+public class Program
+{
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddServiceBusMessagePump(..., options => options.JobId = "abc-123")
+                .WithServiceBusMessageHandler<..., ...>();
+
+        services.AddEventHubsMessagePump(..., options => options.JobId = "def-456")
+                .WithEventHubsMessageHandler<..., ...>();
+    }
+}
+
+public class RateLimitService
+{
+    private readonly IMessagePumpLifetime _pumpLifetime;
+
+    public RateLimitService(IMessagePumpLifetime lifetime)
+    {
+        _pumpLifetime = lifetime;
+    }
+
+    public async Task CantKeepUpAnymoreAsync(CancellationToken cancellationToken)
+    {
+        var duration = TimeSpan.FromSeconds(30);
+        await _pumpLifetime.PauseMessageProcessingAsync("abc-123", duration, cancellationToken);
+    }
+}
+```
+
+⚡ Besides the `PauseMessageProcessingAsync` method, there also exists `Stop...`/`Start...` variants so that you can control the time dynamically when the pump is allowed to run again.
+
+For more information on message pumps:
+- [Azure Service Bus message pump](../02-message-handling/01-service-bus.md)
+- [Azure EventHubs message pump](../02-message-handling/03-event-hubs.md)

--- a/docs/preview/02-Features/06-general-messaging.md
+++ b/docs/preview/02-Features/06-general-messaging.md
@@ -11,7 +11,7 @@ Both and future systems also support some general functionality that will be exp
 
 ⚡ If you use one of the message-type specific packages like `Arcus.Messaging.Pumps.EventHubs`, you will automatically get this functionality. If you implement your own message pump, please use the `services.AddMessagePump(...)` extension which makes sure that you also registers this functionality.
 
-When messages are being processed by a system that works slower than the rate that messages are being received by the message pump, there could occur a rate problem. 
+When messages are being processed by a system that works slower than the rate that messages are being received by the message pump, a rate problem could occur . 
 As a solution to this problem, the Arcus Messaging library registers an `IMessagePumpLifetime` instance in the application services that let you control the message receiving process and pauses if necessary for the dependency downward system to keep up.
 
 The following example below shows how a 'rate limit' service gets injected with the `IMessagePumpLifetime` instance and pauses.

--- a/docs/preview/02-Features/06-general-messaging.md
+++ b/docs/preview/02-Features/06-general-messaging.md
@@ -12,7 +12,7 @@ Both and future systems also support some general functionality that will be exp
 ⚡ If you use one of the message-type specific packages like `Arcus.Messaging.Pumps.EventHubs`, you will automatically get this functionality. If you implement your own message pump, please use the `services.AddMessagePump(...)` extension which makes sure that you also registers this functionality.
 
 When messages are being processed by a system that works slower than the rate that messages are being received by the message pump, a rate problem could occur . 
-As a solution to this problem, the Arcus Messaging library registers an `IMessagePumpLifetime` instance in the application services that let you control the message receiving process and pauses if necessary for the dependency downward system to keep up.
+As a solution to this problem, the Arcus Messaging library registers an `IMessagePumpLifetime` instance in the application services that lets you control the message receiving process and pauses if necessary for the downstream dependency system to keep up.
 
 The following example below shows how a 'rate limit' service gets injected with the `IMessagePumpLifetime` instance and pauses.
 Note that the message pumps need to be registered with a unique job ID so that the lifetime component knows which pump it needs to manage.

--- a/src/Arcus.Messaging.Pumps.Abstractions/DefaultMessagePumpLifetime.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/DefaultMessagePumpLifetime.cs
@@ -36,14 +36,14 @@ namespace Arcus.Messaging.Pumps.Abstractions
         /// <param name="jobId">The uniquely defined identifier of the registered message pump.</param>
         /// <param name="cancellationToken">The token to indicate that the start process has been aborted.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
-        public async Task StartReceivingMessagesAsync(string jobId, CancellationToken cancellationToken)
+        public async Task PauseProcessingMessagesAsync(string jobId, CancellationToken cancellationToken)
         {
             Guard.NotNullOrWhitespace(jobId, nameof(jobId), "Requires a message pump job ID to retrieve the registered message pump in the application services");
 
             MessagePump messagePump = GetMessagePump(jobId);
             
             _logger.LogTrace("Starting message pump '{JobId}' via message pump lifetime...", jobId);
-            await messagePump.StartReceivingMessagesAsync(cancellationToken);
+            await messagePump.StartProcessingMessagesAsync(cancellationToken);
             _logger.LogTrace("Started message pump '{JobId}' via message pump lifetime", jobId);
         }
 
@@ -55,20 +55,20 @@ namespace Arcus.Messaging.Pumps.Abstractions
         /// <param name="cancellationToken">The token to indicate that the shutdown and start process should no longer be graceful.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
-        public async Task PauseReceivingMessagesAsync(string jobId, TimeSpan duration, CancellationToken cancellationToken)
+        public async Task PauseProcessingMessagesAsync(string jobId, TimeSpan duration, CancellationToken cancellationToken)
         {
             Guard.NotNullOrWhitespace(jobId, nameof(jobId), "Requires a message pump job ID to retrieve the registered message pump in the application services");
 
             MessagePump messagePump = GetMessagePump(jobId);
             _logger.LogTrace("Stopping message pump '{JobId}' via message pump lifetime...", jobId);
-            await messagePump.StopReceivingMessagesAsync(cancellationToken);
+            await messagePump.StopProcessingMessagesAsync(cancellationToken);
             _logger.LogTrace("Stopped message pump '{JobId}' via message pump lifetime", jobId);
 
             _ = Task.Delay(duration, cancellationToken)
                     .ContinueWith(async t =>
                     {
                         _logger.LogTrace("Starting message pump '{JobId}' via message pump lifetime...", jobId);
-                        await messagePump.StartReceivingMessagesAsync(cancellationToken);
+                        await messagePump.StartProcessingMessagesAsync(cancellationToken);
                         _logger.LogTrace("Started message pump '{JobId}' via message pump lifetime", jobId);
                     }, cancellationToken);
         }
@@ -79,14 +79,14 @@ namespace Arcus.Messaging.Pumps.Abstractions
         /// <param name="jobId">The uniquely defined identifier of the registered message pump.</param>
         /// <param name="cancellationToken">The token to indicate that the shutdown process should no longer be graceful.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
-        public async Task StopReceivingMessagesAsync(string jobId, CancellationToken cancellationToken)
+        public async Task StopProcessingMessagesAsync(string jobId, CancellationToken cancellationToken)
         {
             Guard.NotNullOrWhitespace(jobId, nameof(jobId), "Requires a message pump job ID to retrieve the registered message pump in the application services");
 
             MessagePump messagePump = GetMessagePump(jobId);
 
             _logger.LogTrace("Stopping message pump '{JobId}' via message pump lifetime...", jobId);
-            await messagePump.StopReceivingMessagesAsync(cancellationToken);
+            await messagePump.StopProcessingMessagesAsync(cancellationToken);
             _logger.LogTrace("Stopped message pump '{JobId}' via message pump lifetime", jobId);
         }
 

--- a/src/Arcus.Messaging.Pumps.Abstractions/DefaultMessagePumpLifetime.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/DefaultMessagePumpLifetime.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using GuardNet;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Arcus.Messaging.Pumps.Abstractions
+{
+    /// <summary>
+    /// Represents the default <see cref="IMessagePumpLifetime"/> implementation to control the lifetime of registered message pumps.
+    /// </summary>
+    public class DefaultMessagePumpLifetime : IMessagePumpLifetime
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultMessagePumpLifetime" /> class.
+        /// </summary>
+        /// <param name="serviceProvider">The application service provider where the message pumps are registered.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
+        public DefaultMessagePumpLifetime(IServiceProvider serviceProvider)
+        {
+            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires a service provider instance to retrieve the registered message pumps");
+            _serviceProvider = serviceProvider;
+            _logger = serviceProvider.GetService<ILogger<DefaultMessagePumpLifetime>>() ?? NullLogger<DefaultMessagePumpLifetime>.Instance;
+        }
+
+        /// <summary>
+        /// Starts a message pump with the given <paramref name="jobId"/>.
+        /// </summary>
+        /// <param name="jobId">The uniquely defined identifier of the registered message pump.</param>
+        /// <param name="cancellationToken">The token to indicate that the start process has been aborted.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
+        public async Task StartReceivingMessagesAsync(string jobId, CancellationToken cancellationToken)
+        {
+            Guard.NotNullOrWhitespace(jobId, nameof(jobId), "Requires a message pump job ID to retrieve the registered message pump in the application services");
+
+            MessagePump messagePump = GetMessagePump(jobId);
+            
+            _logger.LogTrace("Starting message pump '{JobId}' via message pump lifetime...", jobId);
+            await messagePump.StartReceivingMessagesAsync(cancellationToken);
+            _logger.LogTrace("Started message pump '{JobId}' via message pump lifetime", jobId);
+        }
+
+        /// <summary>
+        /// Pauses a message pump with the given <paramref name="jobId"/> for a specified <paramref name="duration"/>.
+        /// </summary>
+        /// <param name="jobId">The uniquely defined identifier of the registered message pump.</param>
+        /// <param name="duration">The time duration in which the message pump should be stopped.</param>
+        /// <param name="cancellationToken">The token to indicate that the shutdown and start process should no longer be graceful.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        public async Task PauseReceivingMessagesAsync(string jobId, TimeSpan duration, CancellationToken cancellationToken)
+        {
+            Guard.NotNullOrWhitespace(jobId, nameof(jobId), "Requires a message pump job ID to retrieve the registered message pump in the application services");
+
+            MessagePump messagePump = GetMessagePump(jobId);
+            _logger.LogTrace("Stopping message pump '{JobId}' via message pump lifetime...", jobId);
+            await messagePump.StopReceivingMessagesAsync(cancellationToken);
+            _logger.LogTrace("Stopped message pump '{JobId}' via message pump lifetime", jobId);
+
+            _ = Task.Delay(duration, cancellationToken)
+                    .ContinueWith(async t =>
+                    {
+                        _logger.LogTrace("Starting message pump '{JobId}' via message pump lifetime...", jobId);
+                        await messagePump.StartReceivingMessagesAsync(cancellationToken);
+                        _logger.LogTrace("Started message pump '{JobId}' via message pump lifetime", jobId);
+                    }, cancellationToken);
+        }
+
+        /// <summary>
+        /// Stops a message pump with a given <paramref name="jobId"/>.
+        /// </summary>
+        /// <param name="jobId">The uniquely defined identifier of the registered message pump.</param>
+        /// <param name="cancellationToken">The token to indicate that the shutdown process should no longer be graceful.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
+        public async Task StopReceivingMessagesAsync(string jobId, CancellationToken cancellationToken)
+        {
+            Guard.NotNullOrWhitespace(jobId, nameof(jobId), "Requires a message pump job ID to retrieve the registered message pump in the application services");
+
+            MessagePump messagePump = GetMessagePump(jobId);
+
+            _logger.LogTrace("Stopping message pump '{JobId}' via message pump lifetime...", jobId);
+            await messagePump.StopReceivingMessagesAsync(cancellationToken);
+            _logger.LogTrace("Stopped message pump '{JobId}' via message pump lifetime", jobId);
+        }
+
+        private MessagePump GetMessagePump(string jobId)
+        {
+            _logger.LogTrace("Getting message pump '{JobId}' in application services...", jobId);
+            MessagePump messagePump =
+                _serviceProvider.GetServices<IHostedService>()
+                                .OfType<MessagePump>()
+                                .FirstOrDefault(pump => pump.JobId == jobId);
+
+            if (messagePump is null)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot control lifetime of Arcus message pump with ID '{jobId}' because no message pump was found in the registered application services");
+            }
+
+            _logger.LogTrace("Get message pump '{JobId}' in application services", jobId);
+            return messagePump;
+        }
+    }
+}

--- a/src/Arcus.Messaging.Pumps.Abstractions/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/Extensions/IServiceCollectionExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Arcus.Messaging.Pumps.Abstractions;
+using GuardNet;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Adds extensions to the <see cref="IServiceCollection"/> for easier message pump registrations
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    public static class IServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Adds an <see cref="MessagePump"/> registration to the application services.
+        /// </summary>
+        /// <typeparam name="TMessagePump">The custom message pump type.</typeparam>
+        /// <param name="services">The application services to register the message pump to.</param>
+        /// <param name="implementationFactory">The factory function to create the custom <typeparamref name="TMessagePump"/> instance.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or the <paramref name="implementationFactory"/> is <c>null</c>.</exception>
+        public static IServiceCollection AddMessagePump<TMessagePump>(
+            this IServiceCollection services,
+            Func<IServiceProvider, TMessagePump> implementationFactory)
+            where TMessagePump : MessagePump
+        {
+            Guard.NotNull(services, nameof(services), "Requires an application services instance to register the custom message pump instance");
+            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a factory implementation function to create the custom message pump instance");
+
+            services.TryAddSingleton<IMessagePumpLifetime, DefaultMessagePumpLifetime>();
+            return services.AddHostedService(implementationFactory);
+        }
+    }
+}

--- a/src/Arcus.Messaging.Pumps.Abstractions/IMessagePumpLifetime.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/IMessagePumpLifetime.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Arcus.Messaging.Pumps.Abstractions
+{
+    /// <summary>
+    /// Represents the handler to control the lifetime of a certain message pump.
+    /// </summary>
+    public interface IMessagePumpLifetime
+    {
+        /// <summary>
+        /// Starts a message pump with the given <paramref name="jobId"/>.
+        /// </summary>
+        /// <param name="jobId">The uniquely defined identifier of the registered message pump.</param>
+        /// <param name="cancellationToken">The token to indicate that the start process has been aborted.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
+        Task StartReceivingMessagesAsync(string jobId, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Pauses a message pump with the given <paramref name="jobId"/> for a specified <paramref name="duration"/>.
+        /// </summary>
+        /// <param name="jobId">The uniquely defined identifier of the registered message pump.</param>
+        /// <param name="duration">The time duration in which the message pump should be stopped.</param>
+        /// <param name="cancellationToken">The token to indicate that the shutdown and start process should no longer be graceful.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
+        Task PauseReceivingMessagesAsync(string jobId, TimeSpan duration, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Stops a message pump with a given <paramref name="jobId"/>.
+        /// </summary>
+        /// <param name="jobId">The uniquely defined identifier of the registered message pump.</param>
+        /// <param name="cancellationToken">The token to indicate that the shutdown process should no longer be graceful.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
+        Task StopReceivingMessagesAsync(string jobId, CancellationToken cancellationToken);
+    }
+}

--- a/src/Arcus.Messaging.Pumps.Abstractions/IMessagePumpLifetime.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/IMessagePumpLifetime.cs
@@ -15,7 +15,7 @@ namespace Arcus.Messaging.Pumps.Abstractions
         /// <param name="jobId">The uniquely defined identifier of the registered message pump.</param>
         /// <param name="cancellationToken">The token to indicate that the start process has been aborted.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
-        Task StartReceivingMessagesAsync(string jobId, CancellationToken cancellationToken);
+        Task PauseProcessingMessagesAsync(string jobId, CancellationToken cancellationToken);
 
         /// <summary>
         /// Pauses a message pump with the given <paramref name="jobId"/> for a specified <paramref name="duration"/>.
@@ -25,7 +25,7 @@ namespace Arcus.Messaging.Pumps.Abstractions
         /// <param name="cancellationToken">The token to indicate that the shutdown and start process should no longer be graceful.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
-        Task PauseReceivingMessagesAsync(string jobId, TimeSpan duration, CancellationToken cancellationToken);
+        Task PauseProcessingMessagesAsync(string jobId, TimeSpan duration, CancellationToken cancellationToken);
 
         /// <summary>
         /// Stops a message pump with a given <paramref name="jobId"/>.
@@ -33,6 +33,6 @@ namespace Arcus.Messaging.Pumps.Abstractions
         /// <param name="jobId">The uniquely defined identifier of the registered message pump.</param>
         /// <param name="cancellationToken">The token to indicate that the shutdown process should no longer be graceful.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
-        Task StopReceivingMessagesAsync(string jobId, CancellationToken cancellationToken);
+        Task StopProcessingMessagesAsync(string jobId, CancellationToken cancellationToken);
     }
 }

--- a/src/Arcus.Messaging.Pumps.Abstractions/MessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/MessagePump.cs
@@ -10,57 +10,24 @@ using Microsoft.Extensions.Logging;
 namespace Arcus.Messaging.Pumps.Abstractions
 {
     /// <summary>
-    ///     Foundation for building message pumps
+    /// Represents the foundation for building message pumps.
     /// </summary>
     public abstract class MessagePump : BackgroundService
     {
         /// <summary>
-        ///     Default encoding used
+        /// Initializes a new instance of the <see cref="MessagePump"/> class.
         /// </summary>
-        protected Encoding DefaultEncoding { get; } = Encoding.UTF8;
-
-        /// <summary>
-        ///     Unique id of this message pump instance
-        /// </summary>
-        protected string Id { get; } = Guid.NewGuid().ToString();
-
-        /// <summary>
-        ///     Id of the client being used to connect to the messaging service
-        /// </summary>
-        protected string ClientId { get; private set; }
-
-        /// <summary>
-        ///     Entity path that is being processed
-        /// </summary>
-        public string EntityPath { get; private set; }
-
-        /// <summary>
-        ///     Logger to write telemetry to
-        /// </summary>
-        protected ILogger Logger { get; }
-
-        /// <summary>
-        ///     Configuration of the application
-        /// </summary>
-        protected IConfiguration Configuration { get; }
-
-
-        /// <summary>
-        ///     Collection of services that are configured
-        /// </summary>
-        protected IServiceProvider ServiceProvider { get; }
-
-        /// <summary>
-        ///     Constructor
-        /// </summary>
-        /// <param name="configuration">Configuration of the application</param>
-        /// <param name="serviceProvider">Collection of services that are configured</param>
-        /// <param name="logger">Logger to write telemetry to</param>
+        /// <param name="configuration">The configuration of the application.</param>
+        /// <param name="serviceProvider">The collection of services that are configured.</param>
+        /// <param name="logger">The logger to write telemetry to.</param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="configuration"/>, the <paramref name="serviceProvider"/>, or <paramref name="logger"/> is <c>null</c>.
+        /// </exception>
         protected MessagePump(IConfiguration configuration, IServiceProvider serviceProvider, ILogger logger)
         {
-            Guard.NotNull(logger, nameof(logger));
             Guard.NotNull(configuration, nameof(configuration));
             Guard.NotNull(serviceProvider, nameof(serviceProvider));
+            Guard.NotNull(logger, nameof(logger));
 
             Logger = logger;
             Configuration = configuration;
@@ -68,7 +35,48 @@ namespace Arcus.Messaging.Pumps.Abstractions
         }
 
         /// <summary>
-        ///     Handles an exception that occurred during the receiving of a message
+        /// Gets the unique identifier for this background job to distinguish this job instance in a multi-instance deployment.
+        /// </summary>
+        public string JobId { get; protected set; } = Guid.NewGuid().ToString();
+
+        /// <summary>
+        ///     Unique id of this message pump instance
+        /// </summary>
+        [Obsolete("Use the " + nameof(JobId) + " instead to identify the message pump")]
+        protected string Id => JobId;
+
+        /// <summary>
+        /// Gets hte ID of the client being used to connect to the messaging service.
+        /// </summary>
+        protected string ClientId { get; private set; }
+
+        /// <summary>
+        /// Gets entity path that is being processed.
+        /// </summary>
+        public string EntityPath { get; private set; }
+
+        /// <summary>
+        /// Gets the configuration of the application.
+        /// </summary>
+        protected IConfiguration Configuration { get; }
+
+        /// <summary>
+        /// Gets the collection of application services that are configured.
+        /// </summary>
+        protected IServiceProvider ServiceProvider { get; }
+
+        /// <summary>
+        /// Gets the default encoding used during the message processing through the message pump.
+        /// </summary>
+        protected Encoding DefaultEncoding { get; } = Encoding.UTF8;
+
+        /// <summary>
+        /// Gets the logger to write telemetry to.
+        /// </summary>
+        protected ILogger Logger { get; }
+
+        /// <summary>
+        /// Handles an exception that occurred during the receiving of a message
         /// </summary>
         /// <param name="receiveException">Exception that occurred</param>
         protected virtual Task HandleReceiveExceptionAsync(Exception receiveException)
@@ -78,7 +86,7 @@ namespace Arcus.Messaging.Pumps.Abstractions
         }
 
         /// <summary>
-        ///     Triggered when the message pump is performing a graceful shutdown.
+        /// Triggered when the message pump is performing a graceful shutdown.
         /// </summary>
         /// <param name="cancellationToken">Indicates that the shutdown process should no longer be graceful.</param>
         public override async Task StopAsync(CancellationToken cancellationToken)
@@ -89,7 +97,25 @@ namespace Arcus.Messaging.Pumps.Abstractions
         }
 
         /// <summary>
-        ///     Register information about the client connected to the messaging service
+        /// Start with receiving messages on this message pump.
+        /// </summary>
+        /// <param name="cancellationToken">The token to indicate the start process should no longer be graceful.</param>
+        public virtual Task StartReceivingMessagesAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Stop with receiving messages on this message pump.
+        /// </summary>
+        /// <param name="cancellationToken">The token to indicate the stop process should no longer be graceful.</param>
+        public virtual Task StopReceivingMessagesAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Register information about the client connected to the messaging service
         /// </summary>
         /// <param name="clientId">Id of the client being used to connect to the messaging service</param>
         /// <param name="entityPath">Entity path that is being processed</param>

--- a/src/Arcus.Messaging.Pumps.Abstractions/MessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/MessagePump.cs
@@ -100,7 +100,7 @@ namespace Arcus.Messaging.Pumps.Abstractions
         /// Start with receiving messages on this message pump.
         /// </summary>
         /// <param name="cancellationToken">The token to indicate the start process should no longer be graceful.</param>
-        public virtual Task StartReceivingMessagesAsync(CancellationToken cancellationToken)
+        public virtual Task StartProcessingMessagesAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }
@@ -109,7 +109,7 @@ namespace Arcus.Messaging.Pumps.Abstractions
         /// Stop with receiving messages on this message pump.
         /// </summary>
         /// <param name="cancellationToken">The token to indicate the stop process should no longer be graceful.</param>
-        public virtual Task StopReceivingMessagesAsync(CancellationToken cancellationToken)
+        public virtual Task StopProcessingMessagesAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }

--- a/src/Arcus.Messaging.Pumps.EventHubs/AzureEventHubsMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.EventHubs/AzureEventHubsMessagePump.cs
@@ -77,7 +77,7 @@ namespace Arcus.Messaging.Pumps.EventHubs
         {
             try
             {
-                await StartReceivingMessagesAsync(stoppingToken);
+                await StartProcessingMessagesAsync(stoppingToken);
                 await UntilCancelledAsync(stoppingToken);
             }
             catch (Exception exception) when (exception is TaskCanceledException || exception is OperationCanceledException)
@@ -90,7 +90,7 @@ namespace Arcus.Messaging.Pumps.EventHubs
             }
             finally
             {
-                await StopReceivingMessagesAsync(CancellationToken.None);
+                await StopProcessingMessagesAsync(CancellationToken.None);
             }
         }
 
@@ -101,13 +101,13 @@ namespace Arcus.Messaging.Pumps.EventHubs
         public async Task RestartAsync(CancellationToken cancellationToken)
         {
             Logger.LogTrace("Restarting Azure EventHubs message pump '{JobId}' on '{ConsumerGroup}/{EventHubsName}' in '{Namespace}' ...", JobId, ConsumerGroup, EventHubName, Namespace);
-            await StopReceivingMessagesAsync(cancellationToken);
-            await StartReceivingMessagesAsync(cancellationToken);
+            await StopProcessingMessagesAsync(cancellationToken);
+            await StartProcessingMessagesAsync(cancellationToken);
             Logger.LogInformation("Azure EventHubs message pump '{JobId}' on '{ConsumerGroup}/{EventHubsName}' in '{Namespace}' restarted!", JobId, ConsumerGroup, EventHubName, Namespace);
         }
 
         /// <inheritdoc />
-        public override async Task StartReceivingMessagesAsync(CancellationToken stoppingToken)
+        public override async Task StartProcessingMessagesAsync(CancellationToken stoppingToken)
         {
             _eventProcessor = await _eventHubsConfig.CreateEventProcessorClientAsync();
             _eventProcessor.ProcessEventAsync += ProcessMessageAsync;
@@ -181,7 +181,7 @@ namespace Arcus.Messaging.Pumps.EventHubs
         }
 
         /// <inheritdoc />
-        public override async Task StopReceivingMessagesAsync(CancellationToken cancellationToken)
+        public override async Task StopProcessingMessagesAsync(CancellationToken cancellationToken)
         {
             try
             {

--- a/src/Arcus.Messaging.Pumps.EventHubs/AzureEventHubsMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.EventHubs/AzureEventHubsMessagePump.cs
@@ -67,9 +67,6 @@ namespace Arcus.Messaging.Pumps.EventHubs
         private string ConsumerGroup => _eventProcessor?.ConsumerGroup;
         private string Namespace => _eventProcessor?.FullyQualifiedNamespace;
 
-        /// <inheritdoc/>
-        public string JobId { get; }
-
         /// <summary>
         /// This method is called when the <see cref="T:Microsoft.Extensions.Hosting.IHostedService" /> starts. The implementation should return a task that represents
         /// the lifetime of the long running operation(s) being performed.
@@ -80,7 +77,7 @@ namespace Arcus.Messaging.Pumps.EventHubs
         {
             try
             {
-                await StartEventProcessingAsync(stoppingToken);
+                await StartReceivingMessagesAsync(stoppingToken);
                 await UntilCancelledAsync(stoppingToken);
             }
             catch (Exception exception) when (exception is TaskCanceledException || exception is OperationCanceledException)
@@ -93,7 +90,7 @@ namespace Arcus.Messaging.Pumps.EventHubs
             }
             finally
             {
-                await StopEventProcessingAsync();
+                await StopReceivingMessagesAsync(CancellationToken.None);
             }
         }
 
@@ -104,12 +101,13 @@ namespace Arcus.Messaging.Pumps.EventHubs
         public async Task RestartAsync(CancellationToken cancellationToken)
         {
             Logger.LogTrace("Restarting Azure EventHubs message pump '{JobId}' on '{ConsumerGroup}/{EventHubsName}' in '{Namespace}' ...", JobId, ConsumerGroup, EventHubName, Namespace);
-            await StopEventProcessingAsync();
-            await StartEventProcessingAsync(cancellationToken);
+            await StopReceivingMessagesAsync(cancellationToken);
+            await StartReceivingMessagesAsync(cancellationToken);
             Logger.LogInformation("Azure EventHubs message pump '{JobId}' on '{ConsumerGroup}/{EventHubsName}' in '{Namespace}' restarted!", JobId, ConsumerGroup, EventHubName, Namespace);
         }
 
-        private async Task StartEventProcessingAsync(CancellationToken stoppingToken)
+        /// <inheritdoc />
+        public override async Task StartReceivingMessagesAsync(CancellationToken stoppingToken)
         {
             _eventProcessor = await _eventHubsConfig.CreateEventProcessorClientAsync();
             _eventProcessor.ProcessEventAsync += ProcessMessageAsync;
@@ -182,12 +180,13 @@ namespace Arcus.Messaging.Pumps.EventHubs
             return Task.CompletedTask;
         }
 
-        private async Task StopEventProcessingAsync()
+        /// <inheritdoc />
+        public override async Task StopReceivingMessagesAsync(CancellationToken cancellationToken)
         {
             try
             {
                 Logger.LogTrace("Stopping Azure EventHubs message pump '{JobId}' on '{ConsumerGroup}/{EventHubsName}' in '{Namespace}'",  JobId, ConsumerGroup, EventHubName , Namespace);
-                await _eventProcessor.StopProcessingAsync();
+                await _eventProcessor.StopProcessingAsync(cancellationToken);
                 _eventProcessor.ProcessEventAsync -= ProcessMessageAsync;
                 _eventProcessor.ProcessErrorAsync -= ProcessErrorAsync;
                 Logger.LogInformation("Azure EventHubs message pump '{JobId}' on '{ConsumerGroup}/{EventHubsName}' in '{Namespace}' stopped: {Time}",  JobId, ConsumerGroup, EventHubName , Namespace, DateTimeOffset.UtcNow);

--- a/src/Arcus.Messaging.Pumps.EventHubs/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.EventHubs/Extensions/IServiceCollectionExtensions.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Extensions.DependencyInjection
             });
             collection.JobId = options.JobId;
 
-            services.AddHostedService(serviceProvider =>
+            services.AddMessagePump(serviceProvider =>
             {
                 ISecretProvider secretProvider = DetermineSecretProvider(serviceProvider);
                 var eventHubsConfig = new AzureEventHubsMessagePumpConfig(

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -173,7 +173,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
         {
             try
             {
-                await StartReceivingMessagesAsync(stoppingToken);
+                await StartProcessingMessagesAsync(stoppingToken);
                 await UntilCancelledAsync(stoppingToken);
             }
             catch (Exception exception) when (exception is TaskCanceledException || exception is OperationCanceledException)
@@ -186,12 +186,12 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             }
             finally
             {
-                await StopReceivingMessagesAsync(CancellationToken.None);
+                await StopProcessingMessagesAsync(CancellationToken.None);
             }
         }
 
         /// <inheritdoc />
-        public override async Task StartReceivingMessagesAsync(CancellationToken cancellationToken)
+        public override async Task StartProcessingMessagesAsync(CancellationToken cancellationToken)
         {
             _messageProcessor = await Settings.CreateMessageProcessorAsync();
             Namespace = _messageProcessor.FullyQualifiedNamespace;
@@ -209,7 +209,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
         }
 
         /// <inheritdoc />
-        public override async Task StopReceivingMessagesAsync(CancellationToken cancellationToken)
+        public override async Task StopProcessingMessagesAsync(CancellationToken cancellationToken)
         {
             if (_messageProcessor is null)
             {
@@ -269,8 +269,8 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             Interlocked.Exchange(ref _unauthorizedExceptionCount, 0);
 
             Logger.LogTrace("Restarting Azure Service Bus message pump '{JobId}' on entity path '{EntityPath}' in '{Namespace}' ...", JobId, EntityPath, Namespace);
-            await StopReceivingMessagesAsync(CancellationToken.None);
-            await StartReceivingMessagesAsync(CancellationToken.None);
+            await StopProcessingMessagesAsync(CancellationToken.None);
+            await StartProcessingMessagesAsync(CancellationToken.None);
             Logger.LogInformation("Azure Service Bus message pump '{JobId}' on entity path '{EntityPath}' in '{Namespace}' restarted!", JobId, EntityPath, Namespace);
         }
 
@@ -282,8 +282,8 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             Interlocked.Exchange(ref _unauthorizedExceptionCount, 0);
 
             Logger.LogTrace("Restarting Azure Service Bus message pump '{JobId}' on entity path '{EntityPath}' in '{Namespace}' ...", JobId, EntityPath, Namespace);
-            await StopReceivingMessagesAsync(cancellationToken);
-            await StartReceivingMessagesAsync(cancellationToken);
+            await StopProcessingMessagesAsync(cancellationToken);
+            await StartProcessingMessagesAsync(cancellationToken);
             Logger.LogInformation("Azure Service Bus message pump '{JobId}' on entity path '{EntityPath}' in '{Namespace}' restarted!", JobId, EntityPath, Namespace);
         }
 

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
@@ -871,7 +871,7 @@ namespace Microsoft.Extensions.DependencyInjection
             });
             collection.JobId = options.JobId;
 
-            services.AddHostedService(serviceProvider =>
+            services.AddMessagePump(serviceProvider =>
             {
                 var logger = serviceProvider.GetRequiredService<ILogger<AzureServiceBusMessagePump>>();
                 if (subscriptionName != null && subscriptionName.Length > 50)

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/EventHubsMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/EventHubsMessagePumpTests.cs
@@ -302,7 +302,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             await using (var consumer = await TestServiceBusMessageEventConsumer.StartNewAsync(_config, _logger))
             {
                 var lifetime = worker.Services.GetRequiredService<IMessagePumpLifetime>();
-                await lifetime.PauseReceivingMessagesAsync(jobId, TimeSpan.FromSeconds(5), CancellationToken.None);
+                await lifetime.PauseProcessingMessagesAsync(jobId, TimeSpan.FromSeconds(5), CancellationToken.None);
 
                 // Act
                 await producer.ProduceAsync(expected);

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/EventHubsMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/EventHubsMessagePumpTests.cs
@@ -9,6 +9,7 @@ using Arcus.EventGrid.Publishing.Interfaces;
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.EventHubs.MessageHandling;
 using Arcus.Messaging.Abstractions.MessageHandling;
+using Arcus.Messaging.Pumps.Abstractions;
 using Arcus.Messaging.Pumps.EventHubs;
 using Arcus.Messaging.Pumps.EventHubs.Configuration;
 using Arcus.Messaging.Tests.Core.Correlation;
@@ -279,6 +280,37 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
 
             // Act / Assert
             await TestEventHubsMessageHandlingForHierarchicalAsync(options, eventHubs, operationParentIdPropertyName: customOperationParentIdPropertyName);
+        }
+
+        [Fact]
+        public async Task EventHubsMessagePump_PausesViaLifetime_RestartsAgain()
+        {
+            // Arrange
+            EventHubsConfig eventHubs = _config.GetEventHubsConfig();
+            string jobId = Guid.NewGuid().ToString();
+            var options = new WorkerOptions();
+            AddEventHubsMessagePump(options, eventHubs, opt => opt.JobId = jobId)
+                .WithEventHubsMessageHandler<OrderEventHubsMessageHandler, Order>();
+
+            var traceParent = TraceParent.Generate();
+            EventData expected = CreateOrderEventDataMessageForW3C(traceParent);
+            
+            string eventHubsName = eventHubs.GetEventHubsName(IntegrationTestType.SelfContained);
+            var producer = new TestEventHubsMessageProducer(eventHubs.EventHubsConnectionString, eventHubsName);
+
+            await using (var worker = await Worker.StartNewAsync(options))
+            await using (var consumer = await TestServiceBusMessageEventConsumer.StartNewAsync(_config, _logger))
+            {
+                var lifetime = worker.Services.GetRequiredService<IMessagePumpLifetime>();
+                await lifetime.PauseReceivingMessagesAsync(jobId, TimeSpan.FromSeconds(5), CancellationToken.None);
+
+                // Act
+                await producer.ProduceAsync(expected);
+
+                // Assert
+                OrderCreatedEventData actual = consumer.ConsumeOrderEventForW3C(traceParent.TransactionId);
+                AssertReceivedOrderEventDataForW3C(expected, actual, traceParent);
+            }
         }
 
         [Fact]

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -801,7 +801,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             await using (var consumer = await TestServiceBusMessageEventConsumer.StartNewAsync(_config, _logger))
             {
                 var lifetime = worker.Services.GetRequiredService<IMessagePumpLifetime>();
-                await lifetime.PauseReceivingMessagesAsync(jobId, TimeSpan.FromSeconds(5), CancellationToken.None);
+                await lifetime.PauseProcessingMessagesAsync(jobId, TimeSpan.FromSeconds(5), CancellationToken.None);
 
                 // Act
                 await producer.ProduceAsync(message);

--- a/src/Arcus.Messaging.Tests.Unit/MessagePump/DefaultMessagePumpLifetimeTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessagePump/DefaultMessagePumpLifetimeTests.cs
@@ -42,7 +42,7 @@ namespace Arcus.Messaging.Tests.Unit.MessagePump
             var lifetime = new DefaultMessagePumpLifetime(provider);
 
             // Act
-            await lifetime.StopReceivingMessagesAsync(jobId, CancellationToken.None);
+            await lifetime.StopProcessingMessagesAsync(jobId, CancellationToken.None);
 
             // Assert
             var pump = Assert.IsType<TestMessagePump>(hostedService);
@@ -63,7 +63,7 @@ namespace Arcus.Messaging.Tests.Unit.MessagePump
             var lifetime = new DefaultMessagePumpLifetime(provider);
 
             // Act
-            await lifetime.StartReceivingMessagesAsync(jobId, CancellationToken.None);
+            await lifetime.PauseProcessingMessagesAsync(jobId, CancellationToken.None);
 
             // Assert
             var pump = Assert.IsType<TestMessagePump>(hostedService);
@@ -85,7 +85,7 @@ namespace Arcus.Messaging.Tests.Unit.MessagePump
             var duration = TimeSpan.FromSeconds(5);
 
             // Act
-            await lifetime.PauseReceivingMessagesAsync(jobId, duration, CancellationToken.None);
+            await lifetime.PauseProcessingMessagesAsync(jobId, duration, CancellationToken.None);
 
             // Assert
             var pump = Assert.IsType<TestMessagePump>(hostedService);

--- a/src/Arcus.Messaging.Tests.Unit/MessagePump/DefaultMessagePumpLifetimeTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessagePump/DefaultMessagePumpLifetimeTests.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.Messaging.Pumps.Abstractions;
+using Arcus.Messaging.Tests.Unit.MessagePump.Fixture;
+using Arcus.Testing.Logging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Polly;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Arcus.Messaging.Tests.Unit.MessagePump
+{
+    public class DefaultMessagePumpLifetimeTests
+    {
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultMessagePumpLifetimeTests" /> class.
+        /// </summary>
+        public DefaultMessagePumpLifetimeTests(ITestOutputHelper outputWriter)
+        {
+            _logger = new XunitTestLogger(outputWriter);
+        }
+
+        [Fact]
+        public async Task StopPump_ViaLifetime_Succeeds()
+        {
+            // Arrange
+            string jobId = Guid.NewGuid().ToString();
+            var services = new ServiceCollection();
+            services.AddMessagePump(serviceProvider => new TestMessagePump(jobId, Mock.Of<IConfiguration>(), serviceProvider, _logger));
+            IServiceProvider provider = services.BuildServiceProvider();
+            var hostedService = provider.GetRequiredService<IHostedService>();
+            await hostedService.StartAsync(CancellationToken.None);
+
+            var lifetime = new DefaultMessagePumpLifetime(provider);
+
+            // Act
+            await lifetime.StopReceivingMessagesAsync(jobId, CancellationToken.None);
+
+            // Assert
+            var pump = Assert.IsType<TestMessagePump>(hostedService);
+            Assert.False(pump.IsRunning);
+        }
+
+        [Fact]
+        public async Task StartPump_ViaLifetime_Succeeds()
+        {
+            // Arrange
+            string jobId = Guid.NewGuid().ToString();
+            var services = new ServiceCollection();
+            services.AddMessagePump(serviceProvider => new TestMessagePump(jobId, Mock.Of<IConfiguration>(), serviceProvider, _logger));
+            IServiceProvider provider = services.BuildServiceProvider();
+            var hostedService = provider.GetRequiredService<IHostedService>();
+            await hostedService.StopAsync(CancellationToken.None);
+
+            var lifetime = new DefaultMessagePumpLifetime(provider);
+
+            // Act
+            await lifetime.StartReceivingMessagesAsync(jobId, CancellationToken.None);
+
+            // Assert
+            var pump = Assert.IsType<TestMessagePump>(hostedService);
+            Assert.True(pump.IsRunning);
+        }
+
+        [Fact]
+        public async Task PausePump_ViaLifetime_Succeeds()
+        {
+            // Arrange
+            string jobId = Guid.NewGuid().ToString();
+            var services = new ServiceCollection();
+            services.AddMessagePump(serviceProvider => new TestMessagePump(jobId, Mock.Of<IConfiguration>(), serviceProvider, _logger));
+            IServiceProvider provider = services.BuildServiceProvider();
+            var hostedService = provider.GetRequiredService<IHostedService>();
+            await hostedService.StartAsync(CancellationToken.None);
+
+            var lifetime = new DefaultMessagePumpLifetime(provider);
+            var duration = TimeSpan.FromSeconds(5);
+
+            // Act
+            await lifetime.PauseReceivingMessagesAsync(jobId, duration, CancellationToken.None);
+
+            // Assert
+            var pump = Assert.IsType<TestMessagePump>(hostedService);
+            Assert.False(pump.IsRunning);
+
+            Policy.Timeout(duration + TimeSpan.FromSeconds(1))
+                  .Wrap(Policy.Handle<XunitException>()
+                              .WaitAndRetryForever(i => TimeSpan.FromMilliseconds(100)))
+                  .Execute(() => Assert.True(pump.IsRunning));
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Unit/MessagePump/Fixture/TestMessagePump.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessagePump/Fixture/TestMessagePump.cs
@@ -15,7 +15,7 @@ namespace Arcus.Messaging.Tests.Unit.MessagePump.Fixture
             ILogger logger) 
             : base(configuration, serviceProvider, logger)
         {
-            Id = jobId;
+            JobId = jobId;
             IsRunning = false;
         }
 

--- a/src/Arcus.Messaging.Tests.Unit/MessagePump/Fixture/TestMessagePump.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessagePump/Fixture/TestMessagePump.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Arcus.Messaging.Tests.Unit.MessagePump.Fixture
+{
+    public class TestMessagePump : Pumps.Abstractions.MessagePump
+    {
+        public TestMessagePump(
+            string jobId,
+            IConfiguration configuration, 
+            IServiceProvider serviceProvider, 
+            ILogger logger) 
+            : base(configuration, serviceProvider, logger)
+        {
+            Id = jobId;
+            IsRunning = false;
+        }
+
+        public bool IsRunning { get; private set; }
+
+        public override async Task StartAsync(CancellationToken cancellationToken)
+        {
+            Logger.LogInformation("Start test message pump");
+            await base.StartAsync(cancellationToken);
+            IsRunning = true;
+        }
+
+        protected override Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            Logger.LogInformation("Execute test message pump");
+            return Task.CompletedTask;
+        }
+
+        public override async Task StopAsync(CancellationToken cancellationToken)
+        {
+            Logger.LogInformation("Stop test message pump");
+            await base.StopAsync(cancellationToken);
+            IsRunning = false;
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Unit/MessagePump/Fixture/TestMessagePump.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessagePump/Fixture/TestMessagePump.cs
@@ -21,7 +21,7 @@ namespace Arcus.Messaging.Tests.Unit.MessagePump.Fixture
 
         public bool IsRunning { get; private set; }
 
-        public override async Task StartAsync(CancellationToken cancellationToken)
+        public override async Task StartProcessingMessagesAsync(CancellationToken cancellationToken)
         {
             Logger.LogInformation("Start test message pump");
             await base.StartAsync(cancellationToken);
@@ -34,7 +34,7 @@ namespace Arcus.Messaging.Tests.Unit.MessagePump.Fixture
             return Task.CompletedTask;
         }
 
-        public override async Task StopAsync(CancellationToken cancellationToken)
+        public override async Task StopProcessingMessagesAsync(CancellationToken cancellationToken)
         {
             Logger.LogInformation("Stop test message pump");
             await base.StopAsync(cancellationToken);


### PR DESCRIPTION
Add an `IMessagePumpLifetime` component that controls the message processing of registered message pumps so that the consumer can pause the message processing when the dependent downstream component can't keep up.

Closes #54