### PR TITLE
chore: introduce routing options to service bus pump options interfaces

### DIFF
--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Arcus.Messaging.Abstractions.MessageHandling;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 using GuardNet;
 
@@ -22,10 +21,6 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         public AzureServiceBusMessagePumpOptions()
         {
             Routing = new AzureServiceBusMessageRouterOptions();
-#pragma warning disable CS0618
-            Deserialization = Routing.Deserialization;
-            Correlation = new AzureServiceBusCorrelationOptions(Routing.Correlation);
-#pragma warning restore CS0618
         }
 
         /// <summary>
@@ -123,18 +118,6 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
                 _maximumUnauthorizedExceptionsBeforeRestart = value;
             }
         }
-
-        /// <summary>
-        /// Gets the options to control the correlation information upon the receiving of Azure Service Bus messages in the <see cref="AzureServiceBusMessagePump"/>.
-        /// </summary>
-        [Obsolete("Use the " + nameof(Routing) + "." + nameof(AzureServiceBusMessageRouterOptions.Correlation) + " instead")]
-        public AzureServiceBusCorrelationOptions Correlation { get; }
-
-        /// <summary>
-        /// Gets the consumer-configurable options to change the deserialization behavior.
-        /// </summary>
-        [Obsolete("Use the " + nameof(Routing) + "." + nameof(AzureServiceBusMessageRouterOptions.Deserialization) + " instead")]
-        public MessageDeserializationOptions Deserialization { get; }
 
         /// <summary>
         /// Gets the consumer-configurable options to change the behavior of the message router.

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusQueueMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusQueueMessagePumpOptions.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Arcus.Messaging.Abstractions.MessageHandling;
+using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 
 namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
 {
@@ -52,15 +52,8 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         int MaximumUnauthorizedExceptionsBeforeRestart { get; set; }
 
         /// <summary>
-        /// Gets the options to control the correlation information upon the receiving of Azure Service Bus messages in the <see cref="AzureServiceBusMessagePump"/>.
+        /// Gets the consumer-configurable options to change the behavior of the message router.
         /// </summary>
-        [Obsolete("Will be moved to message routing options in the future")]
-        AzureServiceBusCorrelationOptions Correlation { get; }
-
-        /// <summary>
-        /// Gets the consumer-configurable options to change the deserialization behavior.
-        /// </summary>
-        [Obsolete("Will be moved to message routing options in the future")]
-        MessageDeserializationOptions Deserialization { get; }
+        AzureServiceBusMessageRouterOptions Routing { get; }
     }
 }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusTopicMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusTopicMessagePumpOptions.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Arcus.Messaging.Abstractions.MessageHandling;
+using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 
 namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
 {
@@ -61,15 +61,8 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         int MaximumUnauthorizedExceptionsBeforeRestart { get; set; }
 
         /// <summary>
-        /// Gets the options to control the correlation information upon the receiving of Azure Service Bus messages in the <see cref="AzureServiceBusMessagePump"/>.
+        /// Gets the consumer-configurable options to change the behavior of the message router.
         /// </summary>
-        [Obsolete("Will be moved to message routing options in the future")]
-        AzureServiceBusCorrelationOptions Correlation { get; }
-        
-        /// <summary>
-        /// Gets the consumer-configurable options to change the deserialization behavior.
-        /// </summary>
-        [Obsolete("Will be moved to message routing options in the future")]
-        MessageDeserializationOptions Deserialization { get; }
+        AzureServiceBusMessageRouterOptions Routing { get; }
     }
 }

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -145,7 +145,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                    .AddServiceBusQueueMessagePump(_ => connectionString, opt =>
                    {
                        opt.AutoComplete = true;
-                       opt.Correlation.Format = MessageCorrelationFormat.Hierarchical;
+                       opt.Routing.Correlation.Format = MessageCorrelationFormat.Hierarchical;
                    })
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 
@@ -249,8 +249,8 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                        opt =>
                        {
                            opt.AutoComplete = true;
-                           opt.Correlation.Format = MessageCorrelationFormat.Hierarchical;
-                           opt.Correlation.TransactionIdPropertyName = customTransactionIdPropertyName;
+                           opt.Routing.Correlation.Format = MessageCorrelationFormat.Hierarchical;
+                           opt.Routing.Correlation.TransactionIdPropertyName = customTransactionIdPropertyName;
                        })
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 
@@ -317,7 +317,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             options.AddEventGridPublisher(_config)
                    .AddServiceBusQueueMessagePump(
                        _ => connectionString, 
-                       opt => opt.Deserialization.AdditionalMembers = AdditionalMemberHandling.Ignore)
+                       opt => opt.Routing.Deserialization.AdditionalMembers = AdditionalMemberHandling.Ignore)
                    .WithServiceBusMessageHandler<OrderV2AzureServiceBusMessageHandler, OrderV2>();
 
             // Act / Assert
