### PR TITLE
docs: correct introduction

### DIFF
--- a/docs/preview/01-index.md
+++ b/docs/preview/01-index.md
@@ -6,8 +6,7 @@ sidebar_label: Welcome
 ---
 
 # Introduction
-Arcus Messaging is a library that helps with the integration of messaging systems like queues or event subscriptions, with application message handling that describes the business.
-The library makes sure that developers only have to concern themselves with the actual processing of messages instead of spending time with message peaking, connections, deserialization, and other infrastructure code that takes up time.
+Arcus Messaging is a library that helps with the integration of messaging systems like queues or event subscriptions and allows you to focus on implementing business logic when processing messages instead of spending time with message peaking, connections, deserialization, and other infrastructure code that takes up time.
 
 ## Guides
 * Migrate from v0.x to v1.0 ([docs](./03-Guides/migration-guide-v1.0.md))

--- a/docs/versioned_docs/version-v1.3.0/01-index.md
+++ b/docs/versioned_docs/version-v1.3.0/01-index.md
@@ -6,8 +6,7 @@ sidebar_label: Welcome
 ---
 
 # Introduction
-Arcus Messaging is a library that helps with the integration of messaging systems like queues or event subscriptions, with application message handling that describes the business.
-The library makes sure that developers only have to concern themselves with the actual processing of messages instead of spending time with message peaking, connections, deserialization, and other infrastructure code that takes up time.
+Arcus Messaging is a library that helps with the integration of messaging systems like queues or event subscriptions and allows you to focus on implementing business logic when processing messages instead of spending time with message peaking, connections, deserialization, and other infrastructure code that takes up time.
 
 ## Guides
 * Migrate from v0.x to v1.0 ([docs](./03-Guides/migration-guide-v1.0.md))


### PR DESCRIPTION
Correct the introduction section in both the preview and published docs so it is in line with the component descriptions on the general site.

Relates to https://github.com/arcus-azure/arcus/pull/278