### PR TITLE
chore: add prev dotnet sdk to release pipeline

### DIFF
--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -31,6 +31,12 @@ stages:
         pool:
           vmImage: '$(Vm.Image)'
         steps:
+          - task: UseDotNet@2
+            displayName: 'Import .NET Core SDK ($(DotNet.Sdk.PreviousVersion))'
+            inputs:
+              packageType: 'sdk'
+              version: '$(DotNet.Sdk.PreviousVersion)'
+              includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
           - template: build/build-solution.yml@templates
             parameters:
               dotnetSdkVersion: '$(DotNet.Sdk.Version)'


### PR DESCRIPTION
Forgot to add this to the Release pipeline, so that we still support .NET 6, while compiling.