### PR TITLE
feat: do not automatically try to create and delete topic subscriptions

### DIFF
--- a/docs/preview/02-Features/02-message-handling/01-service-bus.md
+++ b/docs/preview/02-Features/02-message-handling/01-service-bus.md
@@ -462,7 +462,7 @@ public class Startup
                 options.Deserialization.AdditionalMembers = AdditionalMemberHandling.Ignore;
 
                 // Indicate whether or not a new Azure Service Bus Topic subscription should be created/deleted
-                // when the message pump starts/stops (default: CreateOnStart & DeleteOnStop).
+                // when the message pump starts/stops (default: None, so no subscription will be created or deleted).
                 options.TopicSubscription = TopicSubscription.CreateOnStart | TopicSubscription.DeleteOnStop;
             });
 

--- a/docs/preview/02-Features/02-message-handling/01-service-bus.md
+++ b/docs/preview/02-Features/02-message-handling/01-service-bus.md
@@ -463,7 +463,7 @@ public class Startup
 
                 // Indicate whether or not a new Azure Service Bus Topic subscription should be created/deleted
                 // when the message pump starts/stops (default: None, so no subscription will be created or deleted).
-                options.TopicSubscription = TopicSubscription.CreateOnStart | TopicSubscription.DeleteOnStop;
+                options.TopicSubscription = TopicSubscription.Automatic;
             });
 
         services.AddServiceBusQueueMessagePump(

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -26,6 +26,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
         private readonly IAzureServiceBusMessageRouter _messageRouter;
         private readonly IDisposable _loggingScope;
 
+        private bool _ownsTopicSubscription = false;
         private bool _isHostShuttingDown;
         private ServiceBusProcessor _messageProcessor;
         private ServiceBusReceiver _messageReceiver;
@@ -42,8 +43,8 @@ namespace Arcus.Messaging.Pumps.ServiceBus
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="settings"/>, <paramref name="settings"/>, <paramref name="serviceProvider"/>, <paramref name="messageRouter"/> is <c>null</c>.</exception>
         public AzureServiceBusMessagePump(
             AzureServiceBusMessagePumpSettings settings,
-            IConfiguration applicationConfiguration, 
-            IServiceProvider serviceProvider, 
+            IConfiguration applicationConfiguration,
+            IServiceProvider serviceProvider,
             IAzureServiceBusMessageRouter messageRouter,
             ILogger<AzureServiceBusMessagePump> logger)
             : base(applicationConfiguration, serviceProvider, logger)
@@ -52,7 +53,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             Guard.NotNull(applicationConfiguration, nameof(applicationConfiguration), "Requires a configuration instance to retrieve application-specific information");
             Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires a service provider to retrieve the registered message handlers");
             Guard.NotNull(messageRouter, nameof(messageRouter), "Requires a message router to route incoming Azure Service Bus messages through registered message handlers");
-            
+
             Settings = settings;
             JobId = Settings.Options.JobId;
             SubscriptionName = Settings.SubscriptionName;
@@ -98,7 +99,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
         {
             Guard.NotNull(reconfigure, nameof(reconfigure), "Requires a function to reconfigure the Azure Service Bus Queue options");
             Guard.For<NotSupportedException>(
-                () => Settings.ServiceBusEntity is ServiceBusEntityType.Topic, 
+                () => Settings.ServiceBusEntity is ServiceBusEntityType.Topic,
                 "Requires the message pump to be configured for Azure Service Bus Queue to reconfigure these options, use the Topic overload instead");
 
             reconfigure(Settings.Options);
@@ -130,28 +131,29 @@ namespace Arcus.Messaging.Pumps.ServiceBus
                 && Settings.Options.TopicSubscription.HasValue
                 && Settings.Options.TopicSubscription.Value.HasFlag(TopicSubscription.Automatic))
             {
-                await CreateTopicSubscriptionAsync(cancellationToken);
+                _ownsTopicSubscription = await CreateTopicSubscriptionAsync(cancellationToken);
             }
 
             await base.StartAsync(cancellationToken);
         }
 
