### PR TITLE
chore: rename incorrect 'pause' > 'start' in pump lifetime

### DIFF
--- a/src/Arcus.Messaging.Pumps.Abstractions/DefaultMessagePumpLifetime.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/DefaultMessagePumpLifetime.cs
@@ -36,20 +36,6 @@ namespace Arcus.Messaging.Pumps.Abstractions
         /// <param name="jobId">The uniquely defined identifier of the registered message pump.</param>
         /// <param name="cancellationToken">The token to indicate that the start process has been aborted.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
-        [Obsolete("Use the 'StartProcessingMessageAsync' instead to start the message pump")]
-        public async Task PauseProcessingMessagesAsync(string jobId, CancellationToken cancellationToken)
-        {
-            Guard.NotNullOrWhitespace(jobId, nameof(jobId), "Requires a message pump job ID to retrieve the registered message pump in the application services");
-
-            await StartProcessingMessagesAsync(jobId, cancellationToken);
-        }
-
-        /// <summary>
-        /// Starts a message pump with the given <paramref name="jobId"/>.
-        /// </summary>
-        /// <param name="jobId">The uniquely defined identifier of the registered message pump.</param>
-        /// <param name="cancellationToken">The token to indicate that the start process has been aborted.</param>
-        /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
         public async Task StartProcessingMessagesAsync(string jobId, CancellationToken cancellationToken)
         {
             Guard.NotNullOrWhitespace(jobId, nameof(jobId), "Requires a message pump job ID to retrieve the registered message pump in the application services");

--- a/src/Arcus.Messaging.Pumps.Abstractions/IMessagePumpLifetime.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/IMessagePumpLifetime.cs
@@ -15,8 +15,7 @@ namespace Arcus.Messaging.Pumps.Abstractions
         /// <param name="jobId">The uniquely defined identifier of the registered message pump.</param>
         /// <param name="cancellationToken">The token to indicate that the start process has been aborted.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
-        [Obsolete("Will be renamed to 'StartProcessingMessageAsync' in the next major release")]
-        Task PauseProcessingMessagesAsync(string jobId, CancellationToken cancellationToken);
+        Task StartProcessingMessagesAsync(string jobId, CancellationToken cancellationToken);
 
         /// <summary>
         /// Pauses a message pump with the given <paramref name="jobId"/> for a specified <paramref name="duration"/>.

--- a/src/Arcus.Messaging.Tests.Unit/MessagePump/DefaultMessagePumpLifetimeTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessagePump/DefaultMessagePumpLifetimeTests.cs
@@ -63,7 +63,7 @@ namespace Arcus.Messaging.Tests.Unit.MessagePump
             var lifetime = new DefaultMessagePumpLifetime(provider);
 
             // Act
-            await lifetime.PauseProcessingMessagesAsync(jobId, CancellationToken.None);
+            await lifetime.StartProcessingMessagesAsync(jobId, CancellationToken.None);
 
             // Assert
             var pump = Assert.IsType<TestMessagePump>(hostedService);


### PR DESCRIPTION
Rename the incorrect `IMessagePumpLifetime` method `Pause...` to `Start...`.

Closes #387