### PR TITLE
feat: add servicebus entitytype to req tracking

### DIFF
--- a/docs/preview/02-Features/04-service-bus-extensions.md
+++ b/docs/preview/02-Features/04-service-bus-extensions.md
@@ -171,7 +171,7 @@ using Arcus.Messaging.Abstractions;
 using Azure.Messaging.ServiceBus;
 
 // Creates a new messaging context from the message, using an unique job ID to identify all message handlers that can handle this specific context.
-AzureServiceBusMessageContext messageContext = message.GetMessageContext("my-job-id");
+AzureServiceBusMessageContext messageContext = message.GetMessageContext("my-job-id", ServiceBusEntityType.Topic);
 
 // Extract the encoding information from the `.ApplicationProperties` and wrapped inside a valid `Encoding` type.
 MessageContext messageContext = ...

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/AzureServiceBusMessageContext.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/AzureServiceBusMessageContext.cs
@@ -2,16 +2,17 @@
 using System.Collections.Generic;
 using System.Linq;
 using GuardNet;
+using Microsoft.Extensions.Logging;
 
 namespace Arcus.Messaging.Abstractions.ServiceBus
 {
     /// <summary>
-    ///     Contextual information concerning an Azure Service Bus message
+    /// Represents the contextual information concerning an Azure Service Bus message.
     /// </summary>
     public class AzureServiceBusMessageContext : MessageContext
     {
         /// <summary>
-        ///     Initializes a new instance of the <see cref="AzureServiceBusMessageContext"/> class.
+        /// Initializes a new instance of the <see cref="AzureServiceBusMessageContext"/> class.
         /// </summary>
         /// <param name="messageId">The unique identifier of the message.</param>
         /// <param name="jobId">Unique identifier of the message pump.</param>
@@ -24,6 +25,26 @@ namespace Arcus.Messaging.Abstractions.ServiceBus
             string jobId,
             AzureServiceBusSystemProperties systemProperties,
             IReadOnlyDictionary<string, object> properties)
+            : this(messageId, jobId, systemProperties, properties, ServiceBusEntityType.Unknown)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureServiceBusMessageContext"/> class.
+        /// </summary>
+        /// <param name="messageId">The unique identifier of the message.</param>
+        /// <param name="jobId">Unique identifier of the message pump.</param>
+        /// <param name="systemProperties">The contextual properties provided on the message provided by the Azure Service Bus runtime.</param>
+        /// <param name="properties">The contextual properties provided on the message provided by the message publisher.</param>
+        /// <param name="entityType">The type of the Azure Service Bus entity on which a message with the ID <paramref name="messageId"/> was received.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="systemProperties"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
+        public AzureServiceBusMessageContext(
+            string messageId,
+            string jobId,
+            AzureServiceBusSystemProperties systemProperties,
+            IReadOnlyDictionary<string, object> properties,
+            ServiceBusEntityType entityType)
             : base(messageId, jobId, properties.ToDictionary(item => item.Key, item => item.Value))
         {
             Guard.NotNullOrWhitespace(messageId, nameof(messageId), "Requires an ID to identify the message");
@@ -34,20 +55,26 @@ namespace Arcus.Messaging.Abstractions.ServiceBus
             SystemProperties = systemProperties;
             LockToken = systemProperties.LockToken;
             DeliveryCount = systemProperties.DeliveryCount;
+            EntityType = entityType;
         }
 
         /// <summary>
-        ///     Gets the contextual properties provided on the message provided by the Azure Service Bus runtime
+        /// Gets the type of the Azure Service Bus entity on which the message was received.
+        /// </summary>
+        public ServiceBusEntityType EntityType { get; }
+
+        /// <summary>
+        /// Gets the contextual properties provided on the message provided by the Azure Service Bus runtime
         /// </summary>
         public AzureServiceBusSystemProperties SystemProperties { get; }
 
         /// <summary>
-        ///     Gets the token used to lock an individual message for processing
+        /// Gets the token used to lock an individual message for processing
         /// </summary>
         public string LockToken { get; }
 
         /// <summary>
-        ///     Gets the amount of times a message was delivered
+        /// Gets the amount of times a message was delivered
         /// </summary>
         /// <remarks>This increases when a message is abandoned and re-delivered for processing</remarks>
         public int DeliveryCount { get; }

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/ServiceBusReceivedMessageExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/ServiceBusReceivedMessageExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions.ServiceBus;
 using GuardNet;
+using Microsoft.Extensions.Logging;
 
 // ReSharper disable once CheckNamespace
 namespace Azure.Messaging.ServiceBus
@@ -34,7 +35,23 @@ namespace Azure.Messaging.ServiceBus
             Guard.NotNull(message, nameof(message), "Requires an Azure Service Bus received message to construct an Azure Service Bus messaging context");
             Guard.NotNullOrWhitespace(jobId, nameof(jobId), "Requires an job ID that is not blank to identify the messaging job, pump or router");
             
-            return new AzureServiceBusMessageContext(message.MessageId, jobId, message.GetSystemProperties(), message.ApplicationProperties);
+            return message.GetMessageContext(jobId, ServiceBusEntityType.Unknown);
+        }
+
+        /// <summary>
+        /// Gets the <see cref="AzureServiceBusMessageContext"/>, which contains the user and system messaging information about the received Azure Service Bus <paramref name="message"/>.
+        /// </summary>
+        /// <param name="message">The received Azure Service Bus message to extract the messaging context from.</param>
+        /// <param name="jobId">The unique ID to identify the current messaging job, pump or router that is handling the received <paramref name="message"/>.</param>
+        /// <param name="entityType">The type of the Azure Service Bus entity on which a message was received.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
+        public static AzureServiceBusMessageContext GetMessageContext(this ServiceBusReceivedMessage message, string jobId, ServiceBusEntityType entityType)
+        {
+            Guard.NotNull(message, nameof(message), "Requires an Azure Service Bus received message to construct an Azure Service Bus messaging context");
+            Guard.NotNullOrWhitespace(jobId, nameof(jobId), "Requires an job ID that is not blank to identify the messaging job, pump or router");
+            
+            return new AzureServiceBusMessageContext(message.MessageId, jobId, message.GetSystemProperties(), message.ApplicationProperties, entityType);
         }
     }
 }

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
@@ -263,7 +263,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
                 {
                     string entityName = messageReceiver?.EntityPath ?? "<not-available>";
                     string serviceBusNamespace = messageReceiver?.FullyQualifiedNamespace ?? "<not-available>";
-                    Logger.LogServiceBusRequest(serviceBusNamespace, entityName, operationName: null, isSuccessful, measurement, ServiceBusEntityType.Unknown);
+                    Logger.LogServiceBusRequest(serviceBusNamespace, entityName, operationName: null, isSuccessful, measurement, messageContext.EntityType);
                 }
             }
         }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -353,7 +353,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
 
             using (MessageCorrelationResult correlationResult = DetermineMessageCorrelation(message))
             {
-                AzureServiceBusMessageContext messageContext = message.GetMessageContext(JobId);
+                AzureServiceBusMessageContext messageContext = message.GetMessageContext(JobId, Settings.ServiceBusEntity);
                 ServiceBusReceiver receiver = args.GetServiceBusReceiver();
 
                 await _messageRouter.RouteMessageAsync(receiver, args.Message, messageContext, correlationResult.CorrelationInfo, args.CancellationToken); 

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -839,7 +839,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                 // Assert
                 AssertX.RetryAssertUntilTelemetryShouldBeAvailable(() =>
                 {
-                    RequestTelemetry requestViaArcusServiceBus = AssertX.GetRequestFrom(spySink.Telemetries, r => r.Name == "Process" && r.Context.Operation.Id == traceParent.TransactionId);
+                    RequestTelemetry requestViaArcusServiceBus = AssertX.GetRequestFrom(spySink.Telemetries, r => r.Name == "Process" && r.Context.Operation.Id == traceParent.TransactionId && r.Properties[ContextProperties.RequestTracking.ServiceBus.EntityType] == ServiceBusEntityType.Queue.ToString());
                     DependencyTelemetry dependencyViaArcusKeyVault = AssertX.GetDependencyFrom(spySink.Telemetries, d => d.Type == "Azure key vault" && d.Context.Operation.Id == traceParent.TransactionId);
                     DependencyTelemetry dependencyViaMicrosoftSql = AssertX.GetDependencyFrom(spyChannel.Telemetries, d => d.Type == "SQL" && d.Context.Operation.Id == traceParent.TransactionId);
                     
@@ -879,7 +879,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                 // Assert
                 AssertX.RetryAssertUntilTelemetryShouldBeAvailable(() =>
                 {
-                    RequestTelemetry requestViaArcusServiceBus = AssertX.GetRequestFrom(spySink.Telemetries, r => r.Name == "Process");
+                    RequestTelemetry requestViaArcusServiceBus = AssertX.GetRequestFrom(spySink.Telemetries, r => r.Name == "Process" && r.Properties[ContextProperties.RequestTracking.ServiceBus.EntityType] == ServiceBusEntityType.Queue.ToString());
                     DependencyTelemetry dependencyViaArcusKeyVault = AssertX.GetDependencyFrom(spySink.Telemetries, d => d.Type == "Azure key vault");
                     DependencyTelemetry dependencyViaMicrosoftSql = AssertX.GetDependencyFrom(spyChannel.Telemetries, d => d.Type == "SQL");
                     

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/AzureServiceBusMessageContextTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/AzureServiceBusMessageContextTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Arcus.Messaging.Abstractions.ServiceBus;
+using Azure.Messaging.ServiceBus;
+using Bogus;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
+{
+    public class AzureServiceBusMessageContextTests
+    {
+        private static readonly Faker Bogus = new();
+
+        [Fact]
+        public void Create_WithoutEntityType_IsUnknown()
+        {
+            // Arrange
+            ServiceBusReceivedMessage message = CreateReceivedMessage();
+            var jobId = Bogus.Random.Guid().ToString();
+
+            // Act
+            AzureServiceBusMessageContext context = message.GetMessageContext(jobId);
+
+            // Assert
+            Assert.Equal(jobId, context.JobId);
+            Assert.Equal(message.MessageId, context.MessageId);
+            Assert.Equal(ServiceBusEntityType.Unknown, context.EntityType);
+        }
+
+        [Fact]
+        public void Create_WithEntityType_IsKnown()
+        {
+            // Arrange
+            ServiceBusReceivedMessage message = CreateReceivedMessage();
+            var jobId = Bogus.Random.Guid().ToString();
+            var entityType = Bogus.PickRandomWithout(ServiceBusEntityType.Unknown);
+
+            // Act
+            AzureServiceBusMessageContext context = message.GetMessageContext(jobId, entityType);
+
+            // Assert
+            Assert.Equal(jobId, context.JobId);
+            Assert.Equal(message.MessageId, context.MessageId);
+            Assert.Equal(entityType, context.EntityType);
+        }
+
+        private static ServiceBusReceivedMessage CreateReceivedMessage()
+        {
+            return ServiceBusModelFactory.ServiceBusReceivedMessage(
+                body: BinaryData.FromBytes(Bogus.Random.Bytes(100)),
+                messageId: Bogus.Random.Guid().ToString());
+        }
+    }
+}


### PR DESCRIPTION
Add the Azure Service Bus entity type to the request tracking within the Azure Service Bus message pump.

Closes #413