### PR TITLE
fix: only fail on fallback when az servicebus message wasn't tried

### DIFF
--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
@@ -277,21 +277,20 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
 
                 foreach (MessageHandler messageHandler in messageHandlers)
                 {
-                    MessageResult result = await DeserializeMessageForHandlerAsync(messageBody, messageContext, messageHandler);
-                    if (result.IsSuccess)
+                    MessageResult deserializeResult = await DeserializeMessageForHandlerAsync(messageBody, messageContext, messageHandler);
+                    if (deserializeResult.IsSuccess)
                     {
                         var args = new ProcessMessageEventArgs(message, messageReceiver, cancellationToken);
                         SetServiceBusPropertiesForSpecificOperations(messageHandler, args, messageContext);
 
-                        bool isProcessed = await messageHandler.ProcessMessageAsync(result.DeserializedMessage, messageContext, correlationInfo, cancellationToken);
+                        bool isProcessed = 
+                            await messageHandler.ProcessMessageAsync(deserializeResult.DeserializedMessage, messageContext, correlationInfo, cancellationToken);
+
                         hasGoneThroughMessageHandler = true;
-
-                        if (!isProcessed)
+                        if (isProcessed)
                         {
-                            continue;
+                            return;
                         }
-
-                        return;
                     }
                 }
 

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
@@ -277,14 +277,13 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
 
                 foreach (MessageHandler messageHandler in messageHandlers)
                 {
-                    MessageResult deserializeResult = await DeserializeMessageForHandlerAsync(messageBody, messageContext, messageHandler);
-                    if (deserializeResult.IsSuccess)
+                    MessageResult result = await DeserializeMessageForHandlerAsync(messageBody, messageContext, messageHandler);
+                    if (result.IsSuccess)
                     {
                         var args = new ProcessMessageEventArgs(message, messageReceiver, cancellationToken);
                         SetServiceBusPropertiesForSpecificOperations(messageHandler, args, messageContext);
 
-                        bool isProcessed = 
-                            await messageHandler.ProcessMessageAsync(deserializeResult.DeserializedMessage, messageContext, correlationInfo, cancellationToken);
+                        bool isProcessed = await messageHandler.ProcessMessageAsync(result.DeserializedMessage, messageContext, correlationInfo, cancellationToken);
 
                         hasGoneThroughMessageHandler = true;
                         if (isProcessed)

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
@@ -273,7 +273,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
 
                 Encoding encoding = messageContext.GetMessageEncodingProperty(Logger);
                 string messageBody = encoding.GetString(message.Body.ToArray());
-                bool isTried = false;
+                bool hasGoneThroughMessageHandler = false;
 
                 foreach (MessageHandler messageHandler in messageHandlers)
                 {
@@ -284,7 +284,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
                         SetServiceBusPropertiesForSpecificOperations(messageHandler, args, messageContext);
 
                         bool isProcessed = await messageHandler.ProcessMessageAsync(result.DeserializedMessage, messageContext, correlationInfo, cancellationToken);
-                        isTried = true;
+                        hasGoneThroughMessageHandler = true;
 
                         if (!isProcessed)
                         {
@@ -295,7 +295,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
                     }
                 }
 
-                if (!isTried)
+                if (!hasGoneThroughMessageHandler)
                 {
                     EnsureFallbackMessageHandlerAvailable(messageContext); 
                 }

--- a/src/Arcus.Messaging.Pumps.Abstractions/MessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/MessagePump.cs
@@ -42,6 +42,11 @@ namespace Arcus.Messaging.Pumps.Abstractions
         public string JobId { get; protected set; } = Guid.NewGuid().ToString();
 
         /// <summary>
+        /// Gets the boolean flag that indicates whether the message pump is started and receiving messages.
+        /// </summary>
+        public bool IsStarted { get; private set; }
+
+        /// <summary>
         /// Gets hte ID of the client being used to connect to the messaging service.
         /// </summary>
         protected string ClientId { get; private set; }
@@ -109,6 +114,7 @@ namespace Arcus.Messaging.Pumps.Abstractions
         /// <param name="cancellationToken">The token to indicate the start process should no longer be graceful.</param>
         public virtual Task StartProcessingMessagesAsync(CancellationToken cancellationToken)
         {
+            IsStarted = true;
             return Task.CompletedTask;
         }
 
@@ -118,6 +124,7 @@ namespace Arcus.Messaging.Pumps.Abstractions
         /// <param name="cancellationToken">The token to indicate the stop process should no longer be graceful.</param>
         public virtual Task StopProcessingMessagesAsync(CancellationToken cancellationToken)
         {
+            IsStarted = false;
             return Task.CompletedTask;
         }
 

--- a/src/Arcus.Messaging.Pumps.EventHubs/AzureEventHubsMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.EventHubs/AzureEventHubsMessagePump.cs
@@ -109,6 +109,8 @@ namespace Arcus.Messaging.Pumps.EventHubs
         /// <inheritdoc />
         public override async Task StartProcessingMessagesAsync(CancellationToken stoppingToken)
         {
+            await base.StartProcessingMessagesAsync(stoppingToken);
+
             _eventProcessor = await _eventHubsConfig.CreateEventProcessorClientAsync();
             _eventProcessor.ProcessEventAsync += ProcessMessageAsync;
             _eventProcessor.ProcessErrorAsync += ProcessErrorAsync;
@@ -183,6 +185,8 @@ namespace Arcus.Messaging.Pumps.EventHubs
         /// <inheritdoc />
         public override async Task StopProcessingMessagesAsync(CancellationToken cancellationToken)
         {
+            await base.StopProcessingMessagesAsync(cancellationToken);
+
             try
             {
                 Logger.LogTrace("Stopping Azure EventHubs message pump '{JobId}' on '{ConsumerGroup}/{EventHubsName}' in '{Namespace}'",  JobId, ConsumerGroup, EventHubName , Namespace);

--- a/src/Arcus.Messaging.Pumps.EventHubs/AzureEventHubsMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.EventHubs/AzureEventHubsMessagePump.cs
@@ -109,6 +109,11 @@ namespace Arcus.Messaging.Pumps.EventHubs
         /// <inheritdoc />
         public override async Task StartProcessingMessagesAsync(CancellationToken stoppingToken)
         {
+            if (IsStarted)
+            {
+                return;
+            }
+
             await base.StartProcessingMessagesAsync(stoppingToken);
 
             _eventProcessor = await _eventHubsConfig.CreateEventProcessorClientAsync();
@@ -185,6 +190,11 @@ namespace Arcus.Messaging.Pumps.EventHubs
         /// <inheritdoc />
         public override async Task StopProcessingMessagesAsync(CancellationToken cancellationToken)
         {
+            if (!IsStarted)
+            {
+                return;
+            }
+
             await base.StopProcessingMessagesAsync(cancellationToken);
 
             try

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Arcus.Messaging.Pumps.ServiceBus.csproj
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Arcus.Messaging.Pumps.ServiceBus.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="[2.0.0,3.0.0)" />
-    <PackageReference Include="Azure.Identity" Version="1.10.2" />
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Guard.NET" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -236,7 +236,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
         /// <inheritdoc />
         public override async Task StartProcessingMessagesAsync(CancellationToken cancellationToken)
         {
-            if (!IsStarted)
+            if (IsStarted)
             {
                 return;
             }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -236,6 +236,8 @@ namespace Arcus.Messaging.Pumps.ServiceBus
         /// <inheritdoc />
         public override async Task StartProcessingMessagesAsync(CancellationToken cancellationToken)
         {
+            await base.StartProcessingMessagesAsync(cancellationToken);
+            
             if (_messageProcessor is null)
             {
                 _messageProcessor = await Settings.CreateMessageProcessorAsync();
@@ -258,6 +260,8 @@ namespace Arcus.Messaging.Pumps.ServiceBus
         /// <inheritdoc />
         public override async Task StopProcessingMessagesAsync(CancellationToken cancellationToken)
         {
+            await base.StopProcessingMessagesAsync(cancellationToken);
+
             if (_messageProcessor is null)
             {
                 return;
@@ -413,9 +417,9 @@ namespace Arcus.Messaging.Pumps.ServiceBus
 
             using (MessageCorrelationResult correlationResult = DetermineMessageCorrelation(message))
             {
-                AzureServiceBusMessageContext messageContext = message.GetMessageContext(JobId, Settings.ServiceBusEntity);
                 ServiceBusReceiver receiver = args.GetServiceBusReceiver();
-
+                AzureServiceBusMessageContext messageContext = message.GetMessageContext(JobId, Settings.ServiceBusEntity);
+               
                 await _messageRouter.RouteMessageAsync(receiver, args.Message, messageContext, correlationResult.CorrelationInfo, args.CancellationToken);
             }
         }
@@ -439,7 +443,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
 
         private static async Task UntilCancelledAsync(CancellationToken cancellationToken)
         {
-            if (cancellationToken.IsCancellationRequested == false)
+            if (!cancellationToken.IsCancellationRequested)
             {
                 await Task.Delay(Timeout.Infinite, cancellationToken);
             }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -236,6 +236,11 @@ namespace Arcus.Messaging.Pumps.ServiceBus
         /// <inheritdoc />
         public override async Task StartProcessingMessagesAsync(CancellationToken cancellationToken)
         {
+            if (!IsStarted)
+            {
+                return;
+            }
+
             await base.StartProcessingMessagesAsync(cancellationToken);
             
             if (_messageProcessor is null)
@@ -260,6 +265,11 @@ namespace Arcus.Messaging.Pumps.ServiceBus
         /// <inheritdoc />
         public override async Task StopProcessingMessagesAsync(CancellationToken cancellationToken)
         {
+            if (!IsStarted)
+            {
+                return;
+            }
+
             await base.StopProcessingMessagesAsync(cancellationToken);
 
             if (_messageProcessor is null)

--- a/src/Arcus.Messaging.Tests.Integration/Arcus.Messaging.Tests.Integration.csproj
+++ b/src/Arcus.Messaging.Tests.Integration/Arcus.Messaging.Tests.Integration.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="2.0.0" />
     <PackageReference Include="Arcus.Testing.Logging" Version="0.5.0" />
     <PackageReference Include="Arcus.Testing.Security.Providers.InMemory" Version="0.5.0" />
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
     <PackageReference Include="Microsoft.Azure.ApplicationInsights.Query" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="2.1.0" />

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -755,12 +755,6 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
         }
 
         [Fact]
-        public async Task ServiceBusTopicMessagePumpWithoutFallback_TriesMatchingMessageHandlerButFailing_PassTruMessage()
-        {
-
-        }
-
-        [Fact]
         public async Task ServiceBusTopicMessagePump_PauseViaCircuitBreaker_RestartsAgainWithOneMessage()
         {
             // Arrange

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -760,7 +760,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             // Arrange
             var options = new WorkerOptions();
             ServiceBusMessage[] messages = GenerateShipmentMessages(3);
-            TimeSpan recoveryTime = TimeSpan.FromSeconds(5);
+            TimeSpan recoveryTime = TimeSpan.FromSeconds(10);
             TimeSpan messageInterval = TimeSpan.FromSeconds(1);
 
             options.AddXunitTestLogging(_outputWriter)
@@ -793,8 +793,8 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
 
                 TimeSpan faultMargin = TimeSpan.FromSeconds(1);
                 Assert.Collection(arrivals.SkipLast(1).Zip(arrivals.Skip(1)),
-                    dates => AssertDateDiff(dates.First, dates.Second, recoveryTime, recoveryTime.Add(faultMargin)),
-                    dates => AssertDateDiff(dates.First, dates.Second, messageInterval, messageInterval.Add(faultMargin)));
+                    dates => AssertDateDiff(dates.First, dates.Second, recoveryTime.Subtract(faultMargin), recoveryTime.Add(faultMargin)),
+                    dates => AssertDateDiff(dates.First, dates.Second, messageInterval.Subtract(faultMargin), messageInterval.Add(faultMargin)));
 
             }, timeout: TimeSpan.FromMinutes(2), _logger);
         }

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -761,7 +761,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             var options = new WorkerOptions();
             ServiceBusMessage[] messages = GenerateShipmentMessages(3);
             TimeSpan recoveryTime = TimeSpan.FromSeconds(10);
-            TimeSpan messageInterval = TimeSpan.FromSeconds(1);
+            TimeSpan messageInterval = TimeSpan.FromSeconds(2);
 
             options.AddXunitTestLogging(_outputWriter)
                    .AddServiceBusTopicMessagePump(
@@ -791,10 +791,11 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                 DateTimeOffset[] arrivals = handler.GetMessageArrivals();
                 Assert.Equal(messages.Length, arrivals.Length);
 
+                _outputWriter.WriteLine("Arrivals: {0}", string.Join(", ", arrivals));
                 TimeSpan faultMargin = TimeSpan.FromSeconds(1);
                 Assert.Collection(arrivals.SkipLast(1).Zip(arrivals.Skip(1)),
-                    dates => AssertDateDiff(dates.First, dates.Second, recoveryTime.Subtract(faultMargin), recoveryTime.Add(faultMargin)),
-                    dates => AssertDateDiff(dates.First, dates.Second, messageInterval.Subtract(faultMargin), messageInterval.Add(faultMargin)));
+                    dates => AssertDateDiff(dates.First, dates.Second, recoveryTime, recoveryTime.Add(faultMargin)),
+                    dates => AssertDateDiff(dates.First, dates.Second, messageInterval, messageInterval.Add(faultMargin)));
 
             }, timeout: TimeSpan.FromMinutes(2), _logger);
         }

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -754,7 +754,13 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             await TestServiceBusTopicMessageHandlingForW3CAsync(options);
         }
 
-         [Fact]
+        [Fact]
+        public async Task ServiceBusTopicMessagePumpWithoutFallback_TriesMatchingMessageHandlerButFailing_PassTruMessage()
+        {
+
+        }
+
+        [Fact]
         public async Task ServiceBusTopicMessagePump_PauseViaCircuitBreaker_RestartsAgainWithOneMessage()
         {
             // Arrange

--- a/src/Arcus.Messaging.Tests.Unit/Arcus.Messaging.Tests.Unit.csproj
+++ b/src/Arcus.Messaging.Tests.Unit/Arcus.Messaging.Tests.Unit.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\Arcus.Messaging.Pumps.EventHubs\Arcus.Messaging.Pumps.EventHubs.csproj" />
     <ProjectReference Include="..\Arcus.Messaging.Pumps.ServiceBus\Arcus.Messaging.Pumps.ServiceBus.csproj" />
     <ProjectReference Include="..\Arcus.Messaging.Tests.Core\Arcus.Messaging.Tests.Core.csproj" />
+    <ProjectReference Include="..\Arcus.Messaging.Tests.Workers.ServiceBus\Arcus.Messaging.Tests.Workers.ServiceBus.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/AzureServiceBusMessageRouterTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/AzureServiceBusMessageRouterTests.cs
@@ -158,7 +158,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
             // Assert
             Assert.Contains("none of the registered", exception.Message, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("fallback", exception.Message, StringComparison.OrdinalIgnoreCase);
-            Assert.False(sabotageHandler.IsProcessed, "sabotage message handler should be tried");
+            Assert.False(sabotageHandler.IsProcessed, "sabotage message handler should not be tried");
         }
 
         [Fact]

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/AzureServiceBusMessageRouterTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/AzureServiceBusMessageRouterTests.cs
@@ -13,6 +13,7 @@ using Arcus.Messaging.Tests.Core.Messages.v1;
 using Arcus.Messaging.Tests.Core.Messages.v2;
 using Arcus.Messaging.Tests.Unit.Fixture;
 using Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus.Stubs;
+using Arcus.Messaging.Tests.Workers.MessageHandlers;
 using Arcus.Testing.Logging;
 using Azure.Messaging.ServiceBus;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,13 +22,14 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Newtonsoft.Json;
 using Xunit;
 using Order = Arcus.Messaging.Tests.Core.Messages.v1.Order;
+using OrderV2AzureServiceBusMessageHandler = Arcus.Messaging.Tests.Unit.Fixture.OrderV2AzureServiceBusMessageHandler;
 
 namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
 {
     public class AzureServiceBusMessageRouterTests
     {
         [Fact]
-        public async Task Add_WithDifferentMessageContext_SucceedsWithSameJobId()
+        public async Task RouteMessage_WithDifferentMessageContext_SucceedsWithSameJobId()
         {
             // Arrange
             var services = new ServiceCollection();
@@ -51,7 +53,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
         }
 
         [Fact]
-        public async Task Add_WithDifferentMessageContext_FailsWithDifferentJobId()
+        public async Task RouteMessage_WithDifferentMessageContext_FailsWithDifferentJobId()
         {
             // Arrange
             var services = new ServiceCollection();
@@ -74,7 +76,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
         }
 
         [Fact]
-        public async Task Add_WithMultipleFallbackHandlers_UsesCorrectHandlerByJobId()
+        public async Task RouteMessage_WithMultipleFallbackHandlers_UsesCorrectHandlerByJobId()
         {
             // Arrange
             var services = new ServiceCollection();
@@ -106,7 +108,61 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
         }
 
         [Fact]
-        public async Task WithServiceBusMessageRouting_WithGeneralRouting_GoesThroughRegisteredMessageHandler()
+        public async Task RouteMessage_WithoutFallbackWithFailingButMatchingMessageHandler_PassThruMessage()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var sabotageHandler = new OrdersSabotageAzureServiceBusMessageHandler();
+
+            services.AddServiceBusMessageRouting()
+                    .WithServiceBusMessageHandler<ShipmentAzureServiceBusMessageHandler, Shipment>()
+                    .WithServiceBusMessageHandler<OrdersSabotageAzureServiceBusMessageHandler, Order>(serviceProvider => sabotageHandler);
+
+            IServiceProvider provider = services.BuildServiceProvider();
+            var router = provider.GetRequiredService<IAzureServiceBusMessageRouter>();
+
+            var order = OrderGenerator.Generate();
+            var message = ServiceBusModelFactory.ServiceBusReceivedMessage(BinaryData.FromObjectAsJson(order), messageId: "message-id");
+            var context = AzureServiceBusMessageContextFactory.Generate();
+            var correlationInfo = message.GetCorrelationInfo();
+
+            // Act / Assert
+            await router.RouteMessageAsync(message, context, correlationInfo, CancellationToken.None);
+
+            // Assert
+            Assert.True(sabotageHandler.IsProcessed, "sabotage message handler should be tried");
+        }
+
+        [Fact]
+        public async Task RouteMessage_WithoutFallbackWithFailingButMismatchingMessageHandler_FailsBecauseNoFallback()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var sabotageHandler = new OrdersSabotageAzureServiceBusMessageHandler();
+
+            services.AddServiceBusMessageRouting()
+                    .WithServiceBusMessageHandler<ShipmentAzureServiceBusMessageHandler, Shipment>()
+                    .WithServiceBusMessageHandler<OrdersSabotageAzureServiceBusMessageHandler, Order>(serviceProvider => sabotageHandler);
+
+            IServiceProvider provider = services.BuildServiceProvider();
+            var router = provider.GetRequiredService<IAzureServiceBusMessageRouter>();
+
+            var orderV2 = OrderV2Generator.Generate();
+            var message = ServiceBusModelFactory.ServiceBusReceivedMessage(BinaryData.FromObjectAsJson(orderV2), messageId: "message-id");
+            var context = AzureServiceBusMessageContextFactory.Generate();
+            var correlationInfo = message.GetCorrelationInfo();
+
+            // Act / Assert
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => router.RouteMessageAsync(message, context, correlationInfo, CancellationToken.None));
+
+            // Assert
+            Assert.Contains("none of the registered", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("fallback", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.False(sabotageHandler.IsProcessed, "sabotage message handler should be tried");
+        }
+
+        [Fact]
+        public async Task RouteMessage_WithGeneralRouting_GoesThroughRegisteredMessageHandler()
         {
             // Arrange
             var services = new ServiceCollection();
@@ -139,7 +195,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
         }
 
         [Fact]
-        public async Task WithServiceBusMessageRouting_WithMessageHandler_GoesThroughRegisteredMessageHandlers()
+        public async Task RouteMessage_WithMessageHandler_GoesThroughRegisteredMessageHandlers()
         {
             // Arrange
             var services = new ServiceCollection();
@@ -168,7 +224,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
         }
 
         [Fact]
-        public async Task WithServiceBusMessageRouting_WithMessageHandlerContextFilter_GoesThroughRegisteredMessageHandlers()
+        public async Task RouteMessage_WithMessageHandlerContextFilter_GoesThroughRegisteredMessageHandlers()
         {
             // Arrange
             var services = new ServiceCollection();
@@ -198,7 +254,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
         }
 
         [Fact]
-        public async Task WithServiceBusMessageRouting_WithMessageHandlerMessageBodyFilter_GoesThroughRegisteredMessageHandlers()
+        public async Task RouteMessage_WithMessageHandlerMessageBodyFilter_GoesThroughRegisteredMessageHandlers()
         {
             // Arrange
             var services = new ServiceCollection();
@@ -228,7 +284,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
         }
 
         [Fact]
-        public async Task WithServiceBusMessageRouting_WithMessageHandlerWithoutMessageFilterShouldGoBefore_OtherwiseDoesntTakeIntoAccountTrailingRegistrations()
+        public async Task RouteMessage_WithMessageHandlerWithoutMessageFilterShouldGoBefore_OtherwiseDoesntTakeIntoAccountTrailingRegistrations()
         {
             // Arrange
             var services = new ServiceCollection();
@@ -256,7 +312,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
         }
 
         [Fact]
-        public async Task WithServiceBusRouting_WithMessageHandlerMessageBodySerializer_DeserializesCustomMessage()
+        public async Task RouteMessage_WithMessageHandlerMessageBodySerializer_DeserializesCustomMessage()
         {
             // Arrange
             var services = new ServiceCollection();
@@ -287,7 +343,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
         }
 
         [Fact]
-        public async Task WithServiceBusRouting_WithMessageHandlerMessageBodySerializerSubType_DeserializesCustomMessage()
+        public async Task RouteMessage_WithMessageHandlerMessageBodySerializerSubType_DeserializesCustomMessage()
         {
             // Arrange
             var services = new ServiceCollection();
@@ -318,7 +374,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
         }
 
         [Fact]
-        public async Task WithServiceBusRouting_WithMessageHandlerCanHandleAllFiltersAtOnce_AndStillFindsTheRightMessageHandler()
+        public async Task RouteMessage_WithMessageHandlerCanHandleAllFiltersAtOnce_AndStillFindsTheRightMessageHandler()
         {
             // Arrange
             var services = new ServiceCollection();
@@ -368,7 +424,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
         }
 
         [Fact]
-        public void WithServiceBusRouting_WithCustomRouter_RegistersCustomRouter()
+        public void RouteMessage_WithCustomRouter_RegistersCustomRouter()
         {
             // Arrange
             var services = new ServiceCollection();
@@ -388,7 +444,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
         [Theory]
         [InlineData(AdditionalMemberHandling.Ignore)]
         [InlineData(AdditionalMemberHandling.Error)]
-        public async Task WithServiceBusRouting_IgnoreMissingMembers_ResultsInDifferentMessageHandler(AdditionalMemberHandling additionalMemberHandling)
+        public async Task RouteMessage_IgnoreMissingMembers_ResultsInDifferentMessageHandler(AdditionalMemberHandling additionalMemberHandling)
         {
             // Arrange
             var services = new ServiceCollection();
@@ -416,7 +472,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
         }
 
         [Fact]
-        public async Task WithServiceBusRouting_ExtremeNumberOfMessages_StillUsesTheCorrectMessageHandler()
+        public async Task RouteMessage_ExtremeNumberOfMessages_StillUsesTheCorrectMessageHandler()
         {
             // Arrange
             var services = new ServiceCollection();
@@ -465,7 +521,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
         }
 
         [Fact]
-        public async Task WithServiceBusRouting_WithMessageHandlerWithDifferentJobId_Fails()
+        public async Task RouteMessage_WithMessageHandlerWithDifferentJobId_Fails()
         {
             // Arrange
             var services = new ServiceCollection();

--- a/src/Arcus.Messaging.Tests.Workers.EventHubs.Core/Arcus.Messaging.Tests.Workers.EventHubs.Core.csproj
+++ b/src/Arcus.Messaging.Tests.Workers.EventHubs.Core/Arcus.Messaging.Tests.Workers.EventHubs.Core.csproj
@@ -11,7 +11,8 @@
     <PackageReference Include="Arcus.Observability.Correlation" Version="3.0.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="3.0.0" />
     <PackageReference Include="Arcus.Security.Core" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.0.1" />
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.5" />

--- a/src/Arcus.Messaging.Tests.Workers.ServiceBus/Arcus.Messaging.Tests.Workers.ServiceBus.csproj
+++ b/src/Arcus.Messaging.Tests.Workers.ServiceBus/Arcus.Messaging.Tests.Workers.ServiceBus.csproj
@@ -11,7 +11,8 @@
     <PackageReference Include="Arcus.Observability.Correlation" Version="3.0.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="3.0.0" />
     <PackageReference Include="Arcus.Security.Core" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.0.1" />
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.5" />

--- a/src/Arcus.Messaging.Tests.Workers.ServiceBus/MessageHandlers/CircuitBreakerAzureServiceBusMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Workers.ServiceBus/MessageHandlers/CircuitBreakerAzureServiceBusMessageHandler.cs
@@ -64,14 +64,9 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus.MessageHandlers
             }
 
             MessageArrivals.Add((message, DateTimeOffset.UtcNow));
-            if (MessageArrivals.Count == 1)
+            if (MessageArrivals.Count < _targetMessageIds.Length)
             {
                 await _circuitBreaker.PauseMessageProcessingAsync(messageContext.JobId, _configureOptions);
-            }
-
-            if (MessageArrivals.Count == 2)
-            {
-                throw new InvalidOperationException("Sabotage processing once the message pump starts back up again!");
             }
         }
 

--- a/src/Arcus.Messaging.Tests.Workers.ServiceBus/MessageHandlers/OrdersSabotageAzureServiceBusMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Workers.ServiceBus/MessageHandlers/OrdersSabotageAzureServiceBusMessageHandler.cs
@@ -10,6 +10,8 @@ namespace Arcus.Messaging.Tests.Workers.MessageHandlers
 {
     public class OrdersSabotageAzureServiceBusMessageHandler : IAzureServiceBusMessageHandler<Order>
     {
+        public bool IsProcessed { get; private set; }
+
         /// <summary>
         ///     Process a new message that was received
         /// </summary>
@@ -26,6 +28,7 @@ namespace Arcus.Messaging.Tests.Workers.MessageHandlers
             MessageCorrelationInfo correlationInfo,
             CancellationToken cancellationToken)
         {
+            IsProcessed = true;
             throw new InvalidOperationException(
                 "Sabotage the message processing with an unhandled exception");
         }


### PR DESCRIPTION
Only when an incoming Azure Service bus message hasn't gone trhough a matching but failing message handler, should we throw if there were no fallback message handlers registered.

Closes #424  