### PR TITLE
chore: use `main` in CI build trigger

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -6,7 +6,7 @@ name: $(date:yyyyMMdd)$(rev:.r)
 trigger:
   branches:
     include:
-      - master
+      - main
   paths:
     include:
       - src/*


### PR DESCRIPTION
Use the updated `main` in the CI build trigger.

Relates to https://github.com/arcus-azure/arcus/issues/169