### PR TITLE
feat: use scoped message handlers via pumps/routers

### DIFF
--- a/docs/preview/02-Features/04-service-bus-extensions.md
+++ b/docs/preview/02-Features/04-service-bus-extensions.md
@@ -168,6 +168,10 @@ This information can be access in a more simplified way:
 
 ```csharp
 using Arcus.Messaging.Abstractions;
+using Azure.Messaging.ServiceBus;
+
+// Creates a new messaging context from the message, using an unique job ID to identify all message handlers that can handle this specific context.
+AzureServiceBusMessageContext messageContext = message.GetMessageContext("my-job-id");
 
 // Extract the encoding information from the `.ApplicationProperties` and wrapped inside a valid `Encoding` type.
 MessageContext messageContext = ...

--- a/docs/preview/02-Features/05-event-hubs-extensions.md
+++ b/docs/preview/02-Features/05-event-hubs-extensions.md
@@ -166,12 +166,13 @@ This information can be access in a more simplified way:
 
 ```csharp
 using Arcus.Messaging.Abstractions;
+using Azure.Messaging.EventHubs;
 
 EventProcessorClient processor = ... // Client that receives the message.
 EventData message = ... // The received message.
 
-// Creates a new messaging context from the message <> processor
-AzureEventHubsMessageContext messageContext = message.GetMessageContext(processor);
+// Creates a new messaging context from the message and processor, using an unique job ID to identify all message handlers that can handle this specific context.
+AzureEventHubsMessageContext messageContext = message.GetMessageContext(processor, "my-job-id");
 
 // Extract the encoding information from the `.Properties` and wrapped inside a valid `Encoding` type.
 Encoding encoding = messageContext.GetMessageEncodingProperty();

--- a/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/EventDataExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/EventDataExtensions.cs
@@ -16,6 +16,7 @@ namespace Azure.Messaging.EventHubs
         /// <param name="message">The consumed Azure EventHubs event to describe the messaging context.</param>
         /// <param name="eventProcessor">The Azure EventHubs processor that received the <paramref name="message"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> or the <paramref name="eventProcessor"/> is <c>null</c>.</exception>
+        [Obsolete("Use the other extension method with the job ID to link this message context to a message pump")]
         public static AzureEventHubsMessageContext GetMessageContext(this EventData message, EventProcessorClient eventProcessor)
         {
             Guard.NotNull(message, nameof(message), "Requires an event data to retrieve the Azure EventHubs message context");
@@ -37,6 +38,7 @@ namespace Azure.Messaging.EventHubs
         /// <exception cref="ArgumentException">
         ///     Thrown when the <paramref name="eventHubsNamespace"/>, or <paramref name="eventHubsName"/> is blank.
         /// </exception>
+        [Obsolete("Use the other extension method with the job ID to link this message context to a message pump")]
         public static AzureEventHubsMessageContext GetMessageContext(this EventData message, string eventHubsNamespace, string eventHubsName)
         {
             Guard.NotNull(message, nameof(message), "Requires an event data to retrieve the Azure EventHubs message context");
@@ -60,6 +62,7 @@ namespace Azure.Messaging.EventHubs
         /// <exception cref="ArgumentException">
         ///     Thrown when the <paramref name="eventHubsNamespace"/>, <paramref name="consumerGroup"/>, or <paramref name="eventHubsName"/> is blank.
         /// </exception>
+        [Obsolete("Use the other extension method with the job ID to link this message context to a message pump")]
         public static AzureEventHubsMessageContext GetMessageContext(this EventData message, string eventHubsNamespace, string eventHubsName, string consumerGroup)
         {
             Guard.NotNull(message, nameof(message), "Requires an event data to retrieve the Azure EventHubs message context");
@@ -68,6 +71,49 @@ namespace Azure.Messaging.EventHubs
             Guard.NotNullOrWhitespace(consumerGroup, nameof(consumerGroup), "Requires an Azure EventHubs consumer group to built-up the message context");
 
             return AzureEventHubsMessageContext.CreateFrom(message, eventHubsNamespace, consumerGroup, eventHubsName);
+        }
+
+        /// <summary>
+        /// Gets the message contextual information from the received <paramref name="message"/>.
+        /// </summary>
+        /// <param name="message">The consumed Azure EventHubs event to describe the messaging context.</param>
+        /// <param name="eventProcessor">The Azure EventHubs processor that received the <paramref name="message"/>.</param>
+        /// <param name="jobId">The unique identifier of the message pump that processes the message.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> or the <paramref name="eventProcessor"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
+        public static AzureEventHubsMessageContext GetMessageContext(this EventData message, EventProcessorClient eventProcessor, string jobId)
+        {
+            Guard.NotNull(message, nameof(message), "Requires an event data to retrieve the Azure EventHubs message context");
+            Guard.NotNull(eventProcessor, nameof(eventProcessor), "Requires an Azure EventHubs event processor to retrieve the information to create a messaging context for the consumed event");
+            Guard.NotNullOrWhitespace(jobId, nameof(jobId), "Requires a non-blank job ID to link this message context to a message pump that processes the event message");
+
+            return AzureEventHubsMessageContext.CreateFrom(message, eventProcessor, jobId);
+        }
+
+        /// <summary>
+        /// Gets the message contextual information from the received <paramref name="message"/>.
+        /// </summary>
+        /// <param name="message">The consumed Azure EventHubs event to describe the messaging context.</param>
+        /// <param name="eventHubsNamespace">
+        ///     The fully qualified Event Hubs namespace that the processor is associated with.
+        ///     This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.
+        /// </param>
+        /// <param name="eventHubsName"> The name of the Event Hub that the processor is connected to, specific to the EventHubs namespace that contains it.</param>
+        /// <param name="consumerGroup">The name of the consumer group this event processor is associated with.</param>
+        /// <param name="jobId">The unique identifier of the message pump that processes the message.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">
+        ///     Thrown when the <paramref name="eventHubsNamespace"/>, <paramref name="consumerGroup"/>, <paramref name="eventHubsName"/>, or <paramref name="jobId"/> is blank.
+        /// </exception>
+        public static AzureEventHubsMessageContext GetMessageContext(this EventData message, string eventHubsNamespace, string eventHubsName, string consumerGroup, string jobId)
+        {
+            Guard.NotNull(message, nameof(message), "Requires an event data to retrieve the Azure EventHubs message context");
+            Guard.NotNullOrWhitespace(eventHubsNamespace, nameof(eventHubsNamespace), "Requires an Azure EventHubs namespace to built-up the message context");
+            Guard.NotNullOrWhitespace(eventHubsName, nameof(eventHubsName), "Requires an Azure EventHubs name to built-up the message context");
+            Guard.NotNullOrWhitespace(consumerGroup, nameof(consumerGroup), "Requires an Azure EventHubs consumer group to built-up the message context");
+            Guard.NotNullOrWhitespace(jobId, nameof(jobId), "Requires a non-blank job ID to link this message context to a message pump that processes the event message");
+
+            return AzureEventHubsMessageContext.CreateFrom(message, eventHubsNamespace, consumerGroup, eventHubsName, jobId);
         }
     }
 }

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/AzureServiceBusMessageContext.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/AzureServiceBusMessageContext.cs
@@ -24,14 +24,13 @@ namespace Arcus.Messaging.Abstractions.ServiceBus
             string jobId,
             AzureServiceBusSystemProperties systemProperties,
             IReadOnlyDictionary<string, object> properties)
-            : base(messageId, properties.ToDictionary(item => item.Key, item => item.Value))
+            : base(messageId, jobId, properties.ToDictionary(item => item.Key, item => item.Value))
         {
             Guard.NotNullOrWhitespace(messageId, nameof(messageId), "Requires an ID to identify the message");
             Guard.NotNullOrWhitespace(jobId, nameof(jobId), "Requires an job ID that is not blank to identify the message pump");
             Guard.NotNull(systemProperties, nameof(systemProperties), "Requires a set of system properties provided by the Azure Service Bus runtime");
             Guard.NotNull(properties, nameof(properties), "Requires contextual properties provided by the message publisher");
 
-            JobId = jobId;
             SystemProperties = systemProperties;
             LockToken = systemProperties.LockToken;
             DeliveryCount = systemProperties.DeliveryCount;
@@ -52,10 +51,5 @@ namespace Arcus.Messaging.Abstractions.ServiceBus
         /// </summary>
         /// <remarks>This increases when a message is abandoned and re-delivered for processing</remarks>
         public int DeliveryCount { get; }
-
-        /// <summary>
-        ///     Gets the unique ID on which message pump tis message was processed.
-        /// </summary>
-        public string JobId { get; }
     }
 }

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/ServiceBusMessageHandlerExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/ServiceBusMessageHandlerExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using Arcus.Messaging.Abstractions.MessageHandling;
 using Arcus.Messaging.Abstractions.ServiceBus;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
+using Azure.Messaging.ServiceBus;
 using GuardNet;
 
 // ReSharper disable once CheckNamespace
@@ -61,11 +61,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="handlers"/> is <c>null</c>.</exception>
         public static ServiceBusMessageHandlerCollection WithServiceBusFallbackMessageHandler<TMessageHandler>(
             this ServiceBusMessageHandlerCollection handlers)
-            where TMessageHandler : class, IAzureServiceBusFallbackMessageHandler
+            where TMessageHandler : IAzureServiceBusFallbackMessageHandler
         {
             Guard.NotNull(handlers, nameof(handlers), "Requires a handlers collection to add the Azure Service Bus fallback message handler to");
 
-            handlers.Services.AddTransient<IAzureServiceBusFallbackMessageHandler, TMessageHandler>();
+            handlers.WithServiceBusFallbackMessageHandler(serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
             return handlers;
         }
 
@@ -79,12 +79,12 @@ namespace Microsoft.Extensions.DependencyInjection
         public static ServiceBusMessageHandlerCollection WithServiceBusFallbackMessageHandler<TMessageHandler>(
             this ServiceBusMessageHandlerCollection handlers,
             Func<IServiceProvider, TMessageHandler> createImplementation)
-            where TMessageHandler : class, IAzureServiceBusFallbackMessageHandler
+            where TMessageHandler : IAzureServiceBusFallbackMessageHandler
         {
             Guard.NotNull(handlers, nameof(handlers), "Requires a handlers collection to add the fallback message handler to");
             Guard.NotNull(createImplementation, nameof(createImplementation), "Requires a function to create the fallback message handler");
 
-            handlers.Services.AddTransient<IAzureServiceBusFallbackMessageHandler, TMessageHandler>(createImplementation);
+            handlers.AddFallbackMessageHandler<TMessageHandler, ServiceBusReceivedMessage, AzureServiceBusMessageContext>(createImplementation);
             return handlers;
         }
     }

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
@@ -8,11 +8,11 @@ using Arcus.Observability.Telemetry.Core;
 using Arcus.Messaging.Abstractions.Telemetry;
 using Azure.Messaging.ServiceBus;
 using GuardNet;
-using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Serilog.Context;
+using ServiceBusFallbackMessageHandler = Arcus.Messaging.Abstractions.MessageHandling.FallbackMessageHandler<Azure.Messaging.ServiceBus.ServiceBusReceivedMessage, Arcus.Messaging.Abstractions.ServiceBus.AzureServiceBusMessageContext>;
 
 namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
 {
@@ -21,8 +21,6 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
     /// </summary>
     public class AzureServiceBusMessageRouter : MessageRouter, IAzureServiceBusMessageRouter
     {
-        private readonly Lazy<IAzureServiceBusFallbackMessageHandler> _fallbackMessageHandler;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureServiceBusMessageRouter"/> class.
         /// </summary>
@@ -95,8 +93,6 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         {
             Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires an service provider to retrieve the registered message handlers");
 
-            _fallbackMessageHandler = new Lazy<IAzureServiceBusFallbackMessageHandler>(() => serviceProvider.GetService<IAzureServiceBusFallbackMessageHandler>());
-
             ServiceBusOptions = options;
         }
 
@@ -108,7 +104,12 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         /// <summary>
         /// Gets the flag indicating whether or not the router has an registered <see cref="IAzureServiceBusFallbackMessageHandler"/> instance.
         /// </summary>
-        protected bool HasAzureServiceBusFallbackHandler => _fallbackMessageHandler.Value != null;
+        [Obsolete("Use the " + nameof(GetAvailableFallbackMessageHandlersByContext) + " instead to determine whether a fallback message handler is available for your message context")]
+        protected bool HasAzureServiceBusFallbackHandler => 
+            throw new NotImplementedException(
+                "Because the message handlers are now registered within the scope of the message pump/router, " 
+                + "determining whether a fallback message handler is available or not is only possible when providing a Job ID to identify the message pump/router, " 
+                + $"please use the {nameof(GetAvailableFallbackMessageHandlersByContext)} to determine the available fallback message handlers for your message context");
 
         /// <summary>
         /// Handle a new <paramref name="message"/> that was received by routing them through registered <see cref="IMessageHandler{TMessage,TMessageContext}"/>s
@@ -278,7 +279,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
             try
             {
                 MessageHandler[] messageHandlers = GetRegisteredMessageHandlers(serviceProvider).ToArray();
-                EnsureAnyMessageHandlerAvailable(messageHandlers);
+                EnsureAnyMessageHandlerAvailable(messageHandlers, messageContext);
 
                 Encoding encoding = messageContext.GetMessageEncodingProperty(Logger);
                 string messageBody = encoding.GetString(message.Body.ToArray());
@@ -301,7 +302,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
                     }
                 }
 
-                EnsureFallbackMessageHandlerAvailable();
+                EnsureFallbackMessageHandlerAvailable(messageContext);
                 await TryFallbackProcessMessageAsync(messageBody, messageContext, correlationInfo, cancellationToken);
                 await TryServiceBusFallbackMessageAsync(messageReceiver, message, messageContext, correlationInfo, cancellationToken);
             }