-        private async Task CreateTopicSubscriptionAsync(CancellationToken cancellationToken)
+        private async Task<bool> CreateTopicSubscriptionAsync(CancellationToken cancellationToken)
         {
             ServiceBusAdministrationClient serviceBusClient = await Settings.GetServiceBusAdminClientAsync();
             string entityPath = await Settings.GetEntityPathAsync();
-            
+
             try
             {
                 bool subscriptionExists = await serviceBusClient.SubscriptionExistsAsync(entityPath, SubscriptionName, cancellationToken);
                 if (subscriptionExists)
                 {
                     Logger.LogTrace("Topic subscription with name '{SubscriptionName}' already exists on Service Bus resource", SubscriptionName);
+                    return false;
                 }
                 else
                 {
                     Logger.LogTrace("Creating subscription '{SubscriptionName}' on topic '{TopicPath}'...", SubscriptionName, entityPath);
-                    
+
                     var subscriptionDescription = new CreateSubscriptionOptions(entityPath, SubscriptionName)
                     {
                         UserMetadata = $"Subscription created by Arcus job: '{JobId}' to process Service Bus messages."
@@ -161,11 +163,14 @@ namespace Arcus.Messaging.Pumps.ServiceBus
                                           .ConfigureAwait(continueOnCapturedContext: false);
 
                     Logger.LogTrace("Subscription '{SubscriptionName}' created on topic '{TopicPath}'", SubscriptionName, entityPath);
+
+                    return true;
                 }
             }
             catch (Exception exception) when (exception is not TaskCanceledException && exception is not OperationCanceledException)
             {
                 Logger.LogWarning(exception, "Failed to create topic subscription with name '{SubscriptionName}' on Service Bus resource", SubscriptionName);
+                return false;
             }
         }
 
@@ -209,7 +214,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             }
 
             Logger.LogDebug("Azure Service Bus {EntityType} message pump '{JobId}' on entity path '{EntityPath}' in namespace '{Namespace}' tries to process single message during half-open circuit...", Settings.ServiceBusEntity, JobId, EntityPath, Namespace);
-            
+
             ServiceBusReceivedMessage message = null;
             while (message is null)
             {
@@ -235,14 +240,14 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             {
                 _messageProcessor = await Settings.CreateMessageProcessorAsync();
             }
-            
+
             Namespace = _messageProcessor.FullyQualifiedNamespace;
 
             /* TODO: we can't support Azure Service Bus plug-ins yet because the new Azure SDK doesn't yet support this:
                      https://github.com/arcus-azure/arcus.messaging/issues/176 */
 
             RegisterClientInformation(JobId, _messageProcessor.EntityPath);
-            
+
             Logger.LogTrace("Starting Azure Service Bus {EntityType} message pump '{JobId}' on entity path '{EntityPath}' in namespace '{Namespace}'", Settings.ServiceBusEntity, JobId, EntityPath, Namespace);
             _messageProcessor.ProcessErrorAsync += ProcessErrorAsync;
             _messageProcessor.ProcessMessageAsync += ProcessMessageAsync;
@@ -269,7 +274,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             }
             catch (Exception exception) when (exception is not TaskCanceledException && exception is not OperationCanceledException)
             {
-                Logger.LogWarning(exception, "Cannot correctly close the Azure Service Bus message pump '{JobId}' on entity path '{EntityPath}' in '{Namespace}': {Message}",  JobId, EntityPath, Namespace, exception.Message);
+                Logger.LogWarning(exception, "Cannot correctly close the Azure Service Bus message pump '{JobId}' on entity path '{EntityPath}' in '{Namespace}': {Message}", JobId, EntityPath, Namespace, exception.Message);
             }
         }
 
@@ -280,7 +285,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
                 Logger.LogWarning("Thrown exception on Azure Service Bus {EntityType} message pump '{JobId}' was null, skipping", Settings.ServiceBusEntity, JobId);
                 return;
             }
-            
+
             try
             {
                 await HandleReceiveExceptionAsync(args.Exception);
@@ -296,7 +301,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
                     }
                     else
                     {
-                        Logger.LogWarning("Unable to connect anymore to Azure Service Bus ({CurrentCount}/{MaxCount})", 
+                        Logger.LogWarning("Unable to connect anymore to Azure Service Bus ({CurrentCount}/{MaxCount})",
                             _unauthorizedExceptionCount, Settings.Options.MaximumUnauthorizedExceptionsBeforeRestart);
                     }
                 }
@@ -348,7 +353,8 @@ namespace Arcus.Messaging.Pumps.ServiceBus
 
             if (Settings.ServiceBusEntity == ServiceBusEntityType.Topic
                 && Settings.Options.TopicSubscription.HasValue
-                && Settings.Options.TopicSubscription.Value.HasFlag(TopicSubscription.Automatic))
+                && Settings.Options.TopicSubscription.Value.HasFlag(TopicSubscription.Automatic)
+                && _ownsTopicSubscription)
             {
                 await DeleteTopicSubscriptionAsync(cancellationToken);
             }
@@ -395,7 +401,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
 
             if (_isHostShuttingDown)
             {
-                Logger.LogWarning("Abandoning message with ID '{MessageId}' as the Azure Service Bus {EntityType} message pump '{JobId}' is shutting down",  message.MessageId, Settings.ServiceBusEntity, JobId);
+                Logger.LogWarning("Abandoning message with ID '{MessageId}' as the Azure Service Bus {EntityType} message pump '{JobId}' is shutting down", message.MessageId, Settings.ServiceBusEntity, JobId);
                 await args.AbandonMessageAsync(message);
                 return;
             }
@@ -410,7 +416,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
                 AzureServiceBusMessageContext messageContext = message.GetMessageContext(JobId, Settings.ServiceBusEntity);
                 ServiceBusReceiver receiver = args.GetServiceBusReceiver();
 
-                await _messageRouter.RouteMessageAsync(receiver, args.Message, messageContext, correlationResult.CorrelationInfo, args.CancellationToken); 
+                await _messageRouter.RouteMessageAsync(receiver, args.Message, messageContext, correlationResult.CorrelationInfo, args.CancellationToken);
             }
         }
 
@@ -423,7 +429,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
                 return MessageCorrelationResult.Create(client, transactionId, operationParentId);
             }
 
-            MessageCorrelationInfo correlationInfo = 
+            MessageCorrelationInfo correlationInfo =
                 message.GetCorrelationInfo(
                     Settings.Options.Routing.Correlation?.TransactionIdPropertyName ?? PropertyNames.TransactionId,
                     Settings.Options.Routing.Correlation?.OperationParentIdPropertyName ?? PropertyNames.OperationParentId);

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -128,7 +128,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
         {
             if (Settings.ServiceBusEntity == ServiceBusEntityType.Topic
                 && Settings.Options.TopicSubscription.HasValue
-                && Settings.Options.TopicSubscription.Value.HasFlag(TopicSubscription.CreateOnStart))
+                && Settings.Options.TopicSubscription.Value.HasFlag(TopicSubscription.Automatic))
             {
                 await CreateTopicSubscriptionAsync(cancellationToken);
             }
@@ -348,7 +348,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
 
             if (Settings.ServiceBusEntity == ServiceBusEntityType.Topic
                 && Settings.Options.TopicSubscription.HasValue
-                && Settings.Options.TopicSubscription.Value.HasFlag(TopicSubscription.DeleteOnStop))
+                && Settings.Options.TopicSubscription.Value.HasFlag(TopicSubscription.Automatic))
             {
                 await DeleteTopicSubscriptionAsync(cancellationToken);
             }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
@@ -154,7 +154,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// </summary>
         internal static AzureServiceBusMessagePumpOptions DefaultTopicOptions => new AzureServiceBusMessagePumpOptions()
         {
-            TopicSubscription = ServiceBus.TopicSubscription.CreateOnStart | ServiceBus.TopicSubscription.DeleteOnStop
+            TopicSubscription = ServiceBus.TopicSubscription.None
         };
     }
 }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
@@ -30,7 +30,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
 
         /// <summary>
         /// <para>Gets or sets the value indicating whether or not a new Azure Service Bus Topic subscription has to be created when the <see cref="AzureServiceBusMessagePump"/> starts.</para>
-        /// <para>The subscription will be deleted afterwards when the message pump stops if the options <see cref="ServiceBus.TopicSubscription.DeleteOnStop"/> is selected.</para>
+        /// <para>The subscription will be deleted afterwards when the message pump stops if the options <see cref="ServiceBus.TopicSubscription.Automatic"/> is selected.</para>
         /// </summary>
         /// <remarks>
         ///     Provides capability to create and delete these subscriptions. This requires 'Manage' permissions on the Azure Service Bus Topic or namespace.

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusTopicMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusTopicMessagePumpOptions.cs
@@ -10,7 +10,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
     {
         /// <summary>
         /// <para>Gets or sets the value indicating whether or not a new Azure Service Bus Topic subscription has to be created when the <see cref="AzureServiceBusMessagePump"/> starts.</para>
-        /// <para>The subscription will be deleted afterwards when the message pump stops if the options <see cref="ServiceBus.TopicSubscription.DeleteOnStop"/> is selected.</para>
+        /// <para>The subscription will be deleted afterwards when the message pump stops if the options <see cref="ServiceBus.TopicSubscription.Automatic"/> is selected.</para>
         /// </summary>
         /// <remarks>
         ///     Provides capability to create and delete these subscriptions. This requires 'Manage' permissions on the Azure Service Bus Topic or namespace.

--- a/src/Arcus.Messaging.Pumps.ServiceBus/TopicSubscription.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/TopicSubscription.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Arcus.Messaging.Pumps.ServiceBus 
+namespace Arcus.Messaging.Pumps.ServiceBus
 {
     /// <summary>
     /// Represents the option to control the topic subscription existence during the lifecycle of the <see cref="AzureServiceBusMessagePump"/>.
@@ -12,15 +12,11 @@ namespace Arcus.Messaging.Pumps.ServiceBus
         /// Don't create any Azure Service Bus Topic subscription during the lifecycle of the <see cref="AzureServiceBusMessagePump"/>.
         /// </summary>
         None = 0,
-        
-        /// <summary>
-        /// Creates a new Azure Service Bus Topic subscription when the message pump starts.
-        /// </summary>
-        CreateOnStart = 1,
 
         /// <summary>
-        /// Deletes the new Azure Service Bus Topic subscription when the message pump stops.
+        /// Creates a new Azure Service Bus Topic subscription when the message pump starts, and deletes it
+        /// again when the message pump stops.
         /// </summary>
-        DeleteOnStop = 2
+        Automatic = 1,
     }
 }

--- a/src/Arcus.Messaging.Tests.Integration/Extensions/WorkerOptionsExtensions.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Extensions/WorkerOptionsExtensions.cs
@@ -36,13 +36,28 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
             return options;
         }
 
+        /// <summary>
+        /// Adds a message pump to consume messages from Azure Service Bus Topic.
+        /// </summary>
+        /// <remarks>
+        ///     When using this approach; the connection string should be scoped to the topic that is being processed, not the namespace.
+        /// </remarks>
+        /// <param name="options">The collection of services to add the message pump to.</param>
+        /// <param name="connectionString">The connection string scoped to the Azure Service Bus Topic from the configuration.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionString"/> is blank.</exception>
         public static ServiceBusMessageHandlerCollection AddServiceBusTopicMessagePump(this WorkerOptions options, string connectionString)
         {
-            return options.Services.AddServiceBusTopicMessagePump(subscriptionName: Guid.NewGuid().ToString(), _ => connectionString, opt =>
-            {
-                opt.TopicSubscription = TopicSubscription.Automatic;
-                opt.AutoComplete = true;
-            });
+            Guard.NotNull(options, nameof(options));
+            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString));
+
+            return options.Services.AddServiceBusTopicMessagePump(
+                subscriptionName: Guid.NewGuid().ToString(),
+                _ => connectionString, opt =>
+                {
+                    opt.TopicSubscription = TopicSubscription.Automatic;
+                    opt.AutoComplete = true;
+                });
         }
     }
 }