@@ -394,8 +394,8 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                        opt =>
                        {
                            opt.AutoComplete = true;
-                           opt.Correlation.Format = MessageCorrelationFormat.Hierarchical;
-                           opt.Correlation.OperationParentIdPropertyName = customOperationParentIdPropertyName;
+                           opt.Routing.Correlation.Format = MessageCorrelationFormat.Hierarchical;
+                           opt.Routing.Correlation.OperationParentIdPropertyName = customOperationParentIdPropertyName;
                        })
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
 
@@ -985,7 +985,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             options.AddServiceBusQueueMessagePump(_ => connectionString, opt =>
                    {
                        opt.AutoComplete = true;
-                       opt.Correlation.Format = MessageCorrelationFormat.Hierarchical;
+                       opt.Routing.Correlation.Format = MessageCorrelationFormat.Hierarchical;
                    })
                    .WithServiceBusMessageHandler<OrdersSabotageAzureServiceBusMessageHandler, Order>();
             

--- a/src/Arcus.Messaging.Tests.Unit/ServiceBus/AzureServiceBusMessagePumpOptionsTest.cs
+++ b/src/Arcus.Messaging.Tests.Unit/ServiceBus/AzureServiceBusMessagePumpOptionsTest.cs
@@ -91,7 +91,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var options = new AzureServiceBusMessagePumpOptions();
 
             // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(() => options.Correlation.TransactionIdPropertyName = transactionIdPropertyName);
+            Assert.ThrowsAny<ArgumentException>(() => options.Routing.Correlation.TransactionIdPropertyName = transactionIdPropertyName);
         }
 
         [Fact]
@@ -102,10 +102,10 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             const string expected = "Transaction-ID";
 
             // Act
-            options.Correlation.TransactionIdPropertyName = expected;
+            options.Routing.Correlation.TransactionIdPropertyName = expected;
 
             // Assert
-            Assert.Equal(expected, options.Correlation.TransactionIdPropertyName);
+            Assert.Equal(expected, options.Routing.Correlation.TransactionIdPropertyName);
         }
 
         [Theory]
@@ -117,7 +117,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
 
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(() =>
-                options.Correlation.OperationParentIdPropertyName = operationParentIdPropertyName);
+                options.Routing.Correlation.OperationParentIdPropertyName = operationParentIdPropertyName);
         }
 
         [Fact]
@@ -128,10 +128,10 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var operationParentId = $"operation-parent-{Guid.NewGuid()}";
 
             // Act
-            options.Correlation.OperationParentIdPropertyName = operationParentId;
+            options.Routing.Correlation.OperationParentIdPropertyName = operationParentId;
 
             // Assert
-            Assert.Equal(operationParentId, options.Correlation.OperationParentIdPropertyName);
+            Assert.Equal(operationParentId, options.Routing.Correlation.OperationParentIdPropertyName);
         }
 
         [Theory]


### PR DESCRIPTION
Introduce the `Routing` member to the Azure Service Bus queue/topic message pump options interfaces, so that all the routing-related options are grouped together (and the `Telemetry` is available for configuratio).

Closes #431