@@ -312,9 +313,15 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
             }
         }
 
-        private void EnsureAnyMessageHandlerAvailable(MessageHandler[] messageHandlers)
+        private void EnsureAnyMessageHandlerAvailable(MessageHandler[] messageHandlers, AzureServiceBusMessageContext messageContext)
         {
-            if (messageHandlers.Length <= 0 && !HasFallbackMessageHandler && !HasAzureServiceBusFallbackHandler)
+            ServiceBusFallbackMessageHandler[] serviceBusFallbackHandlers = 
+                GetAvailableFallbackMessageHandlersByContext<ServiceBusReceivedMessage, AzureServiceBusMessageContext>(messageContext);
+
+            FallbackMessageHandler<string, MessageContext>[] generalFallbackHandlers = 
+                GetAvailableFallbackMessageHandlersByContext<string, MessageContext>(messageContext);
+
+            if (messageHandlers.Length <= 0 && serviceBusFallbackHandlers.Length <= 0 && generalFallbackHandlers.Length <= 0)
             {
                 throw new InvalidOperationException(
                     $"Azure Service Bus message router cannot correctly process the message in the '{nameof(AzureServiceBusMessageContext)}' "
@@ -324,9 +331,15 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
             }
         }
 
-        private void EnsureFallbackMessageHandlerAvailable()
+        private void EnsureFallbackMessageHandlerAvailable(AzureServiceBusMessageContext messageContext)
         {
-            if (!HasFallbackMessageHandler && !HasAzureServiceBusFallbackHandler)
+            ServiceBusFallbackMessageHandler[] serviceBusFallbackHandlers = 
+                GetAvailableFallbackMessageHandlersByContext<ServiceBusReceivedMessage, AzureServiceBusMessageContext>(messageContext);
+
+            FallbackMessageHandler<string, MessageContext>[] generalFallbackHandlers = 
+                GetAvailableFallbackMessageHandlersByContext<string, MessageContext>(messageContext);
+
+            if (serviceBusFallbackHandlers.Length <= 0 && generalFallbackHandlers.Length <= 0)
             {
                 throw new InvalidOperationException(
                     $"Azure Service Bus message router cannot correctly process the message in the '{nameof(AzureServiceBusMessageContext)}' "
@@ -391,14 +404,23 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
             Guard.NotNull(message, nameof(message), "Requires an Azure Service Bus message to be processed by the registered fallback message handler");
             Guard.NotNull(messageContext, nameof(messageContext), "Requires an Azure Service Bus message context in which the incoming message can be processed");
             Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires an correlation information to correlate between incoming Azure Service Bus messages");
+
+            ServiceBusFallbackMessageHandler[] fallbackHandlers = 
+                GetAvailableFallbackMessageHandlersByContext<ServiceBusReceivedMessage, AzureServiceBusMessageContext>(messageContext);
             
-            if (HasAzureServiceBusFallbackHandler)
+            if (fallbackHandlers.Length <= 0)
             {
-                if (_fallbackMessageHandler.Value is AzureServiceBusMessageHandlerTemplate template)
+                Logger.LogTrace("No Azure Service Bus message handlers found within message context (JobId: {JobId})", messageContext.JobId);
+                return;
+            }
+
+            foreach (ServiceBusFallbackMessageHandler handler in fallbackHandlers)
+            {
+                if (handler.MessageHandlerInstance is AzureServiceBusMessageHandlerTemplate template)
                 {
                     if (messageReceiver is null)
                     {
-                        Logger.LogWarning("Fallback message handler '{MessageHandlerType}' uses specific Azure Service Bus operations, but is unable to be configured during message routing because the message router didn't receive a Azure Service Bus message receiver; use other '{MethodName}' method overload", _fallbackMessageHandler.Value.GetType().Name, nameof(RouteMessageAsync));
+                        Logger.LogWarning("Fallback message handler '{MessageHandlerType}' uses specific Azure Service Bus operations, but is unable to be configured during message routing because the message router didn't receive a Azure Service Bus message receiver; use other '{MethodName}' method overload", handler.MessageHandlerType.Name, nameof(RouteMessageAsync));
                     }
                     else
                     {
@@ -407,10 +429,17 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
                     }
                 }
 
-                string fallbackMessageHandlerTypeName = _fallbackMessageHandler.Value.GetType().Name;
-                Logger.LogTrace("Fallback on registered '{FallbackMessageHandlerType}' because none of the message handlers were able to process the message", fallbackMessageHandlerTypeName);
-                await _fallbackMessageHandler.Value.ProcessMessageAsync(message, messageContext, correlationInfo, cancellationToken);
-                Logger.LogTrace("Fallback message handler '{FallbackMessageHandlerType}' has processed the message", fallbackMessageHandlerTypeName); 
+                string fallbackMessageHandlerTypeName = handler.MessageHandlerType.Name;
+                Logger.LogTrace("Fallback on registered '{FallbackMessageHandlerType}' because none of the message handlers were able to process the message", fallbackMessageHandlerTypeName); 
+                
+                bool result = await handler.ProcessMessageAsync(message, messageContext, correlationInfo, cancellationToken);
+                if (result)
+                {
+                    Logger.LogTrace("Fallback message handler '{FallbackMessageHandlerType}' has processed the message", fallbackMessageHandlerTypeName);
+                    break;
+                }
+
+                Logger.LogTrace("Fallback message handler '{FallbackMessageHandlerType}' was not able to process the message", fallbackMessageHandlerTypeName);
             }
         }
     }

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/IAzureServiceBusFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/IAzureServiceBusFallbackMessageHandler.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
+﻿using Arcus.Messaging.Abstractions.MessageHandling;
 using Azure.Messaging.ServiceBus;
 
 namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
@@ -8,22 +6,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
     /// <summary>
     /// Fallback version of the <see cref="IAzureServiceBusMessageHandler{TMessage}"/> to have a safety net when no handlers are found could process the message.
     /// </summary>
-    public interface IAzureServiceBusFallbackMessageHandler
+    public interface IAzureServiceBusFallbackMessageHandler : IFallbackMessageHandler<ServiceBusReceivedMessage, AzureServiceBusMessageContext>
     {
-        /// <summary>
-        /// Process a new Azure Service Bus message that was received but couldn't be handled by any of the general registered message handlers.
-        /// </summary>
-        /// <param name="message">The Azure Service Bus Message message that was received.</param>
-        /// <param name="messageContext">The context providing more information concerning the processing.</param>
-        /// <param name="correlationInfo">The information concerning correlation of telemetry and processes by using a variety of unique identifiers.</param>
-        /// <param name="cancellationToken">The token to cancel the processing.</param>
-        /// <exception cref="ArgumentNullException">
-        ///     Thrown when the <paramref name="message"/>, the <paramref name="messageContext"/>, or the <paramref name="correlationInfo"/> is <c>null</c>.
-        /// </exception>
-        Task ProcessMessageAsync(
-            ServiceBusReceivedMessage message,
-            AzureServiceBusMessageContext messageContext,
-            MessageCorrelationInfo correlationInfo,
-            CancellationToken cancellationToken);
     }
 }

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageBody.MessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageBody.MessageHandlerCollectionExtensions.cs
@@ -2,7 +2,6 @@
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.MessageHandling;
 using GuardNet;
-using Microsoft.Extensions.Logging;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -105,12 +104,7 @@ namespace Microsoft.Extensions.DependencyInjection
             Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
             Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent services");
 
-            services.Services.AddTransient(
-                serviceProvider => MessageHandler.Create(
-                    implementationFactory(serviceProvider),
-                    messageBodyFilter: messageBodyFilter,
-                    logger: serviceProvider.GetService<ILogger<IMessageHandler<TMessage, TMessageContext>>>()));
-            
+            services.AddMessageHandler(implementationFactory, messageBodyFilter: messageBodyFilter);
             return services;
         }
     }

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageBody.IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageBody.IServiceCollectionExtensions.cs
@@ -2,7 +2,6 @@
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.MessageHandling;
 using GuardNet;
-using Microsoft.Extensions.Logging;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -87,8 +86,8 @@ namespace Microsoft.Extensions.DependencyInjection
             Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
             Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
 
-            return WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
-                services, messageContextFilter, messageBodyFilter, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
+            return services.WithMessageHandler(
+                messageContextFilter, messageBodyFilter, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
         }
 
         /// <summary>
@@ -117,13 +116,7 @@ namespace Microsoft.Extensions.DependencyInjection
             Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
             Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent services");
 
-            services.Services.AddTransient(
-                serviceProvider => MessageHandler.Create(
-                    messageHandler: implementationFactory(serviceProvider),
-                    messageContextFilter: messageContextFilter, 
-                    messageBodyFilter: messageBodyFilter,
-                    logger: serviceProvider.GetService<ILogger<IMessageHandler<TMessage, TMessageContext>>>()));
-
+            services.AddMessageHandler(implementationFactory, messageBodyFilter, messageContextFilter);
             return services;
         }
     }

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageHandlerCollectionExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Microsoft.Extensions.Logging;
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.MessageHandling;
 using GuardNet;
@@ -105,12 +104,7 @@ namespace Microsoft.Extensions.DependencyInjection
             Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
             Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent services");
 
-            services.Services.AddTransient(
-                serviceProvider => MessageHandler.Create(
-                    messageHandler: implementationFactory(serviceProvider), 
-                    messageContextFilter: messageContextFilter,
-                    logger: serviceProvider.GetService<ILogger<IMessageHandler<TMessage, TMessageContext>>>()));
-            
+            services.AddMessageHandler(implementationFactory, messageContextFilter: messageContextFilter);
             return services;
         }
     }

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageSerializer.MessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageSerializer.MessageHandlerCollectionExtensions.cs
@@ -2,7 +2,6 @@
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.MessageHandling;
 using GuardNet;
-using Microsoft.Extensions.Logging;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -166,14 +165,8 @@ namespace Microsoft.Extensions.DependencyInjection
             Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
             Guard.NotNull(messageHandlerImplementationFactory, nameof(messageHandlerImplementationFactory), "Requires a function to create the message handler with dependent services");
 
-            services.Services.AddTransient(
-                serviceProvider => MessageHandler.Create(
-                    messageHandler: messageHandlerImplementationFactory(serviceProvider),
-                    messageContextFilter: messageContextFilter,
-                    messageBodySerializer: messageBodySerializer,
-                    logger: serviceProvider.GetService<ILogger<IMessageHandler<TMessage, TMessageContext>>>()));
-
-            return services;
+            return services.WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
+                messageContextFilter: messageContextFilter, messageBodySerializerImplementationFactory: _ => messageBodySerializer, messageHandlerImplementationFactory);
         }
 
         /// <summary>
@@ -227,13 +220,11 @@ namespace Microsoft.Extensions.DependencyInjection
             Guard.NotNull(messageHandlerImplementationFactory, nameof(messageHandlerImplementationFactory), "Requires a function to create the message handler with dependent services");
             Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create an custom message body serializer to deserialize the incoming message for the message handler");
 
-            services.Services.AddTransient(
-                serviceProvider => MessageHandler.Create(
-                    messageHandler: messageHandlerImplementationFactory(serviceProvider),
-                    messageContextFilter: messageContextFilter,
-                    messageBodySerializer: messageBodySerializerImplementationFactory(serviceProvider),
-                    logger: serviceProvider.GetService<ILogger<IMessageHandler<TMessage, TMessageContext>>>()));
-
+            services.AddMessageHandler(
+                messageHandlerImplementationFactory, 
+                messageContextFilter: messageContextFilter, 
+                implementationFactoryMessageBodySerializer: messageBodySerializerImplementationFactory);
+            
             return services;
         }
     }

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageSerializer.MessageBody.IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageSerializer.MessageBody.IServiceCollectionExtensions.cs
@@ -2,7 +2,6 @@
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.MessageHandling;
 using GuardNet;
