### PR TITLE
feat: add managed identity to az eventhubs message pump

### DIFF
--- a/docs/preview/02-Features/02-message-handling/03-event-hubs.md
+++ b/docs/preview/02-Features/02-message-handling/03-event-hubs.md
@@ -69,7 +69,7 @@ public class Program
         services.AddSecretStore(stores => ...);
 
         // Add Azure EventHubs message pump and use OrdersMessageHandler to process the messages.
-        services.AddEventHubsMessagePump("<my-eventhubs-name>", "Arcus_EventHubs_ConnectionString", "<my-eventhubs-blob-storage-container-name>", "Arcus_EventHubs_Blob_ConnectionString")
+        services.AddEventHubsMessagePumpUsingManagedIdentity("<my-eventhubs-name>", "Arcus_EventHubs_ConnectionString", "<my-eventhubs-blob-storage-container-name>", "Arcus_EventHubs_Blob_ConnectionString")
                 .WithEventHubsMessageHandler<SensorReadingMessageHandler, SensorReading>();
 
         // Note, that only a single call to the `.WithEventHubsMessageHandler` has to be made when the handler should be used across message pumps.
@@ -118,7 +118,7 @@ public class Program
 {
     public void ConfigureServices(IServiceCollection services)
     {
-        services.AddEventHubsMessagePump(...)
+        services.AddEventHubsMessagePumpUsingManagedIdentity(...)
                 .WithEventHubsMessageHandler<SensorReadingMessageHandler, SensorReading>(context => context.Properties["Location"].ToString() == "Room");
     }
 }