--- a/src/Arcus.Messaging.Tests.Integration/Extensions/WorkerOptionsExtensions.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Extensions/WorkerOptionsExtensions.cs
@@ -1,8 +1,11 @@
 ﻿using System;
+using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
+using Arcus.Messaging.Pumps.ServiceBus;
 using Azure;
 using Azure.Messaging.EventGrid;
 using GuardNet;
 using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.DependencyInjection;
 
 // ReSharper disable once CheckNamespace
 namespace Arcus.Messaging.Tests.Integration.Fixture
@@ -31,6 +34,15 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
             });
 
             return options;
+        }
+
+        public static ServiceBusMessageHandlerCollection AddServiceBusTopicMessagePump(this WorkerOptions options, string connectionString)
+        {
+            return options.Services.AddServiceBusTopicMessagePump(subscriptionName: Guid.NewGuid().ToString(), _ => connectionString, opt =>
+            {
+                opt.TopicSubscription = TopicSubscription.Automatic;
+                opt.AutoComplete = true;
+            });
         }
     }
 }

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpDockerTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpDockerTests.cs
@@ -7,8 +7,6 @@ using Azure.Messaging.ServiceBus;
 using Arcus.Messaging.Tests.Core.Messages.v1;
 using Arcus.Messaging.Tests.Integration.Fixture;
 using Arcus.Messaging.Tests.Integration.MessagePump.Fixture;
-using Bogus;
-using Microsoft.Azure.ServiceBus;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -18,8 +16,6 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
     [Trait("Category", "Docker")]
     public class ServiceBusMessagePumpDockerTests : DockerServiceBusIntegrationTest
     {
-        private static readonly Faker BogusGenerator = new Faker();
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ServiceBusMessagePumpDockerTests" /> class.
         /// </summary>

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -113,10 +113,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = _config.GetServiceBusTopicConnectionString();
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
-                   .AddServiceBusTopicMessagePump(
-                       subscriptionName: Guid.NewGuid().ToString(),
-                       _ => connectionString,
-                       opt => opt.AutoComplete = true)
+                   .AddServiceBusTopicMessagePump(connectionString)
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 
             var traceParnet = TraceParent.Generate();
@@ -191,10 +188,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = _config.GetServiceBusTopicConnectionString();
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
-                   .AddServiceBusTopicMessagePump(
-                        subscriptionName: Guid.NewGuid().ToString(),
-                        _ => connectionString, 
-                        opt => opt.AutoComplete = true)
+                   .AddServiceBusTopicMessagePump(connectionString)
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
             
             // Act / Assert
@@ -247,6 +241,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                        opt =>
                        {
                            opt.AutoComplete = true;
+                           opt.TopicSubscription = TopicSubscription.Automatic;
                            opt.Correlation.Format = MessageCorrelationFormat.Hierarchical;
                            opt.Correlation.TransactionIdPropertyName = customTransactionIdPropertyName;
                        })
@@ -277,7 +272,11 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                    .AddServiceBusTopicMessagePump(
                        "Test-Receive-All-Topic-Only-with-an-azure-servicebus-topic-subscription-name-over-50-characters", 
                        _ => connectionString, 
-                       opt => opt.AutoComplete = true)
+                       opt =>
+                       {
+                           opt.AutoComplete = true;
+                           opt.TopicSubscription = TopicSubscription.Automatic;
+                       })
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
             
             // Act / Assert
@@ -298,7 +297,11 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                        topicName: properties.EntityPath,
                        subscriptionName: Guid.NewGuid().ToString(),
                        getConnectionStringFromConfigurationFunc: _ => namespaceConnectionString,
-                       configureMessagePump: opt => opt.AutoComplete = true)
+                       configureMessagePump: opt =>
+                       {
+                           opt.AutoComplete = true;
+                           opt.TopicSubscription = TopicSubscription.Automatic;
+                       })
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 
             // Act / Assert
@@ -338,7 +341,11 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                        subscriptionName: Guid.NewGuid().ToString(),
                        serviceBusNamespace: properties.FullyQualifiedNamespace,
                        clientId: auth.ClientId,
-                       configureMessagePump: opt => opt.AutoComplete = true)
+                       configureMessagePump: opt =>
+                       {
+                           opt.AutoComplete = true;
+                           opt.TopicSubscription = TopicSubscription.Automatic;
+                       })
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 
             // Act / Assert
@@ -352,10 +359,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = _config.GetServiceBusTopicConnectionString();
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
-                   .AddServiceBusTopicMessagePump(
-                       subscriptionName: Guid.NewGuid().ToString(), 
-                       _ => connectionString, 
-                       opt => opt.AutoComplete = false)
+                   .AddServiceBusTopicMessagePump(connectionString)
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusCompleteMessageHandler, Order>();
             
             // Act / Assert
@@ -522,7 +526,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = _config.GetServiceBusTopicConnectionString();
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
-                   .AddServiceBusTopicMessagePump(subscriptionName: Guid.NewGuid().ToString(), _ => connectionString, opt => opt.AutoComplete = true)
+                   .AddServiceBusTopicMessagePump(connectionString)
                    .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>(context => context.Properties.TryGetValue("Topic", out object value) && value.ToString() == "Customers")
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>(context => context.Properties.TryGetValue("Topic", out object value) && value.ToString() == "Orders")
                    .WithMessageHandler<PassThruOrderMessageHandler, Order, AzureServiceBusMessageContext>((AzureServiceBusMessageContext _) => false);
@@ -551,7 +555,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = _config.GetServiceBusTopicConnectionString();
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
-                   .AddServiceBusTopicMessagePump(subscriptionName: Guid.NewGuid().ToString(), _ => connectionString, opt => opt.AutoComplete = true)
+                   .AddServiceBusTopicMessagePump(connectionString)
                    .WithServiceBusMessageHandler<CustomerMessageHandler, Customer>((Customer body) => body is null)
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>((Order body) => body.Id != null)
                    .WithMessageHandler<PassThruOrderMessageHandler, Order, AzureServiceBusMessageContext>((Order _) => false);
@@ -718,10 +722,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = _config.GetServiceBusTopicConnectionString();
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
-                   .AddServiceBusTopicMessagePump(
-                       subscriptionName: Guid.NewGuid().ToString(), 
-                       _ => connectionString,
-                       opt => opt.AutoComplete = false)
+                   .AddServiceBusTopicMessagePump(connectionString)
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusAbandonMessageHandler, Order>();
             
             // Act / Assert
@@ -735,10 +736,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = _config.GetServiceBusTopicConnectionString();
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
-                   .AddServiceBusTopicMessagePump(
-                       subscriptionName: Guid.NewGuid().ToString(), 
-                       _ => connectionString, 
-                       opt => opt.AutoComplete = false)
+                   .AddServiceBusTopicMessagePump(connectionString)
                    .WithServiceBusMessageHandler<ShipmentAzureServiceBusMessageHandler, Shipment>()
                    .WithServiceBusFallbackMessageHandler<OrdersAzureServiceBusAbandonFallbackMessageHandler>();
             
@@ -753,10 +751,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             string connectionString = _config.GetServiceBusTopicConnectionString();
             var options = new WorkerOptions();
             options.AddEventGridPublisher(_config)
-                   .AddServiceBusTopicMessagePump(
-                       subscriptionName: Guid.NewGuid().ToString(), 
-                       _ => connectionString, 
-                       options => options.AutoComplete = false)
+                   .AddServiceBusTopicMessagePump(connectionString)
                    .WithServiceBusMessageHandler<PassThruOrderMessageHandler, Order>((AzureServiceBusMessageContext _) => false)
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusAbandonMessageHandler, Order>((AzureServiceBusMessageContext _) => true);
             
@@ -854,7 +849,11 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                    .AddServiceBusTopicMessagePump(
                        subscriptionName: Guid.NewGuid().ToString(), 
                        _ => connectionString, 
-                       opt => opt.JobId = jobId)
+                       opt =>
+                       {
+                           opt.JobId = jobId;
+                           opt.TopicSubscription = TopicSubscription.Automatic;
+                       })
                    .WithServiceBusMessageHandler<PassThruOrderMessageHandler, Order>((AzureServiceBusMessageContext _) => false)
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusAbandonMessageHandler, Order>((AzureServiceBusMessageContext _) => true);
 

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -203,9 +203,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
 
         [Theory]
         [InlineData(TopicSubscription.None, false)]
-        [InlineData(TopicSubscription.CreateOnStart, true)]
-        [InlineData(TopicSubscription.DeleteOnStop, false)]
-        [InlineData(TopicSubscription.CreateOnStart | TopicSubscription.DeleteOnStop, true)]
+        [InlineData(TopicSubscription.Automatic, true)]
         public async Task ServiceBusTopicMessagePump_WithNoneTopicSubscription_DoesntCreateTopicSubscription(TopicSubscription topicSubscription, bool expected)
         {
             // Arrange

--- a/src/Arcus.Messaging.Tests.Unit/ServiceBus/IServiceCollectionExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/ServiceBus/IServiceCollectionExtensionsTests.cs
@@ -36,7 +36,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
                     "topic name", "subscription name", "secret name", options =>
                     {
                         options.AutoComplete = true;
-                        options.TopicSubscription = TopicSubscription.CreateOnStart | TopicSubscription.DeleteOnStop;
+                        options.TopicSubscription = TopicSubscription.Automatic;
                     });
             
             // Assert
@@ -91,7 +91,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
                     "topic name", "subscription name", "secret name", configureMessagePump: options =>
                     {
                         options.AutoComplete = true;
-                        options.TopicSubscription = TopicSubscription.CreateOnStart | TopicSubscription.DeleteOnStop;
+                        options.TopicSubscription = TopicSubscription.Automatic;
                     });
 
             // Assert

--- a/src/Arcus.Messaging.Tests.Unit/ServiceBus/IServiceCollectionExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/ServiceBus/IServiceCollectionExtensionsTests.cs
@@ -33,7 +33,11 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             // Act
             ServiceBusMessageHandlerCollection result = 
                 services.AddServiceBusTopicMessagePump(
-                    "topic name", "subscription name", "secret name", options => options.AutoComplete = true);
+                    "topic name", "subscription name", "secret name", options =>
+                    {
+                        options.AutoComplete = true;
+                        options.TopicSubscription = TopicSubscription.CreateOnStart | TopicSubscription.DeleteOnStop;
+                    });
             
             // Assert
             Assert.NotNull(result);
@@ -84,7 +88,11 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             // Act
             ServiceBusMessageHandlerCollection result = 
                 services.AddServiceBusTopicMessagePump(
-                    "topic name", "subscription name", "secret name", configureMessagePump: options => options.AutoComplete = true);
+                    "topic name", "subscription name", "secret name", configureMessagePump: options =>
+                    {
+                        options.AutoComplete = true;
+                        options.TopicSubscription = TopicSubscription.CreateOnStart | TopicSubscription.DeleteOnStop;
+                    });
 
             // Assert
             // Assert

--- a/src/Arcus.Messaging.Tests.Workers.ServiceBus.Topic/Program.cs
+++ b/src/Arcus.Messaging.Tests.Workers.ServiceBus.Topic/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using Arcus.Messaging.Pumps.ServiceBus;
 using Arcus.Messaging.Tests.Core.Messages.v1;
 using Arcus.Messaging.Tests.Workers.MessageHandlers;
 using Azure;
@@ -35,7 +36,7 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus.Topic
                         clients.AddEventGridPublisherClient(new Uri(topicEndpoint), new AzureKeyCredential(authenticationKey));
                     });
                    
-                    services.AddServiceBusTopicMessagePump("Receive-All", configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"])
+                    services.AddServiceBusTopicMessagePump("Receive-All", configuration => configuration["ARCUS_SERVICEBUS_CONNECTIONSTRING"], opt => opt.TopicSubscription = TopicSubscription.Automatic)
                             .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 
                     services.AddTcpHealthProbes("ARCUS_HEALTH_PORT");


### PR DESCRIPTION
Change the default behaviour of the `AzureServiceBusMessagePump`.
Instead of automatically creating a subscription on startup by default, and removing the subscription again on shut-down, we no longer do that.

Closes #432 