-using Microsoft.Extensions.Logging;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -197,14 +196,10 @@ namespace Microsoft.Extensions.DependencyInjection
             Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
             Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent services");
 
-            services.Services.AddTransient(
-                serviceProvider => MessageHandler.Create(
-                    messageHandler: implementationFactory(serviceProvider),
-                    messageBodyFilter: messageBodyFilter,
-                    messageBodySerializer: messageBodySerializer,
-                    logger: serviceProvider.GetService<ILogger<IMessageHandler<TMessage, TMessageContext>>>()));
-
-            return services;
+            return services.WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
+                messageBodySerializerImplementationFactory: _ => messageBodySerializer,
+                messageBodyFilter: messageBodyFilter,
+                messageHandlerImplementationFactory: implementationFactory);
         }
 
         /// <summary>
@@ -233,13 +228,11 @@ namespace Microsoft.Extensions.DependencyInjection
             Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create an custom message body serializer to deserialize the incoming message for the message handler");
             Guard.NotNull(messageHandlerImplementationFactory, nameof(messageHandlerImplementationFactory), "Requires a function to create the message handler with dependent services");
 
-            services.Services.AddTransient(
-                serviceProvider => MessageHandler.Create(
-                    messageHandler: messageHandlerImplementationFactory(serviceProvider),
-                    messageBodyFilter: messageBodyFilter,
-                    messageBodySerializer: messageBodySerializerImplementationFactory(serviceProvider),
-                    logger: serviceProvider.GetService<ILogger<IMessageHandler<TMessage, TMessageContext>>>()));
-
+            services.AddMessageHandler(
+                messageHandlerImplementationFactory, 
+                messageBodyFilter, 
+                implementationFactoryMessageBodySerializer: messageBodySerializerImplementationFactory);
+            
             return services;
         }
     }

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageSerializer.MessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageSerializer.MessageHandlerCollectionExtensions.cs
@@ -2,7 +2,6 @@
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.MessageHandling;
 using GuardNet;
-using Microsoft.Extensions.Logging;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -100,13 +99,9 @@ namespace Microsoft.Extensions.DependencyInjection
             Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent services");
             Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
 
-            services.Services.AddTransient(
-                serviceProvider => MessageHandler.Create(
-                    messageHandler: implementationFactory(arg: serviceProvider),
-                    messageBodySerializer: messageBodySerializer,
-                    logger: serviceProvider.GetService<ILogger<IMessageHandler<TMessage, TMessageContext>>>()));
-
-            return services;
+            return services.WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
+                messageBodySerializerImplementationFactory: _ => messageBodySerializer, 
+                messageHandlerImplementationFactory: implementationFactory);
         }
 
         /// <summary>
@@ -199,12 +194,7 @@ namespace Microsoft.Extensions.DependencyInjection
             Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create an custom message body serializer instance to deserialize incoming message for the message handler");
             Guard.NotNull(messageHandlerImplementationFactory, nameof(messageHandlerImplementationFactory), "Requires a function to create the message handler with dependent services");
 
-            services.Services.AddTransient(
-                serviceProvider => MessageHandler.Create(
-                    messageHandler: messageHandlerImplementationFactory(serviceProvider),
-                    messageBodySerializer: messageBodySerializerImplementationFactory(serviceProvider),
-                    logger: serviceProvider.GetService<ILogger<IMessageHandler<TMessage, TMessageContext>>>()));
-
+            services.AddMessageHandler(messageHandlerImplementationFactory, implementationFactoryMessageBodySerializer: messageBodySerializerImplementationFactory);
             return services;
         }
     }

--- a/src/Arcus.Messaging.Abstractions/MessageContext.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageContext.cs
@@ -1,28 +1,21 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using GuardNet;
 
 namespace Arcus.Messaging.Abstractions
 {
     /// <summary>
-    ///     Contextual information concerning a message
+    /// Represents the contextual information concerning a message that will be processed by a message pump.
     /// </summary>
     public class MessageContext
     {
         /// <summary>
-        ///     Unique identifier of the message
+        /// Initializes a new instance of the <see cref="MessageContext"/> class.
         /// </summary>
-        public string MessageId { get; }
-
-        /// <summary>
-        ///     Contextual properties provided on the message
-        /// </summary>
-        public IDictionary<string, object> Properties { get; }
-
-        /// <summary>
-        ///     Constructor
-        /// </summary>
-        /// <param name="messageId">Unique identifier of the message</param>
-        /// <param name="properties">Contextual properties provided on the message</param>
+        /// <param name="messageId">The unique identifier of the message.</param>
+        /// <param name="properties">The contextual properties provided on the message.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="messageId"/> is blank.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="properties"/> is <c>null</c>.</exception>
         public MessageContext(string messageId, IDictionary<string, object> properties)
         {
             Guard.NotNullOrEmpty(messageId, nameof(messageId));
@@ -31,5 +24,39 @@ namespace Arcus.Messaging.Abstractions
             MessageId = messageId;
             Properties = properties;
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessageContext"/> class.
+        /// </summary>
+        /// <param name="messageId">The unique identifier of the message.</param>
+        /// <param name="jobId">The unique identifier of the message pump that processes the message.</param>
+        /// <param name="properties">The contextual properties provided on the message.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="messageId"/> or the <paramref name="jobId"/> is blank.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="properties"/> is <c>null</c>.</exception>
+        public MessageContext(string messageId, string jobId, IDictionary<string, object> properties)
+        {
+            Guard.NotNullOrEmpty(messageId, nameof(messageId));
+            Guard.NotNullOrWhitespace(jobId, nameof(jobId));
+            Guard.NotNull(properties, nameof(properties));
+
+            MessageId = messageId;
+            JobId = jobId;
+            Properties = properties;
+        }
+
+        /// <summary>
+        /// Gets unique identifier of the message.
+        /// </summary>
+        public string MessageId { get; }
+
+        /// <summary>
+        /// Gets the unique ID on which message pump this message was processed.
+        /// </summary>
+        public string JobId { get; }
+
+        /// <summary>
+        /// Gets the contextual properties provided on the message.
+        /// </summary>
+        public IDictionary<string, object> Properties { get; }
     }
 }

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/FallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/FallbackMessageHandler.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using GuardNet;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Arcus.Messaging.Abstractions.MessageHandling
+{
+    /// <summary>
+    /// Represents a general message handler used to run a fallback action when the regular message handlers weren't able to handle the message.
+    /// </summary>
+    /// <typeparam name="TMessage">The type of the message that this fallback message handler can handle.</typeparam>
+    /// <typeparam name="TMessageContext">The type of the context in which the message is being processed.</typeparam>
+    public class FallbackMessageHandler<TMessage, TMessageContext> 
+        where TMessage : class
+        where TMessageContext : MessageContext
+    {
+        private readonly string _jobId;
+        private readonly ILogger _logger;
+
+        private FallbackMessageHandler(
+            IFallbackMessageHandler<TMessage, TMessageContext> messageHandlerInstance,
+            string jobId,
+            ILogger logger)
+        {
+            Guard.NotNull(messageHandlerInstance, nameof(messageHandlerInstance));
+
+            _jobId = jobId;
+            _logger = logger ?? NullLogger.Instance;
+            MessageHandlerType = messageHandlerInstance.GetType();
+            MessageHandlerInstance = messageHandlerInstance;
+        }
+
+        /// <summary>
+        /// Gets the type of the registered fallback message handler instance.
+        /// </summary>
+        public Type MessageHandlerType { get; }
+
+        /// <summary>
+        /// Gets the object instance of the registered fallback message handler.
+        /// </summary>
+        public IFallbackMessageHandler<TMessage, TMessageContext> MessageHandlerInstance { get; }
+
+        /// <summary>
+        /// Creates a general <see cref="FallbackMessageHandler{TMessage,TMessageContext}"/> via the message handler instance.
+        /// </summary>
+        /// <param name="messageHandlerInstance">The fallback message handler instance.</param>
+        /// <param name="jobId">The job ID to link this fallback message handler to a registered message pump.</param>
+        /// <param name="logger">The logger instance to write diagnostic trace messages during the fallback message processing.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="messageHandlerInstance"/> is <c>null</c>.</exception>
+        internal static FallbackMessageHandler<TMessage, TMessageContext> Create(
+            IFallbackMessageHandler<TMessage, TMessageContext> messageHandlerInstance,
+            string jobId,
+            ILogger<IFallbackMessageHandler<TMessage, TMessageContext>> logger)
+        {
+            Guard.NotNull(messageHandlerInstance, nameof(messageHandlerInstance), "Requires the original instance of the fallback message handler");
+            return new FallbackMessageHandler<TMessage, TMessageContext>(messageHandlerInstance, jobId, logger);
+        }
+
+        /// <summary>
+        /// Determines if the given <typeparamref name="TMessageContext"/> matches the generic parameter of this message handler.
+        /// </summary>
+        /// <param name="messageContext">The context in which the incoming message is processed.</param>
+        public bool CanProcessMessageBasedOnContext(TMessageContext messageContext)
+        {
+            Guard.NotNull(messageContext, nameof(messageContext), "Requires an message context instance to determine if the fallback message handler can process the message");
+           
+            return _jobId is null || messageContext.JobId == _jobId;
+        }
+
+        /// <summary>
+        /// Processes a <paramref name="message"/> in a <paramref name="messageContext"/> with a fallback operation.
+        /// </summary>
+        /// <param name="message">The message that was not be able to be processed by the regular message handlers.</param>
+        /// <param name="messageContext">The message context in which the incoming <paramref name="message"/> is processed.</param>
+        /// <param name="correlationInfo">The information concerning correlation of telemetry and processes by using a variety of unique identifiers.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the fallback processing.</param>
+        /// <returns>
+        ///     [true] when the fallback message handler was able to process the <paramref name="message"/> in the <paramref name="messageContext"/>; [false] otherwise.
+        /// </returns>
+        public async Task<bool> ProcessMessageAsync(
+            TMessage message,
+            TMessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            Guard.NotNull(message, nameof(message), "Requires message content to process the message fallback operation");
+            Guard.NotNull(messageContext, nameof(messageContext), "Requires a message context to send to the fallback message handler");
+            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires correlation information to send to the fallback message handler");
+
+            if (CanProcessMessageBasedOnContext(messageContext))
+            {
+                await MessageHandlerInstance.ProcessMessageAsync(message, messageContext, correlationInfo, cancellationToken);
+                return true;
+            }
+
+            _logger.LogTrace("Fallback message handler '{FallbackMessageHandlerType}' cannot handle message because it was not registered in the correct message context (JobId: {JobId})", MessageHandlerType.Name, _jobId);
+            return false;
+        }
+    }
+}

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/IFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/IFallbackMessageHandler.cs
@@ -1,27 +1,46 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Arcus.Messaging.Abstractions.MessageHandling
 {
     /// <summary>
-    /// Fallback version of the <see cref="IMessageHandler{TMessage,TMessageContext}"/> to have a safety net when no handlers are found could process the message.
+    /// Fallback version of the <see cref="IMessageHandler{TMessage,TMessageContext}"/> to have a safety net when no message handlers are able to process the message.
     /// </summary>
-    public interface IFallbackMessageHandler
+    /// <typeparam name="TMessage">The type of the message that this fallback message handler can handle.</typeparam>
+    /// <typeparam name="TMessageContext">The type of the context in which the message is being processed.</typeparam>
+    public interface IFallbackMessageHandler<in TMessage, in TMessageContext>
+        where TMessage : class
+        where TMessageContext : MessageContext
     {
         /// <summary>
-        ///     Process a new message that was received
+        /// Process a <paramref name="message"/> that was received but couldn't be handled by any of the general registered message handlers.
         /// </summary>
         /// <param name="message">The message that was received.</param>
         /// <param name="messageContext">The context providing more information concerning the processing.</param>
-        /// <param name="correlationInfo">
-        ///     The information concerning correlation of telemetry and processes by using a variety of unique
-        ///     identifiers.
-        /// </param>
-        /// <param name="cancellationToken">The cancellation token to cancel the processing.</param>
+        /// <param name="correlationInfo">The information concerning correlation of telemetry and processes by using a variety of unique identifiers.</param>
+        /// <param name="cancellationToken">The token to cancel the processing.</param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="message"/>, the <paramref name="messageContext"/>, or the <paramref name="correlationInfo"/> is <c>null</c>.
+        /// </exception>
         Task ProcessMessageAsync(
-            string message,
-            MessageContext messageContext,
+            TMessage message,
+            TMessageContext messageContext,
             MessageCorrelationInfo correlationInfo,
             CancellationToken cancellationToken);
+    }
+
+    /// <summary>
+    /// Fallback version of the <see cref="IMessageHandler{TMessage,TMessageContext}"/> to have a safety net when no message handlers able to process the message.
+    /// </summary>
+    public interface IFallbackMessageHandler<in TMessage> : IMessageHandler<TMessage, MessageContext>
+    {
+    }
+
+    /// <summary>
+    /// Fallback version of the <see cref="IMessageHandler{TMessage,TMessageContext}"/> to have a safety net when no message handlers able to process the message.
+    /// </summary>
+    public interface IFallbackMessageHandler : IFallbackMessageHandler<string, MessageContext>
+    {
     }
 }

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageHandler.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageHandler.cs
@@ -89,14 +89,17 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// <typeparam name="TMessage">The type of message the <paramref name="messageHandler"/> processes.</typeparam>
         /// <typeparam name="TMessageContext">The type of context the <paramref name="messageHandler"/> processes.</typeparam>
         /// <param name="messageHandler">The user-defined message handler instance.</param>
+        /// <param name="jobId">The job ID to link this message handler to a registered message pump.</param>
         /// <param name="messageBodyFilter">The optional function to filter on the message body before processing.</param>
         /// <param name="messageContextFilter">The optional function to filter on the message context before processing.</param>
         /// <param name="messageBodySerializer">The optional message body serializer instance to customize how the message should be deserialized.</param>
         /// <param name="logger">The logger instance to write diagnostic messages during the message handler interaction.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="messageHandler"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
         internal static MessageHandler Create<TMessage, TMessageContext>(
             IMessageHandler<TMessage, TMessageContext> messageHandler,
             ILogger<IMessageHandler<TMessage, TMessageContext>> logger,
+            string jobId,
             Func<TMessage, bool> messageBodyFilter = null,
             Func<TMessageContext, bool> messageContextFilter = null,
             IMessageBodySerializer messageBodySerializer = null) 
@@ -109,7 +112,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             Type messageHandlerType = messageHandler.GetType();
 
             Func<object, bool> messageFilter = DetermineMessageBodyFilter(messageBodyFilter, messageHandlerType, logger);
-            Func<MessageContext, bool> contextFilter = DetermineMessageContextFilter(messageContextFilter, messageHandlerType, logger);
+            Func<MessageContext, bool> contextFilter = DetermineMessageContextFilter(messageContextFilter, jobId, messageHandlerType, logger);
 
             return new MessageHandler(
                 messageHandlerInstance: messageHandler,
@@ -164,12 +167,18 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
 
         private static Func<MessageContext, bool> DetermineMessageContextFilter<TMessageContext>(
             Func<TMessageContext, bool> messageContextFilter,
+            string jobId,
             Type messageHandlerType,
             ILogger logger)
             where TMessageContext : MessageContext
         {
            return rawContext =>
-            {
+           {
+                if (rawContext is not null && jobId is not null && rawContext.JobId != jobId)
+                {
+                    return false;
+                }
+
                 if (messageContextFilter is null)
                 {
                     return true;
@@ -184,7 +193,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
                     return canProcessMessage;
                 }
 
-                logger.LogTrace("Cannot run message context filter of message handler '{MessageHandler}' for message context '{MessageContext}' because the message is in another context '{OtherMessageContext}'", messageHandlerType, typeof(TMessageContext).Name, rawContext.GetType().Name);
+                logger.LogTrace("Cannot run message context filter of message handler '{MessageHandler}' for message context '{MessageContext}' because the message is in another context '{OtherMessageContext}'", messageHandlerType, typeof(TMessageContext).Name, rawContext?.GetType().Name);
                 return false;
             };
         }

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageHandlerCollection.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageHandlerCollection.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using GuardNet;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Arcus.Messaging.Abstractions.MessageHandling
 {
@@ -31,5 +32,57 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// Gets the current available collection of services to register the message handling logic into.
         /// </summary>
         public IServiceCollection Services { get; }
+
+        /// <summary>
+        /// Adds a general <see cref="MessageHandler"/> instance to the registered application services.
+        /// </summary>
+        /// <typeparam name="TMessage">The type of message the message handler created from the <paramref name="implementationFactory"/> processes.</typeparam>
+        /// <typeparam name="TMessageContext">The type of context the message handler created from the <paramref name="implementationFactory"/> processes.</typeparam>
+        /// <param name="implementationFactory">The function to create an user-defined message handler instance.</param>
+        /// <param name="messageBodyFilter">The optional function to filter on the message body before processing.</param>
+        /// <param name="messageContextFilter">The optional function to filter on the message context before processing.</param>
+        /// <param name="implementationFactoryMessageBodySerializer">The function to create an optional message body serializer instance to customize how the message should be deserialized.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="implementationFactory"/> is <c>null</c>.</exception>
+        internal void AddMessageHandler<TMessage, TMessageContext>(
+            Func<IServiceProvider, IMessageHandler<TMessage, TMessageContext>> implementationFactory,
+            Func<TMessage, bool> messageBodyFilter = null,
+            Func<TMessageContext, bool> messageContextFilter = null,
+            Func<IServiceProvider, IMessageBodySerializer> implementationFactoryMessageBodySerializer = null)
+            where TMessageContext : MessageContext
+        {
+            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create a message handler implementation to register the handler within the application services");
+            
+            Services.AddTransient(
+                serviceProvider => MessageHandler.Create(
+                    implementationFactory(serviceProvider),
+                    serviceProvider.GetService<ILogger<IMessageHandler<TMessage, TMessageContext>>>(),
+                    JobId,
+                    messageBodyFilter,
+                    messageContextFilter,
+                    implementationFactoryMessageBodySerializer?.Invoke(serviceProvider)));
+        }
+
+        /// <summary>
+        /// Adds a general <see cref="FallbackMessageHandler{TMessage,TMessageContext}"/> instance to the registered application services.
+        /// </summary>
+        /// <typeparam name="TMessageHandler">The type of the user-defined fallback message handler.</typeparam>
+        /// <typeparam name="TMessage">The type of the message that this fallback message handler can handle.</typeparam>
+        /// <typeparam name="TMessageContext">The type of the context in which the message is being processed.</typeparam>
+        /// <param name="implementationFactory">The function to create the user-defined fallback message handler instance.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="implementationFactory"/> is <c>null</c>.</exception>
+        public void AddFallbackMessageHandler<TMessageHandler, TMessage, TMessageContext>(
+            Func<IServiceProvider, TMessageHandler> implementationFactory) 
+            where TMessageHandler : IFallbackMessageHandler<TMessage, TMessageContext>
+            where TMessage : class
+            where TMessageContext : MessageContext
+        {
+            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the user-defined fallback message handler");
+
+            Services.AddSingleton(
+                serviceProvider => FallbackMessageHandler<TMessage, TMessageContext>.Create(
+                    implementationFactory(serviceProvider), 
+                    JobId,
+                    serviceProvider.GetService<ILogger<IFallbackMessageHandler<TMessage, TMessageContext>>>()));
+        }
     }
 }

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
@@ -20,8 +20,6 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
     /// </summary>
     public class MessageRouter : IMessageRouter
     {
-        private readonly Lazy<IFallbackMessageHandler> _fallbackMessageHandler;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MessageRouter"/> class.
         /// </summary>
@@ -96,14 +94,17 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             ServiceProvider = serviceProvider;
             Options = options ?? new MessageRouterOptions();
             Logger = logger ?? NullLogger<MessageRouter>.Instance;
-
-            _fallbackMessageHandler = new Lazy<IFallbackMessageHandler>(() => serviceProvider.GetService<IFallbackMessageHandler>());
         }
 
         /// <summary>
         /// Gets the flag indicating whether or not the router can fallback to an <see cref="IFallbackMessageHandler"/> instance.
         /// </summary>
-        protected bool HasFallbackMessageHandler => _fallbackMessageHandler.Value != null;
+        [Obsolete("Use the " + nameof(GetAvailableFallbackMessageHandlersByContext) + " instead to determine whether a fallback message handler is available for your message context")]
+        protected bool HasFallbackMessageHandler => 
+            throw new NotImplementedException(
+                "Because the message handlers are now registered within the scope of the message pump/router, " 
+                + "determining whether a fallback message handler is available or not is only possible when providing a Job ID to identify the message pump/router, " 
+                + $"please use the {nameof(GetAvailableFallbackMessageHandlersByContext)} to determine the available fallback message handlers for your message context");
 
         /// <summary>
         /// Gets the instance that provides all the registered services in the current application.
@@ -261,7 +262,10 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             where TMessageContext : MessageContext
         {
             MessageHandler[] handlers = GetRegisteredMessageHandlers(serviceProvider).ToArray();
-            if (handlers.Length <= 0 && _fallbackMessageHandler.Value is null)
+            FallbackMessageHandler<string, TMessageContext>[] fallbackHandlers = 
+                GetAvailableFallbackMessageHandlersByContext<string, TMessageContext>(messageContext);
+
+            if (handlers.Length <= 0 && fallbackHandlers.Length <= 0)
             {
                 throw new InvalidOperationException(
                     $"Message pump cannot correctly process the message in the '{typeof(TMessageContext).Name}' "
@@ -386,36 +390,90 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         ///     [true] if the received <paramref name="message"/> was handled by the registered <see cref="IFallbackMessageHandler"/>; [false] otherwise.
         /// </returns>
         protected async Task<bool> TryFallbackProcessMessageAsync<TMessageContext>(
-            string message, 
-            TMessageContext messageContext, 
-            MessageCorrelationInfo correlationInfo, 
+            string message,
+            TMessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
             CancellationToken cancellationToken)
             where TMessageContext : MessageContext
         {
             Guard.NotNull(messageContext, nameof(messageContext), "Requires a message context to send to the message handler");
             Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires correlation information to send to the message handler");
 
-            if (HasFallbackMessageHandler)
+            bool isProcessedByTypedContext = await TryFallbackProcessMessageByContextAsync(message, messageContext, correlationInfo, cancellationToken);
+            if (isProcessedByTypedContext)
             {
-                string fallbackMessageHandlerTypeName = _fallbackMessageHandler.Value.GetType().Name;
-
-                Logger.LogTrace("Fallback on registered '{FallbackMessageHandlerType}' because none of the message handlers were able to process the message", fallbackMessageHandlerTypeName);
-
-                Task processMessageAsync = _fallbackMessageHandler.Value.ProcessMessageAsync(message, messageContext, correlationInfo, cancellationToken);
-                if (processMessageAsync is null)
-                {
-                    throw new InvalidOperationException(
-                        $"Cannot fallback upon the fallback message handler '{fallbackMessageHandlerTypeName}' " 
-                        + "because the handler was not correctly implemented to process the message as it returns 'null' for its asynchronous operation");
-                }
-
-                await processMessageAsync;
-                Logger.LogTrace("Fallback message handler '{FallbackMessageHandlerType}' has processed the message", fallbackMessageHandlerTypeName);
-
                 return true;
             }
 
+            bool isProcessedByGeneralContext = await TryFallbackProcessMessageByContextAsync<MessageContext>(message, messageContext, correlationInfo, cancellationToken);
+            return isProcessedByGeneralContext;
+        }
+
+        private async Task<bool> TryFallbackProcessMessageByContextAsync<TMessageContext>(
+            string message,
+            TMessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+            where TMessageContext : MessageContext
+        {
+            FallbackMessageHandler<string, TMessageContext>[] fallbackHandlers =
+                GetAvailableFallbackMessageHandlersByContext<string, TMessageContext>(messageContext);
+
+            if (fallbackHandlers.Length <= 0)
+            {
+                Logger.LogTrace("No fallback message handlers found within message context '{Type}' (JobId: {JobId})", typeof(TMessageContext).Name, messageContext.JobId);
+                return false;
+            }
+
+            foreach (FallbackMessageHandler<string, TMessageContext> fallbackHandler in fallbackHandlers)
+            {
+                string fallbackMessageHandlerTypeName = fallbackHandler.MessageHandlerType.Name;
+
+                Logger.LogTrace("Fallback on registered '{FallbackMessageHandlerType}' because none of the general message handlers were able to process the message", fallbackMessageHandlerTypeName);
+
+                try
+                {
+                    Task<bool> processMessageAsync = fallbackHandler.ProcessMessageAsync(message, messageContext, correlationInfo, cancellationToken);
+                    if (processMessageAsync is null)
+                    {
+                        throw new InvalidOperationException(
+                            $"Cannot fallback upon the general fallback message handler '{fallbackMessageHandlerTypeName}' "
+                            + "because the handler was not correctly implemented to process the message as it returns 'null' for its asynchronous operation");
+                    }
+
+                    bool result = await processMessageAsync;
+                    if (result)
+                    {
+                        Logger.LogTrace("Fallback message handler '{FallbackMessageHandlerType}' has processed the message", fallbackMessageHandlerTypeName);
+                        return true;
+                    }
+
+                    Logger.LogTrace("Fallback message handler '{FallbackMessageHandlerType}' was not able to process the message", fallbackMessageHandlerTypeName);
+                }
+                catch (Exception exception)
+                {
+                    Logger.LogError(exception, "Fallback message handler '{FallbackMessageHandlerType}' was not able to process the message: {Message}", fallbackMessageHandlerTypeName, exception.Message);
+                }
+            }
+
             return false;
+        }
+
+        /// <summary>
+        /// Gets all the available fallback message handlers for this <paramref name="messageContext"/> registered in the application services.
+        /// </summary>
+        /// <param name="messageContext">The message context in which the message is received and where the fallback message handler should take up.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="messageContext"/> is <c>null</c>.</exception>
+        protected FallbackMessageHandler<TMessage, TMessageContext>[] GetAvailableFallbackMessageHandlersByContext<TMessage, TMessageContext>(
+            TMessageContext messageContext)
+            where TMessage : class
+            where TMessageContext : MessageContext
+        {
+            Guard.NotNull(messageContext, nameof(messageContext), "Requires a message context to filter out fallback message handlers that are registered with the same message context's Job ID");
+
+            return ServiceProvider.GetServices<FallbackMessageHandler<TMessage, TMessageContext>>()
+                                  .Where(handler => handler.CanProcessMessageBasedOnContext(messageContext))
+                                  .ToArray();
         }
 
         /// <summary>

--- a/src/Arcus.Messaging.Pumps.EventHubs/AzureEventHubsMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.EventHubs/AzureEventHubsMessagePump.cs
@@ -138,7 +138,7 @@ namespace Arcus.Messaging.Pumps.EventHubs
                 Logger.LogTrace("No operation ID was found on the message '{MessageId}' during processing in the Azure EventHubs message pump '{JobId}'", message.MessageId, JobId);
             }
 
-            AzureEventHubsMessageContext context = args.Data.GetMessageContext(_eventProcessor);
+            AzureEventHubsMessageContext context = args.Data.GetMessageContext(_eventProcessor, JobId);
             using (MessageCorrelationResult result = DetermineMessageCorrelation(args.Data))
             {
                 await _messageRouter.RouteMessageAsync(args.Data, context, result.CorrelationInfo, args.CancellationToken);

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/Worker.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/Worker.cs
@@ -30,17 +30,18 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
         /// Spawns a new test worker configurable with <paramref name="options"/>.
         /// </summary>
         /// <param name="options">The configurable options to influence the content of the test worker.</param>
-        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> or <paramref name="logger"/> is <c>null</c>.</exception>
+        /// <param name="memberName">The automatically assigned calling member to show in the test output logs which test is stated.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
         public static async Task<Worker> StartNewAsync(WorkerOptions options, [CallerMemberName] string memberName = null)
         {
             Guard.NotNull(options, nameof(options), "Requires a options instance that influence the test worker implementation");
             
             Console.WriteLine("Start '{0}' integration test", memberName);
-            
+
             IHostBuilder hostBuilder = Host.CreateDefaultBuilder();
             options.ApplyOptions(hostBuilder);
             IHost host = hostBuilder.Build();
-            
+
             var worker = new Worker(host, memberName);
             await worker._host.StartAsync();
             return worker;

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/WorkerOptions.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/WorkerOptions.cs
@@ -7,10 +7,8 @@ using GuardNet;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Serilog;
 using Xunit.Abstractions;
-using ILogger = Microsoft.Extensions.Logging.ILogger;
 
 namespace Arcus.Messaging.Tests.Integration.Fixture
 {
@@ -55,31 +53,21 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
         {
             Guard.NotNull(logger, nameof(logger), "Requires a logger instance to write diagnostic trace messages to the test output");
 
-            //Services.AddSingleton<ILogger<AzureServiceBusMessagePump>>(_ => new LoggerProxy<AzureServiceBusMessagePump>(logger));
-            //Services.AddSingleton<ILogger<AzureEventHubsMessagePump>>(_ => new LoggerProxy<AzureEventHubsMessagePump>(logger));
-
            _outputWriter = logger;
            return this;
         }
 
+        /// <summary>
+        /// Add a function to configure the Serilog logging in the test worker.
+        /// </summary>
+        /// <param name="configure">The function to configure the Serilog configuration.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="configure"/> is <c>null</c>.</exception>
         public WorkerOptions ConfigureSerilog(Action<LoggerConfiguration> configure)
         {
+            Guard.NotNull(configure, nameof(configure));
+
             _additionalSerilogConfigOptions.Add(configure);
             return this;
-        }
-
-        internal class LoggerProxy<T> : ILogger<T>
-        {
-            private readonly ILogger _implementation;
-
-            internal LoggerProxy(ILogger implementation)
-            {
-                _implementation = implementation;
-            }
-
-            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter) => _implementation.Log(logLevel, eventId, state, exception, formatter);
-            public bool IsEnabled(LogLevel logLevel) => _implementation.IsEnabled(logLevel);
-            public IDisposable BeginScope<TState>(TState state) => _implementation.BeginScope(state);
         }
 
         /// <summary>

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/EventHubsMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/EventHubsMessagePumpTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -27,6 +28,7 @@ using Arcus.Testing.Logging;
 using Azure.Messaging.EventGrid;
 using Azure.Messaging.EventHubs;
 using Bogus;
+using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Azure;
@@ -337,8 +339,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             var spyChannel = new InMemoryTelemetryChannel();
 
             var options = new WorkerOptions();
-            options.ConfigureSerilog(config => config.WriteTo.ApplicationInsights(spySink))
-                   .Configure<TelemetryConfiguration>(conf => conf.TelemetryChannel = spyChannel);
+            options.ConfigureSerilog(config => config.WriteTo.ApplicationInsights(spySink));
 
             EventHubsConfig eventHubs = _config.GetEventHubsConfig();
             AddEventHubsMessagePump(options, eventHubs)
@@ -354,6 +355,8 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             await using (var worker = await Worker.StartNewAsync(options))
             await using (var consumer = await TestServiceBusMessageEventConsumer.StartNewAsync(_config, _logger))
             {
+                worker.Services.GetRequiredService<TelemetryConfiguration>().TelemetryChannel = spyChannel;
+
                 // Act
                 await producer.ProduceAsync(eventData);
 
@@ -378,8 +381,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             var spyChannel = new InMemoryTelemetryChannel();
 
             var options = new WorkerOptions();
-            options.ConfigureSerilog(config => config.WriteTo.ApplicationInsights(spySink))
-                   .Configure<TelemetryConfiguration>(conf => conf.TelemetryChannel = spyChannel);
+            options.ConfigureSerilog(config => config.WriteTo.ApplicationInsights(spySink));
 
             EventHubsConfig eventHubs = _config.GetEventHubsConfig();
             AddEventHubsMessagePump(options, eventHubs)
@@ -393,6 +395,8 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             await using (var worker = await Worker.StartNewAsync(options))
             await using (var consumer = await TestServiceBusMessageEventConsumer.StartNewAsync(_config, _logger))
             {
+                worker.Services.GetRequiredService<TelemetryConfiguration>().TelemetryChannel = spyChannel;
+
                 // Act
                 await producer.ProduceAsync(eventData);
 

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/MessageRouterTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/MessageRouterTests.cs
@@ -47,19 +47,15 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                 var correlationInfo = new MessageCorrelationInfo(operationId, transactionId);
                 string json = JsonConvert.SerializeObject(order);
 
-                // Act
-                try
-                {
-                    await router.RouteMessageAsync(json, context, correlationInfo, CancellationToken.None);
-                }
-                catch (InvalidOperationException exception) when(exception.Message.Contains("cannot correctly process the message"))
-                {
-                    // Assert
-                    Assert.Contains(spySink.CurrentLogEmits,
-                        log => log.Exception?.Message.Contains("Sabotage") is true 
-                               && log.ContainsProperty(ContextProperties.Correlation.OperationId, operationId) 
-                               && log.ContainsProperty(ContextProperties.Correlation.TransactionId, transactionId));
-                }
+                // Act / Assert
+                var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                    () => router.RouteMessageAsync(json, context, correlationInfo, CancellationToken.None));
+                
+                Assert.Contains("cannot correctly process message", exception.Message);
+                Assert.Contains(spySink.CurrentLogEmits,
+                    log => log.Exception?.Message.Contains("Sabotage") is true 
+                           && log.ContainsProperty(ContextProperties.Correlation.OperationId, operationId) 
+                           && log.ContainsProperty(ContextProperties.Correlation.TransactionId, transactionId));
             }
         }
     }

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -822,12 +822,10 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             var spyChannel = new InMemoryTelemetryChannel();
 
             var options = new WorkerOptions();
-            options.Configure(host => host.UseSerilog((context, config) =>
+            options.ConfigureSerilog(config =>
             {
-                config.MinimumLevel.Debug()
-                      .Enrich.FromLogContext()
-                      .WriteTo.ApplicationInsights(spySink);
-            }));
+                config.WriteTo.ApplicationInsights(spySink);
+            });
             options.AddServiceBusQueueMessagePump(conf => connectionString, opt => opt.AutoComplete = true)
                    .WithServiceBusMessageHandler<OrderWithAutoTrackingAzureServiceBusMessageHandler, Order>();
             options.Services.Configure<TelemetryConfiguration>(conf => conf.TelemetryChannel = spyChannel);
@@ -865,12 +863,10 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             var spyChannel = new InMemoryTelemetryChannel();
 
             var options = new WorkerOptions();
-            options.Configure(host => host.UseSerilog((context, config) =>
+            options.ConfigureSerilog(config =>
             {
-                config.MinimumLevel.Debug()
-                      .Enrich.FromLogContext()
-                      .WriteTo.ApplicationInsights(spySink);
-            }));
+                config.WriteTo.ApplicationInsights(spySink);
+            });
             options.AddServiceBusQueueMessagePump(conf => connectionString, opt => opt.AutoComplete = true)
                    .WithServiceBusMessageHandler<OrderWithAutoTrackingAzureServiceBusMessageHandler, Order>();
             options.Services.Configure<TelemetryConfiguration>(conf => conf.TelemetryChannel = spyChannel);
@@ -905,16 +901,10 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
 
             var spySink = new InMemoryLogSink();
             var options = new WorkerOptions();
-            options.Configure(host => host.UseSerilog((context, currentConfig) =>
+            options.ConfigureSerilog(config =>
             {
-                currentConfig
-                    .MinimumLevel.Debug()
-                    .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
-                    .Enrich.FromLogContext()
-                    .Enrich.WithVersion()
-                    .Enrich.WithComponentName("Service Bus Queue Worker")
-                    .WriteTo.Sink(spySink);
-            }));
+                config.WriteTo.Sink(spySink);
+            });
             options.AddServiceBusQueueMessagePump(configuration => connectionString, opt =>
                    {
                        opt.AutoComplete = true;

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -30,23 +29,17 @@ using Azure.Identity;
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
 using Azure.Security.KeyVault.Secrets;
-using Bogus;
 using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.ApplicationInsights.WorkerService;
 using Microsoft.Azure.Management.ServiceBus.Models;
-using Microsoft.Azure.ServiceBus;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using Polly;
 using Serilog;
 using Serilog.Events;
 using Xunit;
 using Xunit.Abstractions;
-using RetryPolicy = Polly.Retry.RetryPolicy;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
-using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
 
 namespace Arcus.Messaging.Tests.Integration.MessagePump
@@ -58,8 +51,6 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
         private readonly TestConfig _config;
         private readonly ILogger _logger;
         private readonly ITestOutputHelper _outputWriter;
-
-        private static readonly Faker BogusGenerator = new Faker();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ServiceBusMessagePumpTests"/> class.
@@ -91,14 +82,14 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = _config.GetServiceBusQueueConnectionString();
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
-                   .AddServiceBusQueueMessagePump(configuration => connectionString, opt => opt.AutoComplete = true)
+                   .AddServiceBusQueueMessagePump(_ => connectionString, opt => opt.AutoComplete = true)
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 
             var traceParent = TraceParent.Generate();
             ServiceBusMessage message = CreateOrderServiceBusMessageForW3C(traceParent, encoding);
 
             var producer = TestServiceBusMessageProducer.CreateForQueue(_config);
-            await using (var worker = await Worker.StartNewAsync(options))
+            await using (var _ = await Worker.StartNewAsync(options))
             await using (var consumer = await TestServiceBusMessageEventConsumer.StartNewAsync(_config, _logger))
             {
                 // Act
@@ -119,8 +110,8 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
                    .AddServiceBusTopicMessagePump(
-                       "Test-Receive-All-Topic-Only",
-                       configuration => connectionString,
+                       subscriptionName: Guid.NewGuid().ToString(),
+                       _ => connectionString,
                        opt => opt.AutoComplete = true)
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 
@@ -128,7 +119,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             ServiceBusMessage message = CreateOrderServiceBusMessageForW3C(traceParnet, encoding);
 
             var producer = TestServiceBusMessageProducer.CreateForTopic(_config);
-            await using (var worker = await Worker.StartNewAsync(options)) 
+            await using (var _ = await Worker.StartNewAsync(options)) 
             await using (var consumer = await TestServiceBusMessageEventConsumer.StartNewAsync(_config, _logger))
             {
                 // Act
@@ -147,7 +138,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = _config.GetServiceBusQueueConnectionString();
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
-                   .AddServiceBusQueueMessagePump(configuration => connectionString, opt =>
+                   .AddServiceBusQueueMessagePump(_ => connectionString, opt =>
                    {
                        opt.AutoComplete = true;
                        opt.Correlation.Format = MessageCorrelationFormat.Hierarchical;
@@ -165,7 +156,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = _config.GetServiceBusQueueConnectionString();
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
-                   .AddServiceBusQueueMessagePump(configuration => connectionString, opt => opt.AutoComplete = true)
+                   .AddServiceBusQueueMessagePump(_ => connectionString, opt => opt.AutoComplete = true)
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 
             // Act / Assert
@@ -182,7 +173,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
 
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
-                   .AddServiceBusQueueMessagePump(properties.EntityPath, configuration => namespaceConnectionString, opt => opt.AutoComplete = true)
+                   .AddServiceBusQueueMessagePump(properties.EntityPath, _ => namespaceConnectionString, opt => opt.AutoComplete = true)
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
             
             // Act / Assert
@@ -197,8 +188,8 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
                    .AddServiceBusTopicMessagePump(
-                        "Test-Receive-All-Topic-Only", 
-                        configuration => connectionString, 
+                        subscriptionName: Guid.NewGuid().ToString(),
+                        _ => connectionString, 
                         opt => opt.AutoComplete = true)
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
             
@@ -220,7 +211,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             options.AddEventGridPublisher(_config)
                    .AddServiceBusTopicMessagePump(
                        subscriptionName, 
-                       configuration => connectionString, 
+                       _ => connectionString, 
                        opt => opt.TopicSubscription = topicSubscription)
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
             
@@ -250,7 +241,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             options.AddEventGridPublisher(_config)
                    .AddServiceBusTopicMessagePump(
                        $"MySubscription-{Guid.NewGuid():N}",
-                       configuration => _config.GetServiceBusConnectionString(entityType),
+                       _ => _config.GetServiceBusConnectionString(entityType),
                        opt =>
                        {
                            opt.AutoComplete = true;
@@ -283,7 +274,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             options.AddEventGridPublisher(_config)
                    .AddServiceBusTopicMessagePump(
                        "Test-Receive-All-Topic-Only-with-an-azure-servicebus-topic-subscription-name-over-50-characters", 
-                       configuration => connectionString, 
+                       _ => connectionString, 
                        opt => opt.AutoComplete = true)
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
             
@@ -303,8 +294,8 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             options.AddEventGridPublisher(_config)
                    .AddServiceBusTopicMessagePump(
                        topicName: properties.EntityPath,
-                       subscriptionName: "Test-Receive-All-Topic-Only",
-                       getConnectionStringFromConfigurationFunc: configuration => namespaceConnectionString,
+                       subscriptionName: Guid.NewGuid().ToString(),
+                       getConnectionStringFromConfigurationFunc: _ => namespaceConnectionString,
                        configureMessagePump: opt => opt.AutoComplete = true)
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 
@@ -321,7 +312,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
                    .AddServiceBusQueueMessagePump(
-                       configuration => connectionString, 
+                       _ => connectionString, 
                        opt => opt.Deserialization.AdditionalMembers = AdditionalMemberHandling.Ignore)
                    .WithServiceBusMessageHandler<OrderV2AzureServiceBusMessageHandler, OrderV2>();
 
@@ -347,7 +338,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                 options.AddEventGridPublisher(_config)
                        .AddServiceBusTopicMessagePumpUsingManagedIdentity(
                            topicName: properties.EntityPath,
-                           subscriptionName: "Test-Receive-All-Topic-Only", 
+                           subscriptionName: Guid.NewGuid().ToString(),
                            serviceBusNamespace: properties.FullyQualifiedNamespace,
                            clientId: servicePrincipal.ClientId,
                            configureMessagePump: opt => opt.AutoComplete = true)
@@ -366,8 +357,8 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
                    .AddServiceBusTopicMessagePump(
-                       "Test-Receive-All-Topic-Only", 
-                       configuration => connectionString, 
+                       subscriptionName: Guid.NewGuid().ToString(), 
+                       _ => connectionString, 
                        opt => opt.AutoComplete = false)
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusCompleteMessageHandler, Order>();
             
@@ -383,7 +374,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
                    .AddServiceBusQueueMessagePump(
-                       configuration => connectionString, 
+                       _ => connectionString, 
                        opt => opt.AutoComplete = false)
                    .WithServiceBusMessageHandler<ShipmentAzureServiceBusMessageHandler, Shipment>()
                    .WithServiceBusFallbackMessageHandler<OrdersFallbackCompleteMessageHandler>();
@@ -401,7 +392,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
                    .AddServiceBusQueueMessagePump(
-                       configuration => connectionString,
+                       _ => connectionString,
                        opt =>
                        {
                            opt.AutoComplete = true;
@@ -462,7 +453,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
                    .AddServiceBusQueueMessagePump(
-                        configuration => connectionString, 
+                        _ => connectionString, 
                         opt => opt.AutoComplete = false)
                    .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>()
                    .WithServiceBusFallbackMessageHandler<OrdersFallbackCompleteMessageHandler>();
@@ -478,7 +469,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = _config.GetServiceBusQueueConnectionString();
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
-                   .AddServiceBusQueueMessagePump(configuration => connectionString, opt => opt.AutoComplete = true)
+                   .AddServiceBusQueueMessagePump(_ => connectionString, opt => opt.AutoComplete = true)
                     .WithServiceBusMessageHandler<OrderBatchMessageHandler, OrderBatch>(messageBodySerializerImplementationFactory: serviceProvider =>
                     {
                         var logger = serviceProvider.GetService<ILogger<OrderBatchMessageBodySerializer>>();
@@ -496,7 +487,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = _config.GetServiceBusQueueConnectionString();
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
-                   .AddServiceBusQueueMessagePump(configuration => connectionString, opt => opt.AutoComplete = true)
+                   .AddServiceBusQueueMessagePump(_ => connectionString, opt => opt.AutoComplete = true)
                    .WithServiceBusMessageHandler<ShipmentAzureServiceBusMessageHandler, Shipment>()
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 
@@ -511,8 +502,8 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = _config.GetServiceBusQueueConnectionString();
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
-                   .AddServiceBusQueueMessagePump(configuration => connectionString, opt => opt.AutoComplete = true)
-                   .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>(context => context.Properties.ContainsKey("NotExisting"), body => false)
+                   .AddServiceBusQueueMessagePump(_ => connectionString, opt => opt.AutoComplete = true)
+                   .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>(context => context.Properties.ContainsKey("NotExisting"), _ => false)
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>(
                         context => context.Properties["Topic"].ToString() == "Orders", 
                         body => body.Id != null);
@@ -541,10 +532,10 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = _config.GetServiceBusTopicConnectionString();
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
-                   .AddServiceBusTopicMessagePump("Test-Receive-All-Topic-Only", configuration => connectionString, opt => opt.AutoComplete = true)
+                   .AddServiceBusTopicMessagePump(subscriptionName: Guid.NewGuid().ToString(), _ => connectionString, opt => opt.AutoComplete = true)
                    .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>(context => context.Properties.TryGetValue("Topic", out object value) && value.ToString() == "Customers")
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>(context => context.Properties.TryGetValue("Topic", out object value) && value.ToString() == "Orders")
-                   .WithMessageHandler<PassThruOrderMessageHandler, Order, AzureServiceBusMessageContext>((AzureServiceBusMessageContext context) => false);
+                   .WithMessageHandler<PassThruOrderMessageHandler, Order, AzureServiceBusMessageContext>((AzureServiceBusMessageContext _) => false);
 
             var traceParent = TraceParent.Generate();
             ServiceBusMessage message = CreateOrderServiceBusMessageForW3C(traceParent);
@@ -570,10 +561,10 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = _config.GetServiceBusTopicConnectionString();
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
-                   .AddServiceBusTopicMessagePump("Test-Receive-All-Topic-Only", configuration => connectionString, opt => opt.AutoComplete = true)
+                   .AddServiceBusTopicMessagePump(subscriptionName: Guid.NewGuid().ToString(), _ => connectionString, opt => opt.AutoComplete = true)
                    .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>((Customer body) => body is null)
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>((Order body) => body.Id != null)
-                   .WithMessageHandler<PassThruOrderMessageHandler, Order, AzureServiceBusMessageContext>((Order body) => false);
+                   .WithMessageHandler<PassThruOrderMessageHandler, Order, AzureServiceBusMessageContext>((Order _) => false);
 
             // Act / Assert
             await TestServiceBusTopicMessageHandlingForW3CAsync(options);
@@ -586,9 +577,9 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = _config.GetServiceBusQueueConnectionString();
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
-                   .AddServiceBusQueueMessagePump(configuration => connectionString, opt => opt.AutoComplete = true)
-                   .WithServiceBusMessageHandler<PassThruOrderMessageHandler, Order>(messageContextFilter: context => false)
-                   .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>(messageBodyFilter: message => true)
+                   .AddServiceBusQueueMessagePump(_ => connectionString, opt => opt.AutoComplete = true)
+                   .WithServiceBusMessageHandler<PassThruOrderMessageHandler, Order>(messageContextFilter: _ => false)
+                   .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>(messageBodyFilter: _ => true)
                    .WithServiceBusMessageHandler<OrderBatchMessageHandler, OrderBatch>(
                        messageContextFilter: context => context != null,
                        messageBodySerializerImplementationFactory: serviceProvider =>
@@ -609,11 +600,11 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = _config.GetServiceBusQueueConnectionString();
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config);
-            options.AddServiceBusQueueMessagePump(configuration => connectionString, opt => opt.AutoComplete = true)
+            options.AddServiceBusQueueMessagePump(_ => connectionString, opt => opt.AutoComplete = true)
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
             options.AddServiceBusTopicMessagePump(
-                "Test-Receive-All-Topic-And-Queue",
-                configuration => _config.GetServiceBusConnectionString(ServiceBusEntityType.Topic),
+                subscriptionName: Guid.NewGuid().ToString(),
+                _ => _config.GetServiceBusConnectionString(ServiceBusEntityType.Topic),
                 opt => opt.AutoComplete = true)
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 
@@ -629,8 +620,8 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = _config.GetServiceBusQueueConnectionString();
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
-                   .AddServiceBusQueueMessagePump(configuration => connectionString, opt => opt.AutoComplete = true)
-                   .WithServiceBusMessageHandler<PassThruOrderMessageHandler, Order>((AzureServiceBusMessageContext context) => false)
+                   .AddServiceBusQueueMessagePump(_ => connectionString, opt => opt.AutoComplete = true)
+                   .WithServiceBusMessageHandler<PassThruOrderMessageHandler, Order>((AzureServiceBusMessageContext _) => false)
                    .WithFallbackMessageHandler<OrdersFallbackMessageHandler>();
             
             // Act / Assert
@@ -644,8 +635,8 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = _config.GetServiceBusQueueConnectionString();
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
-                   .AddServiceBusQueueMessagePump(configuration => connectionString, opt => opt.AutoComplete = true)
-                   .WithServiceBusMessageHandler<PassThruOrderMessageHandler, Order>((AzureServiceBusMessageContext context) => false)
+                   .AddServiceBusQueueMessagePump(_ => connectionString, opt => opt.AutoComplete = true)
+                   .WithServiceBusMessageHandler<PassThruOrderMessageHandler, Order>((AzureServiceBusMessageContext _) => false)
                    .WithServiceBusFallbackMessageHandler<OrdersServiceBusFallbackMessageHandler>();
 
             // Act / Assert
@@ -658,7 +649,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             // Arrange
             string connectionString = _config.GetServiceBusQueueConnectionString();
             var options = new WorkerOptions();
-            options.AddServiceBusQueueMessagePump(configuration => connectionString, opt => opt.AutoComplete = false)
+            options.AddServiceBusQueueMessagePump(_ => connectionString, opt => opt.AutoComplete = false)
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusDeadLetterMessageHandler, Order>();
 
             var traceParent = TraceParent.Generate();
@@ -684,9 +675,9 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = _config.GetServiceBusQueueConnectionString();
             var options = new WorkerOptions();
             options.AddServiceBusQueueMessagePump(
-                       configuration => connectionString, 
+                       _ => connectionString, 
                        opt => opt.AutoComplete = false)
-                   .WithServiceBusMessageHandler<ShipmentAzureServiceBusMessageHandler, Shipment>((AzureServiceBusMessageContext context) => true)
+                   .WithServiceBusMessageHandler<ShipmentAzureServiceBusMessageHandler, Shipment>((AzureServiceBusMessageContext _) => true)
                    .WithServiceBusFallbackMessageHandler<OrdersAzureServiceBusDeadLetterFallbackMessageHandler>();
 
             var traceParent = TraceParent.Generate();
@@ -710,10 +701,10 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             // Arrange
             string connectionString = _config.GetServiceBusQueueConnectionString();
             var options = new WorkerOptions();
-            options.AddServiceBusQueueMessagePump(configuration => connectionString, opt => opt.AutoComplete = false)
+            options.AddServiceBusQueueMessagePump(_ => connectionString, opt => opt.AutoComplete = false)
                    .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>(context => context.Properties["Topic"].ToString() == "Customers")
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusDeadLetterMessageHandler, Order>(context => context.Properties["Topic"].ToString() == "Orders")
-                   .WithMessageHandler<PassThruOrderMessageHandler, Order, AzureServiceBusMessageContext>((AzureServiceBusMessageContext context) => false);
+                   .WithMessageHandler<PassThruOrderMessageHandler, Order, AzureServiceBusMessageContext>((AzureServiceBusMessageContext _) => false);
 
             var traceParent = TraceParent.Generate();
             ServiceBusMessage message = CreateOrderServiceBusMessageForW3C(traceParent);
@@ -737,8 +728,9 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = _config.GetServiceBusTopicConnectionString();
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
-                   .AddServiceBusTopicMessagePump("Test-Receive-All-Topic-Only",
-                       configuration => connectionString,
+                   .AddServiceBusTopicMessagePump(
+                       subscriptionName: Guid.NewGuid().ToString(), 
+                       _ => connectionString,
                        opt => opt.AutoComplete = false)
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusAbandonMessageHandler, Order>();
             
@@ -754,8 +746,8 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
                    .AddServiceBusTopicMessagePump(
-                       "Test-Receive-All-Topic-Only", 
-                       configuration => connectionString, 
+                       subscriptionName: Guid.NewGuid().ToString(), 
+                       _ => connectionString, 
                        opt => opt.AutoComplete = false)
                    .WithServiceBusMessageHandler<ShipmentAzureServiceBusMessageHandler, Shipment>()
                    .WithServiceBusFallbackMessageHandler<OrdersAzureServiceBusAbandonFallbackMessageHandler>();
@@ -772,11 +764,11 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
                    .AddServiceBusTopicMessagePump(
-                       "Test-Receive-All-Topic-Only", 
-                       configuration => connectionString, 
+                       subscriptionName: Guid.NewGuid().ToString(), 
+                       _ => connectionString, 
                        options => options.AutoComplete = false)
-                   .WithServiceBusMessageHandler<PassThruOrderMessageHandler, Order>((AzureServiceBusMessageContext context) => false)
-                   .WithServiceBusMessageHandler<OrdersAzureServiceBusAbandonMessageHandler, Order>((AzureServiceBusMessageContext context) => true);
+                   .WithServiceBusMessageHandler<PassThruOrderMessageHandler, Order>((AzureServiceBusMessageContext _) => false)
+                   .WithServiceBusMessageHandler<OrdersAzureServiceBusAbandonMessageHandler, Order>((AzureServiceBusMessageContext _) => true);
             
             // Act / Assert
             await TestServiceBusTopicMessageHandlingForW3CAsync(options);
@@ -791,11 +783,11 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
                    .AddServiceBusTopicMessagePump(
-                       "Test-Receive-All-Topic-Only", 
-                       configuration => connectionString, 
+                       subscriptionName: Guid.NewGuid().ToString(), 
+                       _ => connectionString, 
                        opt => opt.JobId = jobId)
-                   .WithServiceBusMessageHandler<PassThruOrderMessageHandler, Order>((AzureServiceBusMessageContext context) => false)
-                   .WithServiceBusMessageHandler<OrdersAzureServiceBusAbandonMessageHandler, Order>((AzureServiceBusMessageContext context) => true);
+                   .WithServiceBusMessageHandler<PassThruOrderMessageHandler, Order>((AzureServiceBusMessageContext _) => false)
+                   .WithServiceBusMessageHandler<OrdersAzureServiceBusAbandonMessageHandler, Order>((AzureServiceBusMessageContext _) => true);
 
             var traceParent = TraceParent.Generate();
             ServiceBusMessage message = CreateOrderServiceBusMessageForW3C(traceParent);
@@ -830,7 +822,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             {
                 config.WriteTo.ApplicationInsights(spySink);
             });
-            options.AddServiceBusQueueMessagePump(conf => connectionString, opt => opt.AutoComplete = true)
+            options.AddServiceBusQueueMessagePump(_ => connectionString, opt => opt.AutoComplete = true)
                    .WithServiceBusMessageHandler<OrderWithAutoTrackingAzureServiceBusMessageHandler, Order>();
             options.Services.Configure<TelemetryConfiguration>(conf => conf.TelemetryChannel = spyChannel);
 
@@ -871,7 +863,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             {
                 config.WriteTo.ApplicationInsights(spySink);
             });
-            options.AddServiceBusQueueMessagePump(conf => connectionString, opt => opt.AutoComplete = true)
+            options.AddServiceBusQueueMessagePump(_ => connectionString, opt => opt.AutoComplete = true)
                    .WithServiceBusMessageHandler<OrderWithAutoTrackingAzureServiceBusMessageHandler, Order>();
             options.Services.Configure<TelemetryConfiguration>(conf => conf.TelemetryChannel = spyChannel);
 
@@ -909,7 +901,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             {
                 config.WriteTo.Sink(spySink);
             });
-            options.AddServiceBusQueueMessagePump(configuration => connectionString, opt =>
+            options.AddServiceBusQueueMessagePump(_ => connectionString, opt =>
                    {
                        opt.AutoComplete = true;
                        opt.Correlation.Format = MessageCorrelationFormat.Hierarchical;
@@ -1068,7 +1060,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
         {
             Order order = OrderGenerator.Generate();
             string json = JsonConvert.SerializeObject(order);
-            encoding = encoding ?? Encoding.UTF8;
+            encoding ??= Encoding.UTF8;
             byte[] raw = encoding.GetBytes(json);
 
             var message = new ServiceBusMessage(raw)
@@ -1142,21 +1134,6 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
         private static async Task SetConnectionStringInKeyVaultAsync(SecretClient keyVaultClient, KeyRotationConfig keyRotationConfig, string rotatedConnectionString)
         {
             await keyVaultClient.SetSecretAsync(keyRotationConfig.KeyVault.SecretName, rotatedConnectionString);
-        }
-
-        private void RetryAssertUntilTelemetryShouldBeAvailable(System.Action assertion, TimeSpan timeout)
-        {
-            RetryPolicy retryPolicy =
-                Policy.Handle<Exception>(exception =>
-                      {
-                          _logger.LogError(exception, "Failed assertion. Reason: {Message}", exception.Message);
-                          return true;
-                      })
-                      .WaitAndRetryForever(index => TimeSpan.FromSeconds(5));
-
-            Policy.Timeout(timeout)
-                  .Wrap(retryPolicy)
-                  .Execute(assertion);
         }
     }
 }

--- a/src/Arcus.Messaging.Tests.Unit/Fixture/PassThruFallbackMessageHandlerT.cs
+++ b/src/Arcus.Messaging.Tests.Unit/Fixture/PassThruFallbackMessageHandlerT.cs
@@ -8,7 +8,8 @@ namespace Arcus.Messaging.Tests.Unit.Fixture
     /// <summary>
     /// Test version of the <see cref="IFallbackMessageHandler"/> to have a solid implementation.
     /// </summary>
-    public class PassThruFallbackMessageHandler : IFallbackMessageHandler
+    public class PassThruFallbackMessageHandler<TMessageContext> : IFallbackMessageHandler<string, TMessageContext> 
+        where TMessageContext : MessageContext
     {
         /// <summary>
         /// Gets the flag indicating whether the fallback handler has processed the message.
@@ -27,7 +28,7 @@ namespace Arcus.Messaging.Tests.Unit.Fixture
         /// <param name="cancellationToken">Cancellation token</param>
         public Task ProcessMessageAsync(
             string message,
-            MessageContext messageContext,
+            TMessageContext messageContext,
             MessageCorrelationInfo correlationInfo,
             CancellationToken cancellationToken)
         {

--- a/src/Arcus.Messaging.Tests.Unit/Fixture/PassThruServiceBusFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Unit/Fixture/PassThruServiceBusFallbackMessageHandler.cs
@@ -14,6 +14,11 @@ namespace Arcus.Messaging.Tests.Unit.Fixture
     public class PassThruServiceBusFallbackMessageHandler : IAzureServiceBusFallbackMessageHandler
     {
         /// <summary>
+        /// Gets the flag indicating whether this fallback message handler has processed a message.
+        /// </summary>
+        public bool IsProcessed { get; private set; }
+
+        /// <summary>
         ///     Process a new message that was received
         /// </summary>
         /// <param name="message">Message that was received</param>
@@ -29,6 +34,7 @@ namespace Arcus.Messaging.Tests.Unit.Fixture
             MessageCorrelationInfo correlationInfo,
             CancellationToken cancellationToken)
         {
+            IsProcessed = true;
             return Task.CompletedTask;
         }
     }

--- a/src/Arcus.Messaging.Tests.Unit/Fixture/TestMessageContext.cs
+++ b/src/Arcus.Messaging.Tests.Unit/Fixture/TestMessageContext.cs
@@ -21,7 +21,7 @@ namespace Arcus.Messaging.Tests.Unit.Fixture
         /// </summary>
         /// <param name="messageId">Unique identifier of the message</param>
         /// <param name="properties">Contextual properties provided on the message</param>
-        public TestMessageContext(string messageId, IDictionary<string, object> properties) : base(messageId, properties) { }
+        public TestMessageContext(string messageId, IDictionary<string, object> properties) : base(messageId, "job-id", properties) { }
 
         /// <summary>
         /// Generate a new <see cref="TestMessageContext"/> instance with random values.

--- a/src/Arcus.Messaging.Tests.Unit/Fixture/TestMessageContext.cs
+++ b/src/Arcus.Messaging.Tests.Unit/Fixture/TestMessageContext.cs
@@ -17,11 +17,19 @@ namespace Arcus.Messaging.Tests.Unit.Fixture
         private static readonly Faker BogusGenerator = new Faker();
 
         /// <summary>
-        ///     Constructor
+        /// Initializes a new instance of the <see cref="TestMessageContext"/> class.
         /// </summary>
-        /// <param name="messageId">Unique identifier of the message</param>
-        /// <param name="properties">Contextual properties provided on the message</param>
-        public TestMessageContext(string messageId, IDictionary<string, object> properties) : base(messageId, "job-id", properties) { }
+        /// <param name="messageId">The unique identifier of the message.</param>
+        /// <param name="properties">The contextual properties provided on the message.</param>
+        public TestMessageContext(string messageId, IDictionary<string, object> properties) : this(messageId, "job-id", properties) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestMessageContext"/> class.
+        /// </summary>
+        /// <param name="messageId">The unique identifier of the message.</param>
+        /// <param name="jobId">The unique ID to identify the registered message handlers that can handle this context.</param>
+        /// <param name="properties">The contextual properties provided on the message.</param>
+        public TestMessageContext(string messageId, string jobId, IDictionary<string, object> properties) : base(messageId, jobId, properties) { }
 
         /// <summary>
         /// Generate a new <see cref="TestMessageContext"/> instance with random values.

--- a/src/Arcus.Messaging.Tests.Unit/MessageContextTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageContextTests.cs
@@ -5,11 +5,10 @@ using Xunit;
 
 namespace Arcus.Messaging.Tests.Unit
 {
-    [Trait("Category", "Unit")]
     public class MessageContextTests
     {
         [Fact]
-        public void Constructor_NoPropertiesSpecified_ThrowsException()
+        public void ConstructorWithoutJobId_NoPropertiesSpecified_ThrowsException()
         {
             // Arrange
             var messageId = Guid.NewGuid().ToString();
@@ -19,7 +18,7 @@ namespace Arcus.Messaging.Tests.Unit
         }
 
         [Fact]
-        public void Constructor_NoMessageIdSpecified_ThrowsException()
+        public void ConstructorWithoutJobId_NoMessageIdSpecified_ThrowsException()
         {
             // Arrange
             var properties = new Dictionary<string, object>();
@@ -29,7 +28,7 @@ namespace Arcus.Messaging.Tests.Unit
         }
 
         [Fact]
-        public void Constructor_Valid_Succeeds()
+        public void ConstructorWithoutJobId_Valid_Succeeds()
         {
             // Arrange
             var messageId = Guid.NewGuid().ToString();
@@ -43,6 +42,48 @@ namespace Arcus.Messaging.Tests.Unit
 
             // Assert
             Assert.Equal(messageId, messageContext.MessageId);
+            Assert.Equal(properties.Count, messageContext.Properties.Count);
+        }
+
+        [Fact]
+        public void Constructor_NoPropertiesSpecified_ThrowsException()
+        {
+            // Arrange
+            var messageId = Guid.NewGuid().ToString();
+            var jobId = Guid.NewGuid().ToString();
+
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() => new MessageContext(messageId, jobId, properties: null));
+        }
+
+        [Fact]
+        public void Constructor_NoMessageIdSpecified_ThrowsException()
+        {
+            // Arrange
+            var properties = new Dictionary<string, object>();
+            var jobId = Guid.NewGuid().ToString();
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() => new MessageContext(messageId: null, jobId, properties: properties));
+        }
+
+        [Fact]
+        public void Constructor_Valid_Succeeds()
+        {
+            // Arrange
+            var messageId = Guid.NewGuid().ToString();
+            var jobId = Guid.NewGuid().ToString();
+            var properties = new Dictionary<string, object>
+            {
+                {"CorrelationId", "ABC"}
+            };
+
+            // Act
+            var messageContext = new MessageContext(messageId, jobId, properties);
+
+            // Assert
+            Assert.Equal(messageId, messageContext.MessageId);
+            Assert.Equal(jobId, messageContext.JobId);
             Assert.Equal(properties.Count, messageContext.Properties.Count);
         }
     }

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/FallbackMessageHandlerTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/FallbackMessageHandlerTests.cs
@@ -36,7 +36,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling
             Assert.True(await handler.ProcessMessageAsync(message, correctContext, correlationInfo, CancellationToken.None));
 
             var incorrectContext = new MessageContext("message-id", "other-job-id", new Dictionary<string, object>());
-            Assert.True(await handler.ProcessMessageAsync(message, incorrectContext, correlationInfo, CancellationToken.None));
+            Assert.False(await handler.ProcessMessageAsync(message, incorrectContext, correlationInfo, CancellationToken.None));
         }
 
         [Fact]
@@ -54,16 +54,16 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling
 
             // Assert
             IServiceProvider provider = services.Services.BuildServiceProvider();
-            var handler = provider.GetRequiredService<FallbackMessageHandler<string, MessageContext>>();
+            var handler = provider.GetRequiredService<FallbackMessageHandler<string, TestMessageContext>>();
 
             var message = "message-body";
             var correlationInfo = new MessageCorrelationInfo("operation-id", "transaction-id");
 
-            var correctContext = new MessageContext("message-id", jobId, new Dictionary<string, object>());
+            var correctContext = new TestMessageContext("message-id", jobId, new Dictionary<string, object>());
             Assert.True(await handler.ProcessMessageAsync(message, correctContext, correlationInfo, CancellationToken.None));
 
-            var incorrectContext = new MessageContext("message-id", "other-job-id", new Dictionary<string, object>());
-            Assert.True(await handler.ProcessMessageAsync(message, incorrectContext, correlationInfo, CancellationToken.None));
+            var incorrectContext = new TestMessageContext("message-id", "other-job-id", new Dictionary<string, object>());
+            Assert.False(await handler.ProcessMessageAsync(message, incorrectContext, correlationInfo, CancellationToken.None));
         }
 
         [Fact]

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/FallbackMessageHandlerTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/FallbackMessageHandlerTests.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Abstractions.MessageHandling;
+using Arcus.Messaging.Tests.Unit.Fixture;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Arcus.Messaging.Tests.Unit.MessageHandling
+{
+    public class FallbackMessageHandlerTests
+    {
+        [Fact]
+        public async Task Add_WithJobId_AdaptsContextFilter()
+        {
+            // Arrange
+            var jobId = Guid.NewGuid().ToString();
+            var services = new MessageHandlerCollection(new ServiceCollection())
+            {
+                JobId = jobId
+            };
+
+            // Act
+            services.WithFallbackMessageHandler<PassThruFallbackMessageHandler>();
+
+            // Assert
+            IServiceProvider provider = services.Services.BuildServiceProvider();
+            var handler = provider.GetRequiredService<FallbackMessageHandler<string, MessageContext>>();
+
+            var message = "message-body";
+            var correlationInfo = new MessageCorrelationInfo("operation-id", "transaction-id");
+
+            var correctContext = new MessageContext("message-id", jobId, new Dictionary<string, object>());
+            Assert.True(await handler.ProcessMessageAsync(message, correctContext, correlationInfo, CancellationToken.None));
+
+            var incorrectContext = new MessageContext("message-id", "other-job-id", new Dictionary<string, object>());
+            Assert.True(await handler.ProcessMessageAsync(message, incorrectContext, correlationInfo, CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task AddT_WithJobId_AdaptsContextFilter()
+        {
+            // Arrange
+            var jobId = Guid.NewGuid().ToString();
+            var services = new MessageHandlerCollection(new ServiceCollection())
+            {
+                JobId = jobId
+            };
+
+            // Act
+            services.WithFallbackMessageHandler<PassThruFallbackMessageHandler<TestMessageContext>, TestMessageContext>();
+
+            // Assert
+            IServiceProvider provider = services.Services.BuildServiceProvider();
+            var handler = provider.GetRequiredService<FallbackMessageHandler<string, MessageContext>>();
+
+            var message = "message-body";
+            var correlationInfo = new MessageCorrelationInfo("operation-id", "transaction-id");
+
+            var correctContext = new MessageContext("message-id", jobId, new Dictionary<string, object>());
+            Assert.True(await handler.ProcessMessageAsync(message, correctContext, correlationInfo, CancellationToken.None));
+
+            var incorrectContext = new MessageContext("message-id", "other-job-id", new Dictionary<string, object>());
+            Assert.True(await handler.ProcessMessageAsync(message, incorrectContext, correlationInfo, CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task Process_WithoutMessage_Fails()
+        {
+            // Arrange
+            var services = new MessageHandlerCollection(new ServiceCollection());
+
+            // Act
+            services.WithFallbackMessageHandler<PassThruFallbackMessageHandler>();
+
+            // Assert
+            IServiceProvider provider = services.Services.BuildServiceProvider();
+            var handler = provider.GetRequiredService<FallbackMessageHandler<string, MessageContext>>();
+
+            var messageContext = new MessageContext("message-id", new Dictionary<string, object>());
+            var correlationInfo = new MessageCorrelationInfo("operation-id", "transaction-id");
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => handler.ProcessMessageAsync(message: null, messageContext, correlationInfo, CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task Process_WithoutMessageContext_Fails()
+        {
+            // Arrange
+            var services = new MessageHandlerCollection(new ServiceCollection());
+
+            // Act
+            services.WithFallbackMessageHandler<PassThruFallbackMessageHandler>();
+
+            // Assert
+            IServiceProvider provider = services.Services.BuildServiceProvider();
+            var handler = provider.GetRequiredService<FallbackMessageHandler<string, MessageContext>>();
+
+            var message = "message-body";
+            var correlationInfo = new MessageCorrelationInfo("operation-id", "transaction-id");
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => handler.ProcessMessageAsync(message, messageContext: null, correlationInfo, CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task Process_WithoutMessageCorrelation_Fails()
+        {
+            // Arrange
+            var services = new MessageHandlerCollection(new ServiceCollection());
+
+            // Act
+            services.WithFallbackMessageHandler<PassThruFallbackMessageHandler>();
+
+            // Assert
+            IServiceProvider provider = services.Services.BuildServiceProvider();
+            var handler = provider.GetRequiredService<FallbackMessageHandler<string, MessageContext>>();
+
+            var message = "message-body";
+            var messageContext = new MessageContext("message-id", new Dictionary<string, object>());
+            await Assert.ThrowsAnyAsync<ArgumentException>(
+                () => handler.ProcessMessageAsync(message, messageContext, correlationInfo: null, CancellationToken.None));
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/MessageHandlerTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/MessageHandlerTests.cs
@@ -33,6 +33,27 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling
         }
 
         [Fact]
+        public void Add_WithJobId_AdaptsMessageContextFilter()
+        {
+            // Arrange
+            var jobId = Guid.NewGuid().ToString();
+            var collection = new MessageHandlerCollection(new ServiceCollection()) { JobId = jobId };
+            collection.WithMessageHandler<DefaultTestMessageHandler, TestMessage>();
+            IServiceProvider provider = collection.Services.BuildServiceProvider();
+
+            // Act
+            IEnumerable<MessageHandler> messageHandlers = MessageHandler.SubtractFrom(provider, _logger);
+
+            // Assert
+            Assert.NotNull(messageHandlers);
+            MessageHandler handler = Assert.Single(messageHandlers);
+            Assert.NotNull(handler);
+
+            Assert.True(handler.CanProcessMessageBasedOnContext(new MessageContext("message-id", jobId, new Dictionary<string, object>())));
+            Assert.False(handler.CanProcessMessageBasedOnContext(new MessageContext("message-id", "other-job-id", new Dictionary<string, object>())));
+        }
+
+        [Fact]
         public async Task CustomMessageHandlerConstructor_WithDefaultContext_SubtractsRegistration()
         {
             // Arrange

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/AzureServiceBusMessageRouterTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/AzureServiceBusMessageRouterTests.cs
@@ -86,8 +86,8 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
 
             var handler1 = new PassThruServiceBusFallbackMessageHandler();
             var handler2 = new PassThruServiceBusFallbackMessageHandler();
-            collection1.WithServiceBusFallbackMessageHandler(provider => handler1);
             collection2.WithServiceBusFallbackMessageHandler(provider => handler2);
+            collection1.WithServiceBusFallbackMessageHandler(provider => handler1);
 
             IServiceProvider provider = services.BuildServiceProvider();
             var router = provider.GetRequiredService<IAzureServiceBusMessageRouter>();

--- a/src/Arcus.Messaging.Tests.Unit/ServiceBus/IServiceCollectionExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/ServiceBus/IServiceCollectionExtensionsTests.cs
@@ -2,10 +2,13 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Abstractions.MessageHandling;
+using Arcus.Messaging.Abstractions.ServiceBus;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 using Arcus.Messaging.Pumps.ServiceBus;
 using Arcus.Messaging.Tests.Unit.Fixture;
 using Arcus.Security.Core;
+using Azure.Messaging.ServiceBus;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -713,9 +716,9 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
 
             // Assert
             IServiceProvider provider = collection.Services.BuildServiceProvider();
-            var messageHandler = provider.GetRequiredService<IAzureServiceBusFallbackMessageHandler>();
+            var messageHandler = provider.GetRequiredService<FallbackMessageHandler<ServiceBusReceivedMessage, AzureServiceBusMessageContext>>();
 
-            Assert.IsType<PassThruServiceBusFallbackMessageHandler>(messageHandler);
+            Assert.IsType<PassThruServiceBusFallbackMessageHandler>(messageHandler.MessageHandlerInstance);
         }
 
         [Fact]
@@ -730,9 +733,9 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
 
             // Assert
             IServiceProvider provider = collection.Services.BuildServiceProvider();
-            var actual = provider.GetRequiredService<IAzureServiceBusFallbackMessageHandler>();
+            var actual = provider.GetRequiredService<FallbackMessageHandler<ServiceBusReceivedMessage, AzureServiceBusMessageContext>>();
 
-            Assert.Same(expected, actual);
+            Assert.Same(expected, actual.MessageHandlerInstance);
         }
 
         [Fact]

--- a/src/Arcus.Messaging.Tests.Workers.EventHubs.Core/MessageHandlers/SabotageEventHubsFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Workers.EventHubs.Core/MessageHandlers/SabotageEventHubsFallbackMessageHandler.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Abstractions.EventHubs;
+using Arcus.Messaging.Abstractions.MessageHandling;
+using Azure.Messaging.EventHubs;
+
+namespace Arcus.Messaging.Tests.Workers.EventHubs.Core.MessageHandlers
+{
+    public class SabotageEventHubsFallbackMessageHandler : IFallbackMessageHandler<string, AzureEventHubsMessageContext>
+    {
+        public Task ProcessMessageAsync(
+            string message,
+            AzureEventHubsMessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            throw new InvalidOperationException("Sabotage this!");
+        }
+    }
+}


### PR DESCRIPTION
Enhances the current message handler registration by scoping any message handler registrations to a pump or router. This means that message handlers registered for another pump/router cannot be used during message routing.

This is a follow-up on the background jobs issue: https://github.com/arcus-azure/arcus.backgroundjobs/issues/200

The cool 😎 thing about this enhancement, is that it does not changes anything for single-message pump/router registrations; but changes the way we work with multiple pumps (which is the case when background jobs are involved).

Closes #395  