@@ -161,11 +161,11 @@ public class Program
     public void ConfigureServices(IServiceCollection services)
     {
         // Register the message body serializer in the dependency container where the dependent services will be injected.
-        services.AddEventHubsMessagePump(...)
+        services.AddEventHubsMessagePumpUsingManagedIdentity(...)
                 .WithEventHubsMessageHandler<SensorReadingBatchMessageHandler, SensorReading>(..., messageBodySerializer: new OrderBatchMessageBodySerializer());
 
         // Register the message body serializer  in the dependency container where the dependent services are manually injected.
-        services.AddEventHubsMessagePump(...)
+        services.AddEventHubsMessagePumpUsingManagedIdentity(...)
                 .WithEventHubsMessageHandler(..., messageBodySerializerImplementationFactory: serviceProvider => 
                 {
                     var logger = serviceProvider.GetService<ILogger<OrderBatchMessageHandler>>();
@@ -213,7 +213,7 @@ public class Program
 {
     public void ConfigureServices(IServiceCollection services)
     {
-        services.AddEventHubsMessagePump(...)
+        services.AddEventHubsMessagePumpUsingManagedIdentity(...)
                 .WithEventHubsMessageHandler<SensorReadingMessageHandler, SensorReading>((SensorReading sensor) => sensor.Status == SensorStatus.Active);
     }
 }
@@ -273,6 +273,13 @@ public class Program
 {
     public void ConfigureServices(IServiceCollection services)
     {
+        // Uses managed identity to authenticate with Azure EventHubs.
+        // 🎖️ Recommended.
+        services.AddEventHubsMessagePumpUsingManagedIdentity(
+            eventHubsName: "<my-eventhubs-name>",
+            fullyQualifiedNamespace: "<my-eventhubs-namespace>",
+            blobContainerUri: "<my-eventhubs-blob-storage-endpoint>");
+
         services.AddEventHubsMessagePump(..., options =>
         {
             // The name of the consumer group this processor is associated with. Events are read in the context of this group. 

--- a/src/Arcus.Messaging.Pumps.EventHubs/Configuration/AzureEventHubsMessagePumpConfig.cs
+++ b/src/Arcus.Messaging.Pumps.EventHubs/Configuration/AzureEventHubsMessagePumpConfig.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Arcus.Security.Core;
+using Azure.Core;
 using Azure.Messaging.EventHubs;
 using Azure.Storage.Blobs;
 using GuardNet;
@@ -12,10 +13,24 @@ namespace Arcus.Messaging.Pumps.EventHubs.Configuration
     /// </summary>
     internal class AzureEventHubsMessagePumpConfig
     {
-        private readonly ISecretProvider _secretProvider;
+        private readonly Func<Task<EventProcessorClient>> _createClient;
+
+        private AzureEventHubsMessagePumpConfig(
+            Func<Task<EventProcessorClient>> createClient,
+            AzureEventHubsMessagePumpOptions options)
+        {
+            _createClient = createClient;
+
+            Options = options;
+        }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="AzureEventHubsMessagePumpConfig" /> class.
+        /// Gets the additional options to influence the behavior of the message pump.
+        /// </summary>
+        public AzureEventHubsMessagePumpOptions Options { get; }
+
+        /// <summary>
+        /// Creates an <see cref="AzureEventHubsMessagePumpConfig"/> instance by using a connection string to interact with Azure EventHubs.
         /// </summary>
         /// <param name="eventHubsName">The name of the Event Hub that the processor is connected to, specific to the EventHubs namespace that contains it.</param>
         /// <param name="eventHubsConnectionStringSecretName">
@@ -31,12 +46,12 @@ namespace Arcus.Messaging.Pumps.EventHubs.Configuration
         ///     The application's secret provider provider to retrieve the connection strings from both <paramref name="eventHubsConnectionStringSecretName"/> and <paramref name="storageAccountConnectionStringSecretName"/>.
         /// </param>
         /// <param name="options">The additional options to influence the behavior of the message pump.</param>
-        ///   /// <exception cref="ArgumentException">
+        /// <exception cref="ArgumentException">
         ///     Thrown when the <paramref name="eventHubsName"/>, the <paramref name="eventHubsConnectionStringSecretName"/>, the <paramref name="blobContainerName"/>,
         ///     or the <paramref name="storageAccountConnectionStringSecretName"/> is blank.
         /// </exception>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="secretProvider"/> or the <paramref name="options"/> is <c>null</c>.</exception>
-        internal AzureEventHubsMessagePumpConfig(
+        internal static AzureEventHubsMessagePumpConfig CreateByConnectionString(
             string eventHubsName, 
             string eventHubsConnectionStringSecretName, 
             string blobContainerName, 
@@ -51,39 +66,70 @@ namespace Arcus.Messaging.Pumps.EventHubs.Configuration
             Guard.NotNull(secretProvider, nameof(secretProvider), "Requires an application's service provider to retrieve registered services during the lifetime of the message pump, like Azure EventHubs message handlers and its dependencies");
             Guard.NotNull(options, nameof(options), "Requires a set of user-defined options to influence the behavior of the Azure EventHubs message pump");
 
-            _secretProvider = secretProvider;
+            return new AzureEventHubsMessagePumpConfig(async () =>
+            {
+                string storageAccountConnectionString = await GetConnectionStringFromSecretAsync(secretProvider, storageAccountConnectionStringSecretName, "Azure Blob storage account");
+                var storageClient = new BlobContainerClient(storageAccountConnectionString, blobContainerName);
 
-            EventHubsName = eventHubsName;
-            EventHubsConnectionStringSecretName = eventHubsConnectionStringSecretName;
-            BlobContainerName = blobContainerName;
-            StorageAccountConnectionStringSecretName = storageAccountConnectionStringSecretName;
-            Options = options;
+                string eventHubsConnectionString = await GetConnectionStringFromSecretAsync(secretProvider, eventHubsConnectionStringSecretName, "Azure EventHubs");
+                var eventProcessor = new EventProcessorClient(storageClient, options.ConsumerGroup, eventHubsConnectionString, eventHubsName);
+
+                return eventProcessor;
+            }, options);
+        }
+
+        private static async Task<string> GetConnectionStringFromSecretAsync(
+            ISecretProvider secretProvider,
+            string connectionStringSecretName, 
+            string connectionStringType)
+        {
+            Task<string> getConnectionStringTask = secretProvider.GetRawSecretAsync(connectionStringSecretName);
+            if (getConnectionStringTask is null)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot retrieve {connectionStringType} connection string via calling the {nameof(ISecretProvider)} because the operation resulted in 'null'");
+            }
+
+            return await getConnectionStringTask;
         }
 
         /// <summary>
-        /// Gets the name of the Event Hub that the processor is connected to, specific to the EventHubs namespace that contains it.
+        /// Creates a <see cref="AzureEventHubsMessagePumpConfig"/> instance by using a token credential to interact with Azure EventHubs.
         /// </summary>
-        public string EventHubsName { get; }
+        /// <param name="eventHubsName">The name of the Event Hub that the processor is connected to, specific to the EventHubs namespace that contains it.</param>
+        /// <param name="fullyQualifiedNamespace">The fully qualified Event Hubs namespace to connect to.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="blobContainerUri">
+        ///     The <see cref="BlobContainerClient.Uri" /> referencing the blob container that includes the
+        ///     name of the account and the name of the container.
+        ///     This is likely to be similar to "https://{account_name}.blob.core.windows.net/{container_name}".
+        /// </param>
+        /// <param name="credential">The Azure identity credential to sign requests.</param>
+        /// <param name="options">The additional options to influence the behavior of the message pump.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="eventHubsName"/> or the <paramref name="fullyQualifiedNamespace"/> is blank.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="credential"/> or the <paramref name="options"/> is <c>null</c>.</exception>
+        /// <exception cref="UriFormatException">Thrown when the <paramref name="blobContainerUri"/> is not an absolute URI.</exception>
+        internal static AzureEventHubsMessagePumpConfig CreateByTokenCredential(
+            string eventHubsName,
+            string fullyQualifiedNamespace,
+            Uri blobContainerUri,
+            TokenCredential credential,
+            AzureEventHubsMessagePumpOptions options)
+        {
+            Guard.NotNullOrWhitespace(eventHubsName, nameof(eventHubsName), "Requires a non-blank Azure EventHubs name where the events will be sent to when adding an Azure EvenHubs message pump");
+            Guard.NotNullOrWhitespace(eventHubsName, nameof(eventHubsName), "Requires a non-blank Azure EventHubs name where the events will be sent to when adding an Azure EvenHubs message pump");
+            Guard.NotNullOrWhitespace(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace), "Requires a non-blank Azure EventHubs namespace to connect to");
+            Guard.For<UriFormatException>(() => !blobContainerUri.IsAbsoluteUri, "Requires a valid absolute URI endpoint for the Azure Blob container to store event checkpoints and load balance the consumed event messages send to the message pump");
+            Guard.NotNull(credential, nameof(credential), "Requires a token credential to authenticate the interaction with the Azure EventHubs resource");
+            Guard.NotNull(options, nameof(options), "Requires a set of user-defined options to influence the behavior of the Azure EventHubs message pump");
 
-        /// <summary>
-        /// Gets the name of the secret to retrieve the Azure EventHubs connection string using your registered Arcus secret store (<see cref="ISecretProvider" />) implementation
-        /// </summary>
-        public string EventHubsConnectionStringSecretName { get; }
+            return new AzureEventHubsMessagePumpConfig(() =>
+            {
+                var storageClient = new BlobContainerClient(blobContainerUri, credential);
+                var eventProcessor = new EventProcessorClient(storageClient, options.ConsumerGroup, fullyQualifiedNamespace, eventHubsName, credential);
 
-        /// <summary>
-        /// Gets the name of the Azure Blob storage container in the storage account to reference where the event checkpoints will be stored and the load balanced.
-        /// </summary>
-        public string BlobContainerName { get; }
-
-        /// <summary>
-        /// Gets the name of the secret to retrieve the Azure EventHubs connection string using your registered Arcus secret store (<see cref="ISecretProvider" />) implementation.
-        /// </summary>
-        public string StorageAccountConnectionStringSecretName { get; }
-
-        /// <summary>
-        /// Gets the additional options to influence the behavior of the message pump.
-        /// </summary>
-        public AzureEventHubsMessagePumpOptions Options { get; }
+                return Task.FromResult(eventProcessor);
+            }, options);
+        }
 
         /// <summary>
         /// Creates an <see cref="EventProcessorClient"/> based on the provided information in this configuration instance.
@@ -93,25 +139,7 @@ namespace Arcus.Messaging.Pumps.EventHubs.Configuration
         /// </exception>
         internal async Task<EventProcessorClient> CreateEventProcessorClientAsync()
         {
-            string storageAccountConnectionString = await GetConnectionStringFromSecretAsync(StorageAccountConnectionStringSecretName, "Azure Blob storage account");
-            var storageClient = new BlobContainerClient(storageAccountConnectionString, BlobContainerName);
-
-            string eventHubsConnectionString = await GetConnectionStringFromSecretAsync(EventHubsConnectionStringSecretName, "Azure EventHubs");
-            var eventProcessor = new EventProcessorClient(storageClient, Options.ConsumerGroup, eventHubsConnectionString, EventHubsName);
-
-            return eventProcessor;
-        }
-
-        private async Task<string> GetConnectionStringFromSecretAsync(string connectionStringSecretName, string connectionStringType)
-        {
-            Task<string> getConnectionStringTask = _secretProvider.GetRawSecretAsync(connectionStringSecretName);
-            if (getConnectionStringTask is null)
-            {
-                throw new InvalidOperationException(
-                    $"Cannot retrieve {connectionStringType} connection string via calling the {nameof(ISecretProvider)} because the operation resulted in 'null'");
-            }
-
-            return await getConnectionStringTask;
+            return await _createClient();
         }
     }
 }

--- a/src/Arcus.Messaging.Pumps.EventHubs/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.EventHubs/Extensions/IServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Arcus.Messaging.Pumps.EventHubs;
 using Arcus.Messaging.Pumps.EventHubs.Configuration;
 using Arcus.Security.Core;
 using Arcus.Security.Core.Caching;
+using Azure.Identity;
 using GuardNet;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
@@ -20,7 +21,7 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class IServiceCollectionExtensions
     {
         /// <summary>
-        /// Adds a message pump to consume messages from Azure EventHubs.
+        /// Adds a message pump to consume events from Azure EventHubs.
         /// </summary>
         /// <remarks>
         ///    Make sure that the application has the Arcus secret store configured correctly.
@@ -56,17 +57,16 @@ namespace Microsoft.Extensions.DependencyInjection
             Guard.NotNullOrWhitespace(blobContainerName, nameof(blobContainerName), "Requires a non-blank Azure Blob storage container name to store event checkpoints and load balance the consumed event messages send to the message pump");
             Guard.NotNullOrWhitespace(storageAccountConnectionStringSecretName, nameof(storageAccountConnectionStringSecretName), "Requires a non-blank secret name to retrieve the connection string to the Azure Blob storage where the event checkpoints will be stored and events will be load balanced during the event processing of the message pump");
 
-            return AddEventHubsMessagePump(
-                services,
-                eventHubsName,
-                eventHubsConnectionStringSecretName,
-                blobContainerName,
-                storageAccountConnectionStringSecretName,
+            return services.AddEventHubsMessagePump(
+                eventHubsName: eventHubsName,
+                eventHubsConnectionStringSecretName: eventHubsConnectionStringSecretName,
+                blobContainerName: blobContainerName,
+                storageAccountConnectionStringSecretName: storageAccountConnectionStringSecretName,
                 configureOptions: null);
         }
 
         /// <summary>
-        /// Adds a message pump to consume messages from Azure EventHubs.
+        /// Adds a message pump to consume events from Azure EventHubs.
         /// </summary>
         /// <remarks>
         ///    Make sure that the application has the Arcus secret store configured correctly.
@@ -103,30 +103,226 @@ namespace Microsoft.Extensions.DependencyInjection
             Guard.NotNullOrWhitespace(eventHubsConnectionStringSecretName, nameof(eventHubsConnectionStringSecretName), "Requires a non-blank secret name to retrieve the connection string to the Azure EventHubs where the message pump will retrieve its event messages");
             Guard.NotNullOrWhitespace(blobContainerName, nameof(blobContainerName), "Requires a non-blank Azure Blob storage container name to store event checkpoints and load balance the consumed event messages send to the message pump");
             Guard.NotNullOrWhitespace(storageAccountConnectionStringSecretName, nameof(storageAccountConnectionStringSecretName), "Requires a non-blank secret name to retrieve the connection string to the Azure Blob storage where the event checkpoints will be stored and events will be load balanced during the event processing of the message pump");
-            
+
+            return services.AddMessagePump((serviceProvider, options) =>
+            {
+                ISecretProvider secretProvider = DetermineSecretProvider(serviceProvider);
+
+                return AzureEventHubsMessagePumpConfig.CreateByConnectionString(
+                    eventHubsName, eventHubsConnectionStringSecretName, 
+                    blobContainerName, storageAccountConnectionStringSecretName, 
+                    secretProvider, options);
+
+            }, configureOptions);
+        }
+
+        /// <summary>
+        /// Adds a message pump to consume events from Azure EventHubs.
+        /// </summary>
+        /// <param name="services">The collection of services to add the message pump to.</param>
+        /// <param name="eventHubsName">The name of the Event Hub that the processor is connected to, specific to the EventHubs namespace that contains it.</param>
+        /// <param name="fullyQualifiedNamespace">
+        ///     The fully qualified Event Hubs namespace to connect to.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.
+        /// </param>
+        /// <param name="blobContainerUri">
+        ///     The <see cref="Uri" /> referencing the blob container that includes the
+        ///     name of the account and the name of the container.
+        ///     This is likely to be similar to "https://{account_name}.blob.core.windows.net/{container_name}".
+        /// </param>
+        /// <returns>A collection where the <see cref="IAzureEventHubsMessageHandler{TMessage}"/>s can be configured.</returns>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="eventHubsName"/> or the <paramref name="fullyQualifiedNamespace"/> is blank.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
+        /// <exception cref="UriFormatException">Thrown when the <paramref name="blobContainerUri"/> is not an absolute URI.</exception>
+        public static EventHubsMessageHandlerCollection AddEventHubsMessagePumpUsingManagedIdentity(
+            this IServiceCollection services,
+            string eventHubsName,
+            string fullyQualifiedNamespace,
+            string blobContainerUri)
+        {
+            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure EventHubs message pump");
+            Guard.NotNullOrWhitespace(eventHubsName, nameof(eventHubsName), "Requires a non-blank Azure EventHubs name where the events will be sent to when adding an Azure EvenHubs message pump");
+            Guard.NotNullOrWhitespace(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace), "Requires a non-blank Azure EventHubs namespace to connect to");
+            Guard.NotNullOrWhitespace(blobContainerUri, nameof(blobContainerUri), "Requires a non-blank Azure Blob storage container endpoint to store event checkpoints and load balance the consumed event messages send to the message pump");
+            Guard.For<UriFormatException>(() => !Uri.IsWellFormedUriString(blobContainerUri, UriKind.Absolute), "Requires a valid absolute URI endpoint for the Azure Blob container to store event checkpoints and load balance the consumed event messages send to the message pump");
+
+            return services.AddEventHubsMessagePumpUsingManagedIdentity(
+                eventHubsName: eventHubsName,
+                fullyQualifiedNamespace: fullyQualifiedNamespace,
+                blobContainerUri: blobContainerUri,
+                configureOptions: null);
+        }
+
+        /// <summary>
+        /// Adds a message pump to consume events from Azure EventHubs.
+        /// </summary>
+        /// <param name="services">The collection of services to add the message pump to.</param>
+        /// <param name="eventHubsName">The name of the Event Hub that the processor is connected to, specific to the EventHubs namespace that contains it.</param>
+        /// <param name="fullyQualifiedNamespace">
+        ///     The fully qualified Event Hubs namespace to connect to.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.
+        /// </param>
+        /// <param name="blobContainerUri">
+        ///     The <see cref="Uri" /> referencing the blob container that includes the
+        ///     name of the account and the name of the container.
+        ///     This is likely to be similar to "https://{account_name}.blob.core.windows.net/{container_name}".
+        /// </param>
+        /// <param name="configureOptions">The function to configure additional options to influence the behavior of the message pump.</param>
+        /// <returns>A collection where the <see cref="IAzureEventHubsMessageHandler{TMessage}"/>s can be configured.</returns>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="eventHubsName"/> or the <paramref name="fullyQualifiedNamespace"/> is blank.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
+        /// <exception cref="UriFormatException">Thrown when the <paramref name="blobContainerUri"/> is not an absolute URI.</exception>
+        public static EventHubsMessageHandlerCollection AddEventHubsMessagePumpUsingManagedIdentity(
+            this IServiceCollection services,
+            string eventHubsName,
+            string fullyQualifiedNamespace,
+            string blobContainerUri,
+            Action<AzureEventHubsMessagePumpOptions> configureOptions)
+        {
+            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure EventHubs message pump");
+            Guard.NotNullOrWhitespace(eventHubsName, nameof(eventHubsName), "Requires a non-blank Azure EventHubs name where the events will be sent to when adding an Azure EvenHubs message pump");
+            Guard.NotNullOrWhitespace(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace), "Requires a non-blank Azure EventHubs namespace to connect to");
+            Guard.NotNullOrWhitespace(blobContainerUri, nameof(blobContainerUri), "Requires a non-blank Azure Blob storage container endpoint to store event checkpoints and load balance the consumed event messages send to the message pump");
+            Guard.For<UriFormatException>(() => !Uri.IsWellFormedUriString(blobContainerUri, UriKind.Absolute), "Requires a valid absolute URI endpoint for the Azure Blob container to store event checkpoints and load balance the consumed event messages send to the message pump");
+
+            return services.AddEventHubsMessagePumpUsingManagedIdentity(
+                eventHubsName: eventHubsName,
+                fullyQualifiedNamespace: fullyQualifiedNamespace,
+                blobContainerUri: blobContainerUri,
+                clientId: null,
+                configureOptions: configureOptions);
+        }
+
+         /// <summary>
+        /// Adds a message pump to consume events from Azure EventHubs.
+        /// </summary>
+        /// <param name="services">The collection of services to add the message pump to.</param>
+        /// <param name="eventHubsName">The name of the Event Hub that the processor is connected to, specific to the EventHubs namespace that contains it.</param>
+        /// <param name="fullyQualifiedNamespace">
+        ///     The fully qualified Event Hubs namespace to connect to.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.
+        /// </param>
+        /// <param name="blobContainerUri">
+        ///     The <see cref="Uri" /> referencing the blob container that includes the
+        ///     name of the account and the name of the container.
+        ///     This is likely to be similar to "https://{account_name}.blob.core.windows.net/{container_name}".
+        /// </param>
+        /// <param name="clientId">
+        ///     The client ID to authenticate for a user assigned managed identity. More information on user assigned managed identities cam be found here:
+        ///     <see href="https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm" />.
+        /// </param>
+        /// <returns>A collection where the <see cref="IAzureEventHubsMessageHandler{TMessage}"/>s can be configured.</returns>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="eventHubsName"/> or the <paramref name="fullyQualifiedNamespace"/> is blank.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
+        /// <exception cref="UriFormatException">Thrown when the <paramref name="blobContainerUri"/> is not an absolute URI.</exception>
+        public static EventHubsMessageHandlerCollection AddEventHubsMessagePumpUsingManagedIdentity(
+            this IServiceCollection services,
+            string eventHubsName,
+            string fullyQualifiedNamespace,
+            string blobContainerUri,
+            string clientId)
+        {
+            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure EventHubs message pump");
+            Guard.NotNullOrWhitespace(eventHubsName, nameof(eventHubsName), "Requires a non-blank Azure EventHubs name where the events will be sent to when adding an Azure EvenHubs message pump");
+            Guard.NotNullOrWhitespace(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace), "Requires a non-blank Azure EventHubs namespace to connect to");
+            Guard.NotNullOrWhitespace(blobContainerUri, nameof(blobContainerUri), "Requires a non-blank Azure Blob storage container endpoint to store event checkpoints and load balance the consumed event messages send to the message pump");
+            Guard.For<UriFormatException>(() => !Uri.IsWellFormedUriString(blobContainerUri, UriKind.Absolute), "Requires a valid absolute URI endpoint for the Azure Blob container to store event checkpoints and load balance the consumed event messages send to the message pump");
+
+            return services.AddEventHubsMessagePumpUsingManagedIdentity(
+                eventHubsName: eventHubsName,
+                fullyQualifiedNamespace: fullyQualifiedNamespace,
+                blobContainerUri: blobContainerUri,
+                clientId: clientId,
+                configureOptions: null);
+        }
+
+        /// <summary>
+        /// Adds a message pump to consume events from Azure EventHubs.
+        /// </summary>
+        /// <param name="services">The collection of services to add the message pump to.</param>
+        /// <param name="eventHubsName">The name of the Event Hub that the processor is connected to, specific to the EventHubs namespace that contains it.</param>
+        /// <param name="fullyQualifiedNamespace">
+        ///     The fully qualified Event Hubs namespace to connect to.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.
+        /// </param>
+        /// <param name="blobContainerUri">
+        ///     The <see cref="Uri" /> referencing the blob container that includes the
+        ///     name of the account and the name of the container.
+        ///     This is likely to be similar to "https://{account_name}.blob.core.windows.net/{container_name}".
+        /// </param>
+        /// <param name="clientId">
+        ///     The client ID to authenticate for a user assigned managed identity. More information on user assigned managed identities cam be found here:
+        ///     <see href="https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview#how-a-user-assigned-managed-identity-works-with-an-azure-vm" />.
+        /// </param>
+        /// <param name="configureOptions">The function to configure additional options to influence the behavior of the message pump.</param>
+        /// <returns>A collection where the <see cref="IAzureEventHubsMessageHandler{TMessage}"/>s can be configured.</returns>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="eventHubsName"/> or the <paramref name="fullyQualifiedNamespace"/> is blank.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
+        /// <exception cref="UriFormatException">Thrown when the <paramref name="blobContainerUri"/> is not an absolute URI.</exception>
+        public static EventHubsMessageHandlerCollection AddEventHubsMessagePumpUsingManagedIdentity(
+            this IServiceCollection services,
+            string eventHubsName,
+            string fullyQualifiedNamespace,
+            string blobContainerUri,
+            string clientId,
+            Action<AzureEventHubsMessagePumpOptions> configureOptions)
+        {
+            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure EventHubs message pump");
+            Guard.NotNullOrWhitespace(eventHubsName, nameof(eventHubsName), "Requires a non-blank Azure EventHubs name where the events will be sent to when adding an Azure EvenHubs message pump");
+            Guard.NotNullOrWhitespace(fullyQualifiedNamespace, nameof(fullyQualifiedNamespace), "Requires a non-blank Azure EventHubs namespace to connect to");
+            Guard.NotNullOrWhitespace(blobContainerUri, nameof(blobContainerUri), "Requires a non-blank Azure Blob storage container endpoint to store event checkpoints and load balance the consumed event messages send to the message pump");
+            Guard.For<UriFormatException>(() => !Uri.IsWellFormedUriString(blobContainerUri, UriKind.Absolute), "Requires a valid absolute URI endpoint for the Azure Blob container to store event checkpoints and load balance the consumed event messages send to the message pump");
+
+            return services.AddMessagePump((_, options) =>
+            {
+               return AzureEventHubsMessagePumpConfig.CreateByTokenCredential(
+                   eventHubsName, fullyQualifiedNamespace,
+                   new Uri(blobContainerUri),
+                   new DefaultAzureCredential(new DefaultAzureCredentialOptions { ManagedIdentityClientId = clientId }),
+                   options);
+
+            }, configureOptions);
+        }
+
+        private static EventHubsMessageHandlerCollection AddMessagePump(
+            this IServiceCollection services,
+            Func<IServiceProvider, AzureEventHubsMessagePumpOptions, AzureEventHubsMessagePumpConfig> createConfig,
+            Action<AzureEventHubsMessagePumpOptions> configureOptions)
+        {
+            AzureEventHubsMessagePumpOptions options = CreateOptions(configureOptions);
+            EventHubsMessageHandlerCollection collection = services.AddMessageRouter(options);
+
+            services.AddMessagePump(serviceProvider =>
+            {
+                AzureEventHubsMessagePumpConfig config = createConfig(serviceProvider, options);
+                return CreateMessagePump(serviceProvider, config);
+            });
+
+            return collection;
+        }
+
+        private static AzureEventHubsMessagePumpOptions CreateOptions(Action<AzureEventHubsMessagePumpOptions> configureOptions)
+        {
             var options = new AzureEventHubsMessagePumpOptions();
             configureOptions?.Invoke(options);
+            
+            return options;
+        }
 
+        private static AzureEventHubsMessagePump CreateMessagePump(IServiceProvider serviceProvider, AzureEventHubsMessagePumpConfig eventHubsConfig)
+        {
+            var appConfiguration = serviceProvider.GetRequiredService<IConfiguration>();
+            var router = serviceProvider.GetService<IAzureEventHubsMessageRouter>();
+            var logger = serviceProvider.GetRequiredService<ILogger<AzureEventHubsMessagePump>>();
+
+            return new AzureEventHubsMessagePump(eventHubsConfig, appConfiguration, serviceProvider, router, logger);
+        }
+
+        private static EventHubsMessageHandlerCollection AddMessageRouter(this IServiceCollection services, AzureEventHubsMessagePumpOptions options)
+        {
             EventHubsMessageHandlerCollection collection = services.AddEventHubsMessageRouting(provider =>
             {
                 var logger = provider.GetService<ILogger<AzureEventHubsMessageRouter>>();
                 return new AzureEventHubsMessageRouter(provider, options.Routing, logger);
             });
             collection.JobId = options.JobId;
-
-            services.AddMessagePump(serviceProvider =>
-            {
-                ISecretProvider secretProvider = DetermineSecretProvider(serviceProvider);
-                var eventHubsConfig = new AzureEventHubsMessagePumpConfig(
-                    eventHubsName, eventHubsConnectionStringSecretName, blobContainerName, storageAccountConnectionStringSecretName, secretProvider, options);
-
-                var appConfiguration = serviceProvider.GetRequiredService<IConfiguration>();
-                var router = serviceProvider.GetService<IAzureEventHubsMessageRouter>();
-                var logger = serviceProvider.GetRequiredService<ILogger<AzureEventHubsMessagePump>>();
-
-                return new AzureEventHubsMessagePump(eventHubsConfig, appConfiguration, serviceProvider, router, logger);
-            });
-
+            
             return collection;
         }
 

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/TemporaryManagedIdentityConnection.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/TemporaryManagedIdentityConnection.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using GuardNet;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Arcus.Messaging.Tests.Integration.Fixture
+{
+    /// <summary>
+    /// Represents a temporary connection to Azure with managed identity.
+    /// </summary>
+    internal class TemporaryManagedIdentityConnection : IDisposable
+    {
+        private readonly ILogger _logger;
+        private readonly TemporaryEnvironmentVariable[] _environmentVariables;
+
+        private TemporaryManagedIdentityConnection(
+            string clientId,
+            ILogger logger,
+            params TemporaryEnvironmentVariable[] environmentVariables)
+        {
+            Guard.NotNull(environmentVariables, nameof(environmentVariables));
+            Guard.NotAny(environmentVariables, nameof(environmentVariables));
+
+            _logger = logger ?? NullLogger.Instance;
+            _environmentVariables = environmentVariables;
+            ClientId = clientId;
+        }
+
+        /// <summary>
+        /// Gets the client ID of the user-assigned managed identity in this current connection.
+        /// </summary>
+        public string ClientId { get; }
+
+        /// <summary>
+        /// Creates a <see cref="TemporaryManagedIdentityConnection"/> instance based on the current test <paramref name="configuration"/>.
+        /// </summary>
+        /// <param name="configuration">The current integration test configuration which includes the necessary settings to set up the managed identity connection.</param>
+        /// <param name="logger">The logger instance to write diagnostic trace messages during the setup of the managed identity connection.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="configuration"/> is <c>null</c>.</exception>
+        internal static TemporaryManagedIdentityConnection Create(TestConfig configuration, ILogger logger)
+        {
+            Guard.NotNull(configuration, nameof(configuration));
+            logger ??= NullLogger.Instance;
+
+            string tenantId = configuration.GetTenantId();
+            ServicePrincipal servicePrincipal = configuration.GetServicePrincipal();
+
+            logger.LogTrace("Set managed identity connection for service principal: {ClientId}", servicePrincipal.ClientId);
+            return new TemporaryManagedIdentityConnection(
+                servicePrincipal.ClientId,
+                logger,
+                TemporaryEnvironmentVariable.Create(EnvironmentVariables.AzureTenantId, tenantId),
+                TemporaryEnvironmentVariable.Create(EnvironmentVariables.AzureServicePrincipalClientId, servicePrincipal.ClientId),
+                TemporaryEnvironmentVariable.Create(EnvironmentVariables.AzureServicePrincipalClientSecret, servicePrincipal.ClientSecret));
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            _logger.LogTrace("Remove managed identity connection for service principal: {ClientId}", ClientId);
+            Assert.All(_environmentVariables, envVar => envVar.Dispose());
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/TestConfig.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/TestConfig.cs
@@ -87,14 +87,14 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
         }
 
         /// <summary>
-        /// Gets the service principal that can authenticate with the Azure Service Bus used in these integration tests.
+        /// Gets the service principal that can authenticate with the Azure resources used in these integration tests.
         /// </summary>
         /// <returns></returns>
-        public ServicePrincipal GetServiceBusServicePrincipal()
+        public ServicePrincipal GetServicePrincipal()
         {
             var servicePrincipal = new ServicePrincipal(
-                clientId: _config.GetValue<string>("Arcus:ServiceBus:SelfContained:ServicePrincipal:ClientId"),
-                clientSecret: _config.GetValue<string>("Arcus:ServiceBus:SelfContained:ServicePrincipal:ClientSecret"));
+                clientId: _config.GetValue<string>("Arcus:Infra:ServicePrincipal:ClientId"),
+                clientSecret: _config.GetValue<string>("Arcus:Infra:ServicePrincipal:ClientSecret"));
 
             return servicePrincipal;
         }
@@ -104,7 +104,7 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
         /// </summary>
         public string GetTenantId()
         {
-            const string tenantIdKey = "Arcus:ServiceBus:SelfContained:TenantId";
+            const string tenantIdKey = "Arcus:Infra:TenantId";
             var tenantId = _config.GetValue<string>(tenantIdKey);
             Guard.For<KeyNotFoundException>(() => tenantId is null, $"Requires a non-blank 'TenantId' at '{tenantIdKey}'");
 

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/Worker.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/Worker.cs
@@ -62,7 +62,7 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
             }
             catch (OperationCanceledException)
             {
-                // Ignore.
+                // Ignore: cancellation is to be expected when the test runs to its end.
             }
         }
     }

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/EventHubs/TemporaryBlobStorageContainer.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/EventHubs/TemporaryBlobStorageContainer.cs
@@ -25,12 +25,18 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump.EventHubs
             _logger = logger;
 
             ContainerName = containerName;
+            ContainerUri = client.Uri.OriginalString;
         }
 
         /// <summary>
         /// Gets the container name used during this temporary Azure Blob storage container.
         /// </summary>
         public string ContainerName { get; }
+
+        /// <summary>
+        /// Gets the container primary endpoint used during this temporary Azure Blob storage container.
+        /// </summary>
+        public string ContainerUri { get; }
 
         /// <summary>
         /// Creates an <see cref="TemporaryBlobStorageContainer"/> instance that creates an Azure Blob container on the Azure storage account

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/EventHubsMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/EventHubsMessagePumpTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -27,8 +26,6 @@ using Arcus.Messaging.Tests.Workers.MessageHandlers;
 using Arcus.Testing.Logging;
 using Azure.Messaging.EventGrid;
 using Azure.Messaging.EventHubs;
-using Bogus;
-using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Azure;
@@ -47,9 +44,10 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
     [Trait("Category", "Integration")]
     public class EventHubsMessagePumpTests : IAsyncLifetime
     {
-        private readonly ITestOutputHelper _outputWriter;
         private readonly TestConfig _config;
+        private readonly EventHubsConfig _eventHubsConfig;
         private readonly ILogger _logger;
+        private readonly ITestOutputHelper _outputWriter;
 
         private TemporaryBlobStorageContainer _blobStorageContainer;
 
@@ -59,10 +57,14 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
         public EventHubsMessagePumpTests(ITestOutputHelper outputWriter)
         {
             _outputWriter = outputWriter;
-            _config = TestConfig.Create();
             _logger = new XunitTestLogger(outputWriter);
+            
+            _config = TestConfig.Create();
+            _eventHubsConfig = _config.GetEventHubsConfig();
         }
 
+        private string EventHubsName => _eventHubsConfig.GetEventHubsName(IntegrationTestType.SelfContained);
+        private string FullyQualifiedEventHubsNamespace => EventHubsConnectionStringProperties.Parse(_eventHubsConfig.EventHubsConnectionString).FullyQualifiedNamespace;
         private string ContainerName => _blobStorageContainer.ContainerName;
 
         /// <summary>
@@ -70,104 +72,96 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
         /// </summary>
         public async Task InitializeAsync()
         {
-            EventHubsConfig eventHubs = _config.GetEventHubsConfig();
-            _blobStorageContainer = await TemporaryBlobStorageContainer.CreateAsync(eventHubs.StorageConnectionString, _logger);
+            _blobStorageContainer = await TemporaryBlobStorageContainer.CreateAsync(_eventHubsConfig.StorageConnectionString, _logger);
         }
 
         [Fact]
         public async Task EventHubsMessagePump_PublishMessageForHierarchical_MessageSuccessfullyProcessed()
         {
             // Arrange
-            EventHubsConfig eventHubs = _config.GetEventHubsConfig();
             var options = new WorkerOptions();
-            AddEventHubsMessagePump(options, eventHubs, opt => opt.Routing.Correlation.Format = MessageCorrelationFormat.Hierarchical)
+            AddEventHubsMessagePump(options, opt => opt.Routing.Correlation.Format = MessageCorrelationFormat.Hierarchical)
                .WithEventHubsMessageHandler<OrderEventHubsMessageHandler, Order>();
 
             // Act / Assert
-            await TestEventHubsMessageHandlingForHierarchicalAsync(options, eventHubs);
+            await TestEventHubsMessageHandlingForHierarchicalAsync(options);
         }
 
         [Fact]
         public async Task EventHubsMessagePump_PublishMessageForW3C_MessageSuccessfullyProcessed()
         {
             // Arrange
-            EventHubsConfig eventHubs = _config.GetEventHubsConfig();
             var options = new WorkerOptions();
-            AddEventHubsMessagePump(options, eventHubs, opt => opt.Routing.Correlation.Format = MessageCorrelationFormat.W3C)
+            AddEventHubsMessagePump(options, opt => opt.Routing.Correlation.Format = MessageCorrelationFormat.W3C)
                 .WithEventHubsMessageHandler<OrderEventHubsMessageHandler, Order>();
 
             // Act / Assert
-            await TestEventHubsMessageHandlingForW3CAsync(options, eventHubs);
+            await TestEventHubsMessageHandlingForW3CAsync(options);
         }
 
         [Fact]
         public async Task EventHubsMessagePumpWithoutSameJobId_PublishesMessage_MessageFailsToBeProcessed()
         {
             // Arrange
-            EventHubsConfig eventHubs = _config.GetEventHubsConfig();
             var options = new WorkerOptions();
-            EventHubsMessageHandlerCollection collection = AddEventHubsMessagePump(options, eventHubs);
+            EventHubsMessageHandlerCollection collection = AddEventHubsMessagePump(options);
             Assert.False(string.IsNullOrWhiteSpace(collection.JobId));
 
             var otherCollection = new EventHubsMessageHandlerCollection(new ServiceCollection());
             otherCollection.JobId = Guid.NewGuid().ToString();
 
-            otherCollection.WithEventHubsMessageHandler<TestEventHubsMessageHandler<Order>, Order>(messageContextFilter: context => false)
+            otherCollection.WithEventHubsMessageHandler<TestEventHubsMessageHandler<Order>, Order>(messageContextFilter: _ => false)
                            .WithEventHubsMessageHandler<OrderEventHubsMessageHandler, Order>();
 
             // Act / Assert
-            await TestFailedEventHubsMessageHandlingForW3CAsync(options, eventHubs);
+            await TestFailedEventHubsMessageHandlingForW3CAsync(options);
         }
 
         [Fact]
         public async Task EventHubsMessagePumpWithMessageContextFilter_PublishesMessage_MessageSuccessfullyProcessed()
         {
             // Arrange
-            EventHubsConfig eventHubs = _config.GetEventHubsConfig();
             var options = new WorkerOptions();
-            AddEventHubsMessagePump(options, eventHubs)
-                .WithEventHubsMessageHandler<TestEventHubsMessageHandler<Order>, Order>(messageContextFilter: context => false)
+            AddEventHubsMessagePump(options)
+                .WithEventHubsMessageHandler<TestEventHubsMessageHandler<Order>, Order>(messageContextFilter: _ => false)
                 .WithEventHubsMessageHandler<OrderEventHubsMessageHandler, Order>();
 
             // Act / Assert
-            await TestEventHubsMessageHandlingForW3CAsync(options, eventHubs);
+            await TestEventHubsMessageHandlingForW3CAsync(options);
         }
 
         [Fact]
         public async Task EventHubsMessagePumpWithMessageFilter_PublishesMessage_MessageSuccessfullyProcessed()
         {
             // Arrange
-            EventHubsConfig eventHubs = _config.GetEventHubsConfig();
             var options = new WorkerOptions();
-            AddEventHubsMessagePump(options, eventHubs)
-                .WithEventHubsMessageHandler<TestEventHubsMessageHandler<Order>, Order>(messageBodyFilter: body => false)
+            AddEventHubsMessagePump(options)
+                .WithEventHubsMessageHandler<TestEventHubsMessageHandler<Order>, Order>(messageBodyFilter: _ => false)
                 .WithEventHubsMessageHandler<OrderEventHubsMessageHandler, Order>();
 
             // Act / Assert
-            await TestEventHubsMessageHandlingForW3CAsync(options, eventHubs);
+            await TestEventHubsMessageHandlingForW3CAsync(options);
         }
 
         [Fact]
         public async Task EventHubsMessagePumpWithDifferentMessageType_PublishesMessage_MessageSuccessfullyProcessed()
         {
             // Arrange
-            EventHubsConfig eventHubs = _config.GetEventHubsConfig();
             var options = new WorkerOptions();
-            AddEventHubsMessagePump(options, eventHubs)
+            AddEventHubsMessagePump(options)
                 .WithEventHubsMessageHandler<TestEventHubsMessageHandler<Shipment>, Shipment>()
                 .WithEventHubsMessageHandler<OrderEventHubsMessageHandler, Order>();
 
             // Act / Assert
-            await TestEventHubsMessageHandlingForW3CAsync(options, eventHubs);
+            await TestEventHubsMessageHandlingForW3CAsync(options);
         }
 
         [Fact]
         public async Task EventHubsMessagePumpWithMessageBodySerializer_PublishesMessage_MessageSuccessfullyProcessed()
         {
             // Arrange
-            EventHubsConfig eventHubs = _config.GetEventHubsConfig();
             var options = new WorkerOptions();
-            AddEventHubsMessagePump(options, eventHubs)
+            AddEventHubsMessagePump(options)
                 .WithEventHubsMessageHandler<OrderEventHubsMessageHandler, Order>(messageBodySerializerImplementationFactory: provider =>
                 {
                     var logger = provider.GetService<ILogger<OrderBatchMessageBodySerializer>>();
@@ -175,37 +169,53 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                 });
 
             // Act / Assert
-            await TestEventHubsMessageHandlingForW3CAsync(options, eventHubs);
+            await TestEventHubsMessageHandlingForW3CAsync(options);
         }
 
         [Fact]
         public async Task EventHubsMessagePumpWithFallback_PublishesMessage_MessageSuccessfullyProcessed()
         {
             // Arrange
-            EventHubsConfig eventHubs = _config.GetEventHubsConfig();
             var options = new WorkerOptions();
-            AddEventHubsMessagePump(options, eventHubs)
+            AddEventHubsMessagePump(options)
                 .WithEventHubsMessageHandler<TestEventHubsMessageHandler<Shipment>, Shipment>()
                 .WithFallbackMessageHandler<SabotageEventHubsFallbackMessageHandler, AzureEventHubsMessageContext>()
                 .WithFallbackMessageHandler<OrderEventHubsFallbackMessageHandler>();
 
             // Act / Assert
-            await TestEventHubsMessageHandlingForW3CAsync(options, eventHubs);
+            await TestEventHubsMessageHandlingForW3CAsync(options);
+        }
+
+        [Fact]
+        public async Task EventHubsMessagePumpUsingManagedIdentity_PublishesMessage_MessageSuccessfullyProcessed()
+        {
+            // Arrange
+            var options = new WorkerOptions();
+            using var auth = TemporaryManagedIdentityConnection.Create(_config, _logger);
+            
+            options.AddEventGridPublisher(_config)
+                   .AddEventHubsMessagePumpUsingManagedIdentity(
+                       eventHubsName: EventHubsName,
+                       fullyQualifiedNamespace: FullyQualifiedEventHubsNamespace,
+                       blobContainerUri: _blobStorageContainer.ContainerUri,
+                       clientId: auth.ClientId)
+                   .WithEventHubsMessageHandler<OrderEventHubsMessageHandler, Order>();
+
+            // Act / Assert
+            await TestEventHubsMessageHandlingForW3CAsync(options);
         }
 
         [Fact]
         public async Task RestartedEventHubsMessagePump_PublishMessage_MessageSuccessfullyProcessed()
         {
             // Arrange
-            EventHubsConfig eventHubs = _config.GetEventHubsConfig();
             var options = new WorkerOptions();
-            AddEventHubsMessagePump(options, eventHubs)
+            AddEventHubsMessagePump(options)
                 .WithEventHubsMessageHandler<OrderEventHubsMessageHandler, Order>();
 
             var traceParent = TraceParent.Generate();
             EventData expected = CreateOrderEventDataMessageForW3C(traceParent);
-            string eventHubsName = eventHubs.GetEventHubsName(IntegrationTestType.SelfContained);
-            var producer = new TestEventHubsMessageProducer(eventHubs.EventHubsConnectionString, eventHubsName);
+            TestEventHubsMessageProducer producer = CreateEventHubsMessageProducer();
 
             await using (var worker = await Worker.StartNewAsync(options))
             await using (var consumer = await TestServiceBusMessageEventConsumer.StartNewAsync(_config, _logger))
@@ -223,28 +233,23 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                 await producer.ProduceAsync(expected);
 
                 // Assert
-                OrderCreatedEventData actual = consumer.ConsumeOrderEventForW3C(traceParent.TransactionId);
-                AssertReceivedOrderEventDataForW3C(expected, actual, traceParent);
+                AssertConsumeW3CEvent(consumer, traceParent, expected);
             }
         }
 
         [Fact]
-        public async Task EventHubsMessagePumpWithAll_PublishesMessage_MessageSuccessfullyProcessed()
+        public async Task EventHubsMessagePumpWithAllFiltersAndOptions_PublishesMessage_MessageSuccessfullyProcessed()
         {
             // Arrange
-            EventHubsConfig eventHubs = _config.GetEventHubsConfig();
-            string eventHubsName = eventHubs.GetEventHubsName(IntegrationTestType.SelfContained);
-            var properties = EventHubsConnectionStringProperties.Parse(eventHubs.EventHubsConnectionString);
-            
             var options = new WorkerOptions();
-            AddEventHubsMessagePump(options, eventHubs)
+            AddEventHubsMessagePump(options)
                 .WithEventHubsMessageHandler<TestEventHubsMessageHandler<Shipment>, Shipment>()
-                .WithEventHubsMessageHandler<TestEventHubsMessageHandler<Order>, Order>(messageBodyFilter: body => false)
-                .WithEventHubsMessageHandler<TestEventHubsMessageHandler<Order>, Order>(messageContextFilter: body => false)
+                .WithEventHubsMessageHandler<TestEventHubsMessageHandler<Order>, Order>(messageBodyFilter: _ => false)
+                .WithEventHubsMessageHandler<TestEventHubsMessageHandler<Order>, Order>(messageContextFilter: _ => false)
                 .WithEventHubsMessageHandler<OrderEventHubsMessageHandler, Order>(
                     messageContextFilter: context => context.ConsumerGroup == "$Default" 
-                                                     && context.EventHubsName == eventHubsName
-                                                     && context.EventHubsNamespace == properties.FullyQualifiedNamespace,
+                                                     && context.EventHubsName == EventHubsName
+                                                     && context.EventHubsNamespace == FullyQualifiedEventHubsNamespace,
                     messageBodySerializerImplementationFactory: provider =>
                     {
                         var logger = provider.GetService<ILogger<OrderBatchMessageBodySerializer>>();
@@ -260,17 +265,16 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                     });
 
             // Act / Assert
-            await TestEventHubsMessageHandlingForW3CAsync(options, eventHubs);
+            await TestEventHubsMessageHandlingForW3CAsync(options);
         }
 
         [Fact]
         public async Task EventHubsMessagePump_WithCustomTransactionIdProperty_RetrievesCorrelationCorrectlyDuringMessageProcessing()
         {
             // Arrange
-            EventHubsConfig eventHubs = _config.GetEventHubsConfig();
             var customTransactionIdPropertyName = "MyTransactionId";
             var options = new WorkerOptions();
-            AddEventHubsMessagePump(options, eventHubs, opt =>
+            AddEventHubsMessagePump(options, opt =>
                 {
                     opt.Routing.Correlation.Format = MessageCorrelationFormat.Hierarchical;
                     opt.Routing.Correlation.TransactionIdPropertyName = customTransactionIdPropertyName;
@@ -278,17 +282,16 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                 .WithEventHubsMessageHandler<OrderEventHubsMessageHandler, Order>();
 
             // Act / Assert
-            await TestEventHubsMessageHandlingForHierarchicalAsync(options, eventHubs, customTransactionIdPropertyName);
+            await TestEventHubsMessageHandlingForHierarchicalAsync(options, customTransactionIdPropertyName);
         }
 
         [Fact]
         public async Task EventHubsMessagePump_WithCustomOperationParentIdProperty_RetrievesCorrelationCorrectlyDuringMessageProcessing()
         {
             // Arrange
-            EventHubsConfig eventHubs = _config.GetEventHubsConfig();
             var customOperationParentIdPropertyName = "MyOperationParentId";
             var options = new WorkerOptions();
-            AddEventHubsMessagePump(options, eventHubs, opt =>
+            AddEventHubsMessagePump(options, opt =>
                 {
                     opt.Routing.Correlation.Format = MessageCorrelationFormat.Hierarchical;
                     opt.Routing.Correlation.OperationParentIdPropertyName = customOperationParentIdPropertyName;
@@ -296,26 +299,22 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                 .WithEventHubsMessageHandler<OrderEventHubsMessageHandler, Order>();
 
             // Act / Assert
-            await TestEventHubsMessageHandlingForHierarchicalAsync(options, eventHubs, operationParentIdPropertyName: customOperationParentIdPropertyName);
+            await TestEventHubsMessageHandlingForHierarchicalAsync(options, operationParentIdPropertyName: customOperationParentIdPropertyName);
         }
 
         [Fact]
         public async Task EventHubsMessagePump_PausesViaLifetime_RestartsAgain()
         {
             // Arrange
-            EventHubsConfig eventHubs = _config.GetEventHubsConfig();
             string jobId = Guid.NewGuid().ToString();
             var options = new WorkerOptions();
-            AddEventHubsMessagePump(options, eventHubs, opt => opt.JobId = jobId)
+            AddEventHubsMessagePump(options, opt => opt.JobId = jobId)
                 .WithEventHubsMessageHandler<OrderEventHubsMessageHandler, Order>();
 
             var traceParent = TraceParent.Generate();
             EventData expected = CreateOrderEventDataMessageForW3C(traceParent);
 
-            var producer = new TestEventHubsMessageProducer(
-                eventHubs.EventHubsConnectionString, 
-                eventHubs.GetEventHubsName(IntegrationTestType.SelfContained));
-
+            TestEventHubsMessageProducer producer = CreateEventHubsMessageProducer();
             await using (var worker = await Worker.StartNewAsync(options))
             await using (var consumer = await TestServiceBusMessageEventConsumer.StartNewAsync(_config, _logger))
             {
@@ -326,8 +325,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                 await producer.ProduceAsync(expected);
 
                 // Assert
-                OrderCreatedEventData actual = consumer.ConsumeOrderEventForW3C(traceParent.TransactionId);
-                AssertReceivedOrderEventDataForW3C(expected, actual, traceParent);
+                AssertConsumeW3CEvent(consumer, traceParent, expected);
             }
         }
 
@@ -341,19 +339,16 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             var options = new WorkerOptions();
             options.ConfigureSerilog(config => config.WriteTo.ApplicationInsights(spySink));
 
-            EventHubsConfig eventHubs = _config.GetEventHubsConfig();
-            AddEventHubsMessagePump(options, eventHubs)
+            AddEventHubsMessagePump(options)
                 .WithEventHubsMessageHandler<OrderWithAutoTrackingEventHubsMessageHandler, Order>();
 
             var traceParent = TraceParent.Generate();
-            var eventData = new EventData(BinaryData.FromObjectAsJson(OrderGenerator.Generate())).WithDiagnosticId(traceParent);
+            var eventData = CreateOrderEventDataMessageForW3C(traceParent);
 
-            var producer = new TestEventHubsMessageProducer(
-                eventHubs.EventHubsConnectionString, 
-                eventHubs.GetEventHubsName(IntegrationTestType.SelfContained));
+            TestEventHubsMessageProducer producer = CreateEventHubsMessageProducer();
 
             await using (var worker = await Worker.StartNewAsync(options))
-            await using (var consumer = await TestServiceBusMessageEventConsumer.StartNewAsync(_config, _logger))
+            await using (await TestServiceBusMessageEventConsumer.StartNewAsync(_config, _logger))
             {
                 worker.Services.GetRequiredService<TelemetryConfiguration>().TelemetryChannel = spyChannel;
 
@@ -383,17 +378,14 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             var options = new WorkerOptions();
             options.ConfigureSerilog(config => config.WriteTo.ApplicationInsights(spySink));
 
-            EventHubsConfig eventHubs = _config.GetEventHubsConfig();
-            AddEventHubsMessagePump(options, eventHubs)
+            AddEventHubsMessagePump(options)
                 .WithEventHubsMessageHandler<OrderWithAutoTrackingEventHubsMessageHandler, Order>();
 
-            var eventData = new EventData(BinaryData.FromObjectAsJson(OrderGenerator.Generate()));
-            var producer = new TestEventHubsMessageProducer(
-                eventHubs.EventHubsConnectionString, 
-                eventHubs.GetEventHubsName(IntegrationTestType.SelfContained));
+            EventData eventData = CreateOrderEventDataMessageForW3C(traceParent: null);
+            TestEventHubsMessageProducer producer = CreateEventHubsMessageProducer();
 
             await using (var worker = await Worker.StartNewAsync(options))
-            await using (var consumer = await TestServiceBusMessageEventConsumer.StartNewAsync(_config, _logger))
+            await using (await TestServiceBusMessageEventConsumer.StartNewAsync(_config, _logger))
             {
                 worker.Services.GetRequiredService<TelemetryConfiguration>().TelemetryChannel = spyChannel;
 
@@ -409,17 +401,16 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                     bool correlationSuccess = spySink.Telemetries.Any(t =>
                     {
                         return t is RequestTelemetry r && r.Name == "Process" 
-                               && dependenciesViaArcusKeyVault.SingleOrDefault(d => d.Context.Operation.ParentId == r.Id) != null
-                               && dependenciesViaMicrosoftSql.SingleOrDefault(d => d.Context.Operation.ParentId == r.Id) != null;
+                                                       && dependenciesViaArcusKeyVault.SingleOrDefault(d => d.Context.Operation.ParentId == r.Id) != null
+                                                       && dependenciesViaMicrosoftSql.SingleOrDefault(d => d.Context.Operation.ParentId == r.Id) != null;
                     });
                     Assert.True(correlationSuccess);
                 }, timeout: TimeSpan.FromMinutes(1), _logger);
             }
         }
 
-        private EventHubsMessageHandlerCollection AddEventHubsMessagePump(WorkerOptions options, EventHubsConfig eventHubs, Action<AzureEventHubsMessagePumpOptions> configureOptions = null)
+        private EventHubsMessageHandlerCollection AddEventHubsMessagePump(WorkerOptions options, Action<AzureEventHubsMessagePumpOptions> configureOptions = null)
         {
-            string eventHubsName = eventHubs.GetEventHubsName(IntegrationTestType.SelfContained);
             string eventHubsConnectionStringSecretName = "Arcus_EventHubs_ConnectionString",
                    storageAccountConnectionStringSecretName = "Arcus_StorageAccount_ConnectionString";
 
@@ -427,24 +418,65 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                           .AddXunitTestLogging(_outputWriter)
                           .AddSecretStore(stores => stores.AddInMemory(new Dictionary<string, string>
                           {
-                              [eventHubsConnectionStringSecretName] = eventHubs.EventHubsConnectionString,
-                              [storageAccountConnectionStringSecretName] = eventHubs.StorageConnectionString
+                              [eventHubsConnectionStringSecretName] = _eventHubsConfig.EventHubsConnectionString,
+                              [storageAccountConnectionStringSecretName] = _eventHubsConfig.StorageConnectionString
                           }))
-                          .AddEventHubsMessagePump(eventHubsName, eventHubsConnectionStringSecretName, ContainerName, storageAccountConnectionStringSecretName, configureOptions);
+                          .AddEventHubsMessagePump(EventHubsName, eventHubsConnectionStringSecretName, ContainerName, storageAccountConnectionStringSecretName, configureOptions);
+        }
+
+        private async Task TestEventHubsMessageHandlingForW3CAsync(WorkerOptions options)
+        {
+            await TestEventHubsMessageHandlingForW3CAsync(options,
+                (traceParent, expected, consumer) => AssertConsumeW3CEvent(consumer, traceParent, expected));
+        }
+
+        private static void AssertConsumeW3CEvent(
+            TestServiceBusMessageEventConsumer consumer,
+            TraceParent traceParent,
+            EventData expected)
+        {
+            OrderCreatedEventData actual = consumer.ConsumeOrderEventForW3C(traceParent.TransactionId);
+            AssertReceivedOrderEventDataForW3C(expected, actual, traceParent);
+        }
+
+        private async Task TestFailedEventHubsMessageHandlingForW3CAsync(WorkerOptions options)
+        {
+            await TestEventHubsMessageHandlingForW3CAsync(options,
+                (traceParent, _, consumer) =>
+                {
+                    Assert.Throws<TimeoutException>(() => consumer.ConsumeOrderEventForW3C(traceParent.TransactionId, timeoutInSeconds: 30));
+                });
+        }
+
+        private async Task TestEventHubsMessageHandlingForW3CAsync(
+            WorkerOptions options,
+            Action<TraceParent, EventData, TestServiceBusMessageEventConsumer> assertion)
+        {
+            var traceParent = TraceParent.Generate();
+            EventData expected = CreateOrderEventDataMessageForW3C(traceParent);
+
+            TestEventHubsMessageProducer producer = CreateEventHubsMessageProducer();
+
+            await using (await Worker.StartNewAsync(options))
+            await using (var consumer = await TestServiceBusMessageEventConsumer.StartNewAsync(_config, _logger))
+            {
+                // Act
+                await producer.ProduceAsync(expected);
+
+                // Assert
+                assertion(traceParent, expected, consumer);
+            }
         }
 
         private async Task TestEventHubsMessageHandlingForHierarchicalAsync(
             WorkerOptions options, 
-            EventHubsConfig eventHubs, 
             string transactionIdPropertyName = PropertyNames.TransactionId, 
             string operationParentIdPropertyName = PropertyNames.OperationParentId)
         {
             EventData expected = CreateOrderEventDataMessageForHierarchical(transactionIdPropertyName, operationParentIdPropertyName);
-            var producer = new TestEventHubsMessageProducer(
-                eventHubs.EventHubsConnectionString, 
-                eventHubs.GetEventHubsName(IntegrationTestType.SelfContained));
+            TestEventHubsMessageProducer producer = CreateEventHubsMessageProducer();
 
-            await using (var worker = await Worker.StartNewAsync(options))
+            await using (await Worker.StartNewAsync(options))
             await using (var consumer = await TestServiceBusMessageEventConsumer.StartNewAsync(_config, _logger))
             {
                 // Act
@@ -456,49 +488,11 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             }
         }
 
-        private async Task TestEventHubsMessageHandlingForW3CAsync(
-            WorkerOptions options,
-            EventHubsConfig eventHubs)
+        private TestEventHubsMessageProducer CreateEventHubsMessageProducer()
         {
-            var traceParent = TraceParent.Generate();
-            EventData expected = CreateOrderEventDataMessageForW3C(traceParent);
-
-            var producer = new TestEventHubsMessageProducer(
-                eventHubs.EventHubsConnectionString, 
-                eventHubs.GetEventHubsName(IntegrationTestType.SelfContained));
-
-            await using (var worker = await Worker.StartNewAsync(options))
-            await using (var consumer = await TestServiceBusMessageEventConsumer.StartNewAsync(_config, _logger))
-            {
-                // Act
-                await producer.ProduceAsync(expected);
-
-                // Assert
-                OrderCreatedEventData actual = consumer.ConsumeOrderEventForW3C(traceParent.TransactionId);
-                AssertReceivedOrderEventDataForW3C(expected, actual, traceParent);
-            }
-        }
-
-        private async Task TestFailedEventHubsMessageHandlingForW3CAsync(
-            WorkerOptions options,
-            EventHubsConfig eventHubs)
-        {
-            var traceParent = TraceParent.Generate();
-            EventData expected = CreateOrderEventDataMessageForW3C(traceParent);
-
-            var producer = new TestEventHubsMessageProducer(
-                eventHubs.EventHubsConnectionString, 
-                eventHubs.GetEventHubsName(IntegrationTestType.SelfContained));
-
-            await using (var worker = await Worker.StartNewAsync(options))
-            await using (var consumer = await TestServiceBusMessageEventConsumer.StartNewAsync(_config, _logger))
-            {
-                // Act
-                await producer.ProduceAsync(expected);
-
-                // Assert
-                Assert.Throws<TimeoutException>(() => consumer.ConsumeOrderEventForW3C(traceParent.TransactionId, timeoutInSeconds: 30));
-            }
+            return new TestEventHubsMessageProducer(
+                _eventHubsConfig.EventHubsConnectionString,
+                EventHubsName);
         }
 
         private static EventData CreateOrderEventDataMessageForHierarchical(
@@ -518,7 +512,14 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
         private static EventData CreateOrderEventDataMessageForW3C(TraceParent traceParent)
         {
             Order order = OrderGenerator.Generate();
-            return new EventData(JsonConvert.SerializeObject(order)).WithDiagnosticId(traceParent);
+            var eventData = new EventData(JsonConvert.SerializeObject(order));
+
+            if (traceParent != null)
+            {
+                eventData.WithDiagnosticId(traceParent);
+            }
+
+            return eventData;
         }
 
         private static void AssertReceivedOrderEventDataForHierarchical(
@@ -528,7 +529,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string operationParentIdPropertyName = PropertyNames.OperationParentId,
             Encoding encoding = null)
         {
-            encoding = encoding ?? Encoding.UTF8;
+            encoding ??= Encoding.UTF8;
             string json = encoding.GetString(message.EventBody);
 
             var order = JsonConvert.DeserializeObject<Order>(json);
@@ -552,7 +553,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             TraceParent traceParent,
             Encoding encoding = null)
         {
-            encoding = encoding ?? Encoding.UTF8;
+            encoding ??= Encoding.UTF8;
             string json = encoding.GetString(message.EventBody);
             var order = JsonConvert.DeserializeObject<Order>(json);
 

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -327,26 +327,20 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = _config.GetServiceBusTopicConnectionString();
             ServiceBusConnectionStringProperties properties = ServiceBusConnectionStringProperties.Parse(connectionString);
 
-            ServicePrincipal servicePrincipal = _config.GetServiceBusServicePrincipal();
-            string tenantId = _config.GetTenantId();
+            using var auth = TemporaryManagedIdentityConnection.Create(_config, _logger);
+            
+            var options = new WorkerOptions();
+            options.AddEventGridPublisher(_config)
+                   .AddServiceBusTopicMessagePumpUsingManagedIdentity(
+                       topicName: properties.EntityPath,
+                       subscriptionName: Guid.NewGuid().ToString(),
+                       serviceBusNamespace: properties.FullyQualifiedNamespace,
+                       clientId: auth.ClientId,
+                       configureMessagePump: opt => opt.AutoComplete = true)
+                   .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 
-            using (TemporaryEnvironmentVariable.Create(EnvironmentVariables.AzureTenantId, tenantId))
-            using (TemporaryEnvironmentVariable.Create(EnvironmentVariables.AzureServicePrincipalClientId, servicePrincipal.ClientId))
-            using (TemporaryEnvironmentVariable.Create(EnvironmentVariables.AzureServicePrincipalClientSecret, servicePrincipal.ClientSecret))
-            {
-                var options = new WorkerOptions();
-                options.AddEventGridPublisher(_config)
-                       .AddServiceBusTopicMessagePumpUsingManagedIdentity(
-                           topicName: properties.EntityPath,
-                           subscriptionName: Guid.NewGuid().ToString(),
-                           serviceBusNamespace: properties.FullyQualifiedNamespace,
-                           clientId: servicePrincipal.ClientId,
-                           configureMessagePump: opt => opt.AutoComplete = true)
-                       .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
-
-                // Act / Assert
-                await TestServiceBusTopicMessageHandlingForW3CAsync(options);
-            }
+            // Act / Assert
+            await TestServiceBusTopicMessageHandlingForW3CAsync(options);
         }
 
         [Fact]
@@ -424,25 +418,19 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = _config.GetServiceBusQueueConnectionString();
             ServiceBusConnectionStringProperties properties = ServiceBusConnectionStringProperties.Parse(connectionString);
 
-            ServicePrincipal servicePrincipal = _config.GetServiceBusServicePrincipal();
-            string tenantId = _config.GetTenantId();
+            using var auth = TemporaryManagedIdentityConnection.Create(_config, _logger);
             
-            using (TemporaryEnvironmentVariable.Create(EnvironmentVariables.AzureTenantId, tenantId))
-            using (TemporaryEnvironmentVariable.Create(EnvironmentVariables.AzureServicePrincipalClientId, servicePrincipal.ClientId))
-            using (TemporaryEnvironmentVariable.Create(EnvironmentVariables.AzureServicePrincipalClientSecret, servicePrincipal.ClientSecret))
-            {
-                var options = new WorkerOptions();
-                options.AddEventGridPublisher(_config)
-                       .AddServiceBusQueueMessagePumpUsingManagedIdentity(
-                           queueName: properties.EntityPath,
-                           serviceBusNamespace: properties.FullyQualifiedNamespace,
-                           clientId: servicePrincipal.ClientId,
-                           configureMessagePump: opt => opt.AutoComplete = true)
-                       .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
+            var options = new WorkerOptions();
+            options.AddEventGridPublisher(_config)
+                   .AddServiceBusQueueMessagePumpUsingManagedIdentity(
+                       queueName: properties.EntityPath,
+                       serviceBusNamespace: properties.FullyQualifiedNamespace,
+                       clientId: auth.ClientId,
+                       configureMessagePump: opt => opt.AutoComplete = true)
+                   .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 
-                // Act / Assert
-                await TestServiceBusQueueMessageHandlingForW3CAsync(options);
-            }
+            // Act / Assert
+            await TestServiceBusQueueMessageHandlingForW3CAsync(options);
         }
 
         [Fact]

--- a/src/Arcus.Messaging.Tests.Integration/appsettings.json
+++ b/src/Arcus.Messaging.Tests.Integration/appsettings.json
@@ -11,6 +11,11 @@
       "EventGrid": {
         "TopicUri": "#{Arcus.TestInfra.EventGrid.Topic.Uri}#",
         "AuthKey": "#{Arcus.TestInfra.EventGrid.Auth.Key}#"
+      },
+      "TenantId": "#{Arcus.Infra.TenantId}#",
+      "ServicePrincipal": {
+        "ClientId": "#{Arcus.Infra.ServicePrincipal.ClientId}#",
+        "ClientSecret": "#{Arcus.Infra.ServicePrincipal.ClientSecret}#"
       }
     },
     "ServiceBus": {
@@ -25,12 +30,7 @@
       },
       "SelfContained": {
         "ConnectionStringWithQueue": "#{Arcus.ServiceBus.ConnectionStringWithQueue}#",
-        "ConnectionStringWithTopic": "#{Arcus.ServiceBus.ConnectionStringWithTopic}#",
-        "TenantId": "#{Arcus.ServiceBus.TenantId}#",
-        "ServicePrincipal": {
-          "ClientId": "#{Arcus.ServiceBus.ServicePrincipal.ClientId}#",
-          "ClientSecret": "#{Arcus.ServiceBus.ServicePrincipal.ClientSecret}#"
-        }
+        "ConnectionStringWithTopic": "#{Arcus.ServiceBus.ConnectionStringWithTopic}#"
       }
     },
     "EventHubs": {

--- a/src/Arcus.Messaging.Tests.Unit/EventHubs/IServiceCollectionExtensionTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/EventHubs/IServiceCollectionExtensionTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions.EventHubs.MessageHandling;
+using Arcus.Messaging.Pumps.EventHubs;
 using Bogus;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,16 +14,16 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
     // ReSharper disable once InconsistentNaming
     public class IServiceCollectionExtensionTests
     {
-        private static readonly Faker BogusGenerator = new Faker();
+        private static readonly Faker Bogus = new Faker();
 
         [Fact]
         public void AddWithoutOptions_WithSecretStore_Succeeds()
         {
             // Arrange
-            string eventHubsName = BogusGenerator.Lorem.Word();
-            string eventHubsConnectionStringSecretName = BogusGenerator.Lorem.Word();
-            string blobStorageContainerName = BogusGenerator.Lorem.Word();
-            string storageAccountConnectionStringSecretName = BogusGenerator.Lorem.Word();
+            string eventHubsName = Bogus.Lorem.Word();
+            string eventHubsConnectionStringSecretName = Bogus.Lorem.Word();
+            string blobStorageContainerName = Bogus.Lorem.Word();
+            string storageAccountConnectionStringSecretName = Bogus.Lorem.Word();
             var services = new ServiceCollection();
             services.AddSingleton(Mock.Of<IConfiguration>())
                     .AddLogging()
@@ -41,11 +42,11 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
         public void AddWithoutOptions_WithCustomJobId_Succeeds()
         {
             // Arrange
-            string eventHubsName = BogusGenerator.Lorem.Word();
-            string eventHubsConnectionStringSecretName = BogusGenerator.Lorem.Word();
-            string blobStorageContainerName = BogusGenerator.Lorem.Word();
-            string storageAccountConnectionStringSecretName = BogusGenerator.Lorem.Word();
-            string jobId = BogusGenerator.Random.Guid().ToString();
+            string eventHubsName = Bogus.Lorem.Word();
+            string eventHubsConnectionStringSecretName = Bogus.Lorem.Word();
+            string blobStorageContainerName = Bogus.Lorem.Word();
+            string storageAccountConnectionStringSecretName = Bogus.Lorem.Word();
+            string jobId = Bogus.Random.Guid().ToString();
             var services = new ServiceCollection();
             services.AddSingleton(Mock.Of<IConfiguration>())
                     .AddLogging()
@@ -68,10 +69,10 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
         public void AddWithoutOptions_WithoutSecretStore_Fails()
         {
             // Arrange
-            string eventHubsName = BogusGenerator.Lorem.Word();
-            string eventHubsConnectionStringSecretName = BogusGenerator.Lorem.Word();
-            string blobStorageContainerName = BogusGenerator.Lorem.Word();
-            string storageAccountConnectionStringSecretName = BogusGenerator.Lorem.Word();
+            string eventHubsName = Bogus.Lorem.Word();
+            string eventHubsConnectionStringSecretName = Bogus.Lorem.Word();
+            string blobStorageContainerName = Bogus.Lorem.Word();
+            string storageAccountConnectionStringSecretName = Bogus.Lorem.Word();
             var services = new ServiceCollection();
             services.AddSingleton(Mock.Of<IConfiguration>())
                     .AddLogging();
@@ -89,9 +90,9 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
         public void AddWithoutOptions_WithoutEventHubName_Fails(string eventHubsName)
         {
             // Arrange
-            string eventHubsConnectionStringSecretName = BogusGenerator.Lorem.Word();
-            string blobStorageContainerName = BogusGenerator.Lorem.Word();
-            string storageAccountConnectionStringSecretName = BogusGenerator.Lorem.Word();
+            string eventHubsConnectionStringSecretName = Bogus.Lorem.Word();
+            string blobStorageContainerName = Bogus.Lorem.Word();
+            string storageAccountConnectionStringSecretName = Bogus.Lorem.Word();
             var services = new ServiceCollection();
 
             // Act / Assert
@@ -107,9 +108,9 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
         public void AddWithoutOptions_WithoutEventHubsConnectionStringSecretName_Fails(string eventHubsConnectionStringSecretName)
         {
             // Arrange
-            string eventHubsName = BogusGenerator.Lorem.Word();
-            string blobStorageContainerName = BogusGenerator.Lorem.Word();
-            string storageAccountConnectionStringSecretName = BogusGenerator.Lorem.Word();
+            string eventHubsName = Bogus.Lorem.Word();
+            string blobStorageContainerName = Bogus.Lorem.Word();
+            string storageAccountConnectionStringSecretName = Bogus.Lorem.Word();
             var services = new ServiceCollection();
 
             // Act / Assert
@@ -125,9 +126,9 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
         public void AddWithoutOptions_WithoutBlobStorageContainerName_Fails(string blobStorageContainerName)
         {
             // Arrange
-            string eventHubsName = BogusGenerator.Lorem.Word();
-            string eventHubsConnectionStringSecretName = BogusGenerator.Lorem.Word();
-            string storageAccountConnectionStringSecretName = BogusGenerator.Lorem.Word();
+            string eventHubsName = Bogus.Lorem.Word();
+            string eventHubsConnectionStringSecretName = Bogus.Lorem.Word();
+            string storageAccountConnectionStringSecretName = Bogus.Lorem.Word();
             var services = new ServiceCollection();
 
             // Act / Assert
@@ -143,9 +144,9 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
         public void AddWithoutOptions_WithoutStorageAccountConnectionStringSecretName_Fails(string storageAccountConnectionStringSecretName)
         {
             // Arrange
-            string eventHubsName = BogusGenerator.Lorem.Word();
-            string eventHubsConnectionStringSecretName = BogusGenerator.Lorem.Word();
-            string blobStorageContainerName = BogusGenerator.Lorem.Word();
+            string eventHubsName = Bogus.Lorem.Word();
+            string eventHubsConnectionStringSecretName = Bogus.Lorem.Word();
+            string blobStorageContainerName = Bogus.Lorem.Word();
             var services = new ServiceCollection();
 
             // Act / Assert
@@ -161,9 +162,9 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
         public void AddWithOptions_WithoutEventHubName_Fails(string eventHubsName)
         {
             // Arrange
-            string eventHubsConnectionStringSecretName = BogusGenerator.Lorem.Word();
-            string blobStorageContainerName = BogusGenerator.Lorem.Word();
-            string storageAccountConnectionStringSecretName = BogusGenerator.Lorem.Word();
+            string eventHubsConnectionStringSecretName = Bogus.Lorem.Word();
+            string blobStorageContainerName = Bogus.Lorem.Word();
+            string storageAccountConnectionStringSecretName = Bogus.Lorem.Word();
             var services = new ServiceCollection();
 
             // Act / Assert
@@ -172,7 +173,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
                 eventHubsConnectionStringSecretName,
                 blobStorageContainerName,
                 storageAccountConnectionStringSecretName,
-                options => { }));
+                configureOptions: _ => { }));
         }
 
         [Theory]
@@ -180,9 +181,9 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
         public void AddWithOptions_WithoutEventHubsConnectionStringSecretName_Fails(string eventHubsConnectionStringSecretName)
         {
             // Arrange
-            string eventHubsName = BogusGenerator.Lorem.Word();
-            string blobStorageContainerName = BogusGenerator.Lorem.Word();
-            string storageAccountConnectionStringSecretName = BogusGenerator.Lorem.Word();
+            string eventHubsName = Bogus.Lorem.Word();
+            string blobStorageContainerName = Bogus.Lorem.Word();
+            string storageAccountConnectionStringSecretName = Bogus.Lorem.Word();
             var services = new ServiceCollection();
 
             // Act / Assert
@@ -191,7 +192,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
                 eventHubsConnectionStringSecretName,
                 blobStorageContainerName,
                 storageAccountConnectionStringSecretName,
-                options => { }));
+                configureOptions: _ => { }));
         }
 
         [Theory]
@@ -199,9 +200,9 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
         public void AddWithOptions_WithoutBlobStorageContainerName_Fails(string blobStorageContainerName)
         {
             // Arrange
-            string eventHubsName = BogusGenerator.Lorem.Word();
-            string eventHubsConnectionStringSecretName = BogusGenerator.Lorem.Word();
-            string storageAccountConnectionStringSecretName = BogusGenerator.Lorem.Word();
+            string eventHubsName = Bogus.Lorem.Word();
+            string eventHubsConnectionStringSecretName = Bogus.Lorem.Word();
+            string storageAccountConnectionStringSecretName = Bogus.Lorem.Word();
             var services = new ServiceCollection();
 
             // Act / Assert
@@ -210,7 +211,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
                 eventHubsConnectionStringSecretName,
                 blobStorageContainerName,
                 storageAccountConnectionStringSecretName,
-                options => { }));
+                configureOptions: _ => { }));
         }
 
         [Theory]
@@ -218,9 +219,9 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
         public void AddWithOptions_WithoutStorageAccountConnectionStringSecretName_Fails(string storageAccountConnectionStringSecretName)
         {
             // Arrange
-            string eventHubsName = BogusGenerator.Lorem.Word();
-            string eventHubsConnectionStringSecretName = BogusGenerator.Lorem.Word();
-            string blobStorageContainerName = BogusGenerator.Lorem.Word();
+            string eventHubsName = Bogus.Lorem.Word();
+            string eventHubsConnectionStringSecretName = Bogus.Lorem.Word();
+            string blobStorageContainerName = Bogus.Lorem.Word();
             var services = new ServiceCollection();
 
             // Act / Assert
@@ -229,7 +230,408 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
                 eventHubsConnectionStringSecretName,
                 blobStorageContainerName,
                 storageAccountConnectionStringSecretName,
-                options => { }));
+                configureOptions: _ => { }));
+        }
+
+        [Fact]
+        public void AddUsingManagedIdentityWithoutClientIdAndOptions_WithValidArguments_Succeeds()
+        {
+            // Arrange
+            string eventHubsName = Bogus.Lorem.Word();
+            string fullyQualifiedNamespace = Bogus.Lorem.Sentence();
+            string blobContainerUri = Bogus.Internet.UrlWithPath();
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(new ConfigurationManager());
+
+            // Act
+            services.AddEventHubsMessagePumpUsingManagedIdentity(eventHubsName, fullyQualifiedNamespace, blobContainerUri);
+
+            // Assert
+            IServiceProvider provider = services.BuildServiceProvider();
+            Assert.NotNull(
+                Assert.IsType<AzureEventHubsMessagePump>(
+                    Assert.Single(provider.GetServices<IHostedService>())));
+        }
+
+        [Fact]
+        public void AddUsingManagedIdentityWithClientIdAndWithoutOptions_WithValidArguments_Succeeds()
+        {
+            // Arrange
+            string eventHubsName = Bogus.Lorem.Word();
+            string fullyQualifiedNamespace = Bogus.Lorem.Sentence();
+            string blobContainerUri = Bogus.Internet.UrlWithPath();
+            string clientId = Bogus.Random.Guid().ToString();
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(new ConfigurationManager());
+
+            // Act
+            services.AddEventHubsMessagePumpUsingManagedIdentity(eventHubsName, fullyQualifiedNamespace, blobContainerUri, clientId);
+
+            // Assert
+            IServiceProvider provider = services.BuildServiceProvider();
+            Assert.NotNull(
+                Assert.IsType<AzureEventHubsMessagePump>(
+                    Assert.Single(provider.GetServices<IHostedService>())));
+        }
+
+        [Fact]
+        public void AddUsingManagedIdentityWithoutClientIdAndWithOptions_WithValidArguments_Succeeds()
+        {
+            // Arrange
+            string eventHubsName = Bogus.Lorem.Word();
+            string fullyQualifiedNamespace = Bogus.Lorem.Sentence();
+            string blobContainerUri = Bogus.Internet.UrlWithPath();
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(new ConfigurationManager());
+            string jobId = null;
+
+            // Act
+            EventHubsMessageHandlerCollection collection = 
+                services.AddEventHubsMessagePumpUsingManagedIdentity(eventHubsName, fullyQualifiedNamespace, blobContainerUri, opt => jobId = opt.JobId);
+
+            // Assert
+            IServiceProvider provider = services.BuildServiceProvider();
+            var pump = Assert.IsType<AzureEventHubsMessagePump>(
+                Assert.Single(provider.GetServices<IHostedService>()));
+            
+            Assert.NotNull(pump);
+            Assert.NotNull(jobId);
+            Assert.Equal(collection.JobId, pump.JobId);
+            Assert.Equal(jobId, pump.JobId);
+        }
+
+        [Fact]
+        public void AddUsingManagedIdentityWithClientIdAndOptions_WithValidArguments_Succeeds()
+        {
+            // Arrange
+            string eventHubsName = Bogus.Lorem.Word();
+            string fullyQualifiedNamespace = Bogus.Lorem.Sentence();
+            string blobContainerUri = Bogus.Internet.UrlWithPath();
+            string clientId = Bogus.Random.Guid().ToString();
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(new ConfigurationManager());
+            string jobId = null;
+
+            // Act
+            EventHubsMessageHandlerCollection collection = 
+                services.AddEventHubsMessagePumpUsingManagedIdentity(eventHubsName, fullyQualifiedNamespace, blobContainerUri, clientId, opt => jobId = opt.JobId);
+
+            // Assert
+            IServiceProvider provider = services.BuildServiceProvider();
+            var pump = Assert.IsType<AzureEventHubsMessagePump>(
+                Assert.Single(provider.GetServices<IHostedService>()));
+            
+            Assert.NotNull(pump);
+            Assert.NotNull(jobId);
+            Assert.Equal(collection.JobId, pump.JobId);
+            Assert.Equal(jobId, pump.JobId);
+        }
+
+        [Fact]
+        public void AddUsingManagedIdentityWithClientIdAndOptions_WithCustomJobId_Succeeds()
+        {
+            // Arrange
+            string eventHubsName = Bogus.Lorem.Word();
+            string fullyQualifiedNamespace = Bogus.Lorem.Sentence();
+            string blobContainerUri = Bogus.Internet.UrlWithPath();
+            string clientId = Bogus.Random.Guid().ToString();
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(new ConfigurationManager());
+            string jobId = Bogus.Random.Guid().ToString();
+
+            // Act
+            EventHubsMessageHandlerCollection collection = 
+                services.AddEventHubsMessagePumpUsingManagedIdentity(eventHubsName, fullyQualifiedNamespace, blobContainerUri, clientId, opt => opt.JobId = jobId);
+
+            // Assert
+            IServiceProvider provider = services.BuildServiceProvider();
+            var pump = Assert.IsType<AzureEventHubsMessagePump>(
+                Assert.Single(provider.GetServices<IHostedService>()));
+            
+            Assert.NotNull(pump);
+            Assert.NotNull(jobId);
+            Assert.Equal(collection.JobId, pump.JobId);
+            Assert.Equal(jobId, pump.JobId);
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddUsingManagedIdentityWithoutClientIdAndOptions_WithoutEventHubsName_Fails(string eventHubsName)
+        {
+            // Arrange
+            string fullyQualifiedNamespace = Bogus.Lorem.Sentence();
+            string blobContainerUri = Bogus.Internet.UrlWithPath();
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => services.AddEventHubsMessagePumpUsingManagedIdentity(
+                eventHubsName,
+                fullyQualifiedNamespace,
+                blobContainerUri));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddUsingManagedIdentityWithClientIdAndWithoutOptions_WithoutEventHubsName_Fails(string eventHubsName)
+        {
+            // Arrange
+            string fullyQualifiedNamespace = Bogus.Lorem.Sentence();
+            string blobContainerUri = Bogus.Internet.UrlWithPath();
+            string clientId = Bogus.Random.Guid().ToString();
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => services.AddEventHubsMessagePumpUsingManagedIdentity(
+                eventHubsName,
+                fullyQualifiedNamespace,
+                blobContainerUri,
+                clientId));
+        }
+
+          [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddUsingManagedIdentityWithoutClientIdAndWithOptions_WithoutEventHubsName_Fails(string eventHubsName)
+        {
+            // Arrange
+            string fullyQualifiedNamespace = Bogus.Lorem.Sentence();
+            string blobContainerUri = Bogus.Internet.UrlWithPath();
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => services.AddEventHubsMessagePumpUsingManagedIdentity(
+                eventHubsName,
+                fullyQualifiedNamespace,
+                blobContainerUri,
+                configureOptions: _ => { }));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddUsingManagedIdentityWithClientIdAndOptions_WithoutEventHubsName_Fails(string eventHubsName)
+        {
+            // Arrange
+            string fullyQualifiedNamespace = Bogus.Lorem.Sentence();
+            string blobContainerUri = Bogus.Internet.UrlWithPath();
+            string clientId = Bogus.Random.Guid().ToString();
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => services.AddEventHubsMessagePumpUsingManagedIdentity(
+                eventHubsName,
+                fullyQualifiedNamespace,
+                blobContainerUri,
+                clientId,
+                configureOptions: _ => { }));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddUsingManagedIdentityWithoutClientIdAndOptions_WithoutNamespace_Fails(string fullyQualifiedNamespace)
+        {
+            // Arrange
+            string eventHubsName = Bogus.Lorem.Sentence();
+            string blobContainerUri = Bogus.Internet.UrlWithPath();
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => services.AddEventHubsMessagePumpUsingManagedIdentity(
+                eventHubsName,
+                fullyQualifiedNamespace,
+                blobContainerUri));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddUsingManagedIdentityWithClientIdAndWithoutOptions_WithoutNamespace_Fails(string fullyQualifiedNamespace)
+        {
+            // Arrange
+            string eventHubsName = Bogus.Lorem.Sentence();
+            string blobContainerUri = Bogus.Internet.UrlWithPath();
+            string clientId = Bogus.Random.Guid().ToString();
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => services.AddEventHubsMessagePumpUsingManagedIdentity(
+                eventHubsName,
+                fullyQualifiedNamespace,
+                blobContainerUri,
+                clientId));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddUsingManagedIdentityWithoutClientIdAndWithOptions_WithoutNamespace_Fails(string fullyQualifiedNamespace)
+        {
+            // Arrange
+            string eventHubsName = Bogus.Lorem.Sentence();
+            string blobContainerUri = Bogus.Internet.UrlWithPath();
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => services.AddEventHubsMessagePumpUsingManagedIdentity(
+                eventHubsName,
+                fullyQualifiedNamespace,
+                blobContainerUri,
+                configureOptions: _ => { }));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddUsingManagedIdentityWithClientIdAndOptions_WithoutNamespace_Fails(string fullyQualifiedNamespace)
+        {
+            // Arrange
+            string eventHubsName = Bogus.Lorem.Sentence();
+            string blobContainerUri = Bogus.Internet.UrlWithPath();
+            string clientId = Bogus.Random.Guid().ToString();
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => services.AddEventHubsMessagePumpUsingManagedIdentity(
+                eventHubsName,
+                fullyQualifiedNamespace,
+                blobContainerUri,
+                clientId,
+                configureOptions: _ => { }));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddUsingManagedIdentityWithoutClientIdAndOptions_WithoutBlobEndpoint_Fails(string blobContainerUri)
+        {
+            // Arrange
+            string eventHubsName = Bogus.Lorem.Sentence();
+            string fullyQualifiedNamespace = Bogus.Internet.UrlWithPath();
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => services.AddEventHubsMessagePumpUsingManagedIdentity(
+                eventHubsName,
+                fullyQualifiedNamespace,
+                blobContainerUri));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddUsingManagedIdentityWithClientIdAndWithoutOptions_WithoutBlobEndpoint_Fails(string blobContainerUri)
+        {
+            // Arrange
+            string eventHubsName = Bogus.Lorem.Sentence();
+            string fullyQualifiedNamespace = Bogus.Internet.UrlWithPath();
+            string clientId = Bogus.Random.Guid().ToString();
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => services.AddEventHubsMessagePumpUsingManagedIdentity(
+                eventHubsName,
+                fullyQualifiedNamespace,
+                blobContainerUri,
+                clientId));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddUsingManagedIdentityWithoutClientIdAndWithOptions_WithoutBlobEndpoint_Fails(string blobContainerUri)
+        {
+            // Arrange
+            string eventHubsName = Bogus.Lorem.Sentence();
+            string fullyQualifiedNamespace = Bogus.Internet.UrlWithPath();
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => services.AddEventHubsMessagePumpUsingManagedIdentity(
+                eventHubsName,
+                fullyQualifiedNamespace,
+                blobContainerUri,
+                configureOptions: _ => { }));
+        }
+
+        [Theory]
+        [ClassData(typeof(Blanks))]
+        public void AddUsingManagedIdentityWithClientIdAndOptions_WithoutBlobEndpoint_Fails(string blobContainerUri)
+        {
+            // Arrange
+            string eventHubsName = Bogus.Lorem.Sentence();
+            string fullyQualifiedNamespace = Bogus.Internet.UrlWithPath();
+            string clientId = Bogus.Random.Guid().ToString();
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<ArgumentException>(() => services.AddEventHubsMessagePumpUsingManagedIdentity(
+                eventHubsName,
+                fullyQualifiedNamespace,
+                blobContainerUri,
+                clientId,
+                configureOptions: _ => { }));
+        }
+
+        [Fact]
+        public void AddUsingManagedIdentityWithoutClientIdAndOptions_WithRelativeBlobEndpoint_Fails()
+        {
+            // Arrange
+            string eventHubsName = Bogus.Lorem.Sentence();
+            string fullyQualifiedNamespace = Bogus.Internet.UrlWithPath();
+            string blobContainerUri = Bogus.Internet.UrlRootedPath();
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<UriFormatException>(() => services.AddEventHubsMessagePumpUsingManagedIdentity(
+                eventHubsName,
+                fullyQualifiedNamespace,
+                blobContainerUri));
+        }
+
+        [Fact]
+        public void AddUsingManagedIdentityWithClientIdAndWithoutOptions_WithRelativeBlobEndpoint_Fails()
+        {
+            // Arrange
+            string eventHubsName = Bogus.Lorem.Sentence();
+            string fullyQualifiedNamespace = Bogus.Internet.UrlWithPath();
+            string blobContainerUri = Bogus.Internet.UrlRootedPath();
+            string clientId = Bogus.Random.Guid().ToString();
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<UriFormatException>(() => services.AddEventHubsMessagePumpUsingManagedIdentity(
+                eventHubsName,
+                fullyQualifiedNamespace,
+                blobContainerUri,
+                clientId));
+        }
+
+        [Fact]
+        public void AddUsingManagedIdentityWithoutClientIdAndWithOptions_WithRelativeBlobEndpoint_Fails()
+        {
+            // Arrange
+            string eventHubsName = Bogus.Lorem.Sentence();
+            string fullyQualifiedNamespace = Bogus.Internet.UrlWithPath();
+            string blobContainerUri = Bogus.Internet.UrlRootedPath();
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<UriFormatException>(() => services.AddEventHubsMessagePumpUsingManagedIdentity(
+                eventHubsName,
+                fullyQualifiedNamespace,
+                blobContainerUri,
+                configureOptions: _ => { }));
+        }
+
+        [Fact]
+        public void AddUsingManagedIdentityWithClientIdAndOptions_WithRelativeBlobEndpoint_Fails()
+        {
+            // Arrange
+            string eventHubsName = Bogus.Lorem.Sentence();
+            string fullyQualifiedNamespace = Bogus.Internet.UrlWithPath();
+            string blobContainerUri = Bogus.Internet.UrlRootedPath();
+            string clientId = Bogus.Random.Guid().ToString();
+            var services = new ServiceCollection();
+
+            // Act / Assert
+            Assert.ThrowsAny<UriFormatException>(() => services.AddEventHubsMessagePumpUsingManagedIdentity(
+                eventHubsName,
+                fullyQualifiedNamespace,
+                blobContainerUri,
+                clientId,
+                configureOptions: _ => { }));
         }
     }
 #endif


### PR DESCRIPTION
Add the possibility to use Azure Managed Identity authentication when registering an Azure EventHubs message pump.

Closes #409