### PR TITLE
chore: remove guard.net references from abstractions

### DIFF
--- a/src/Arcus.Messaging.Abstractions/Arcus.Messaging.Abstractions.csproj
+++ b/src/Arcus.Messaging.Abstractions/Arcus.Messaging.Abstractions.csproj
@@ -27,7 +27,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Guard.NET" Version="3.0.0" />
     <PackageReference Include="Arcus.Observability.Correlation" Version="[3.0.0,4.0.0)" />
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="[3.0.0,4.0.0)" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[3.0.0,4.0.0)" />

--- a/src/Arcus.Messaging.Abstractions/Arcus.Messaging.Abstractions.csproj
+++ b/src/Arcus.Messaging.Abstractions/Arcus.Messaging.Abstractions.csproj
@@ -27,7 +27,6 @@
   </ItemGroup>
 
   <ItemGroup>
-
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[3.0.0,4.0.0)" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/src/Arcus.Messaging.Abstractions/Extensions/IDictionaryExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/IDictionaryExtensions.cs
@@ -19,7 +19,11 @@ namespace System
         public static (string transactionId, string operationParentId) GetTraceParent(
             this IReadOnlyDictionary<string, object> applicationProperties)
         {
-            Guard.NotNull(applicationProperties, nameof(applicationProperties), "Requires a set of application properties to retrieve the 'traceparent' property");
+            if (applicationProperties is null)
+            {
+                throw new ArgumentNullException(nameof(applicationProperties));
+            }
+
             return GetTraceParent((IDictionary<string, object>) applicationProperties);
         }
 
@@ -30,7 +34,10 @@ namespace System
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="applicationProperties"/> is <c>null</c>.</exception>
         public static (string transactionId, string operationParentId) GetTraceParent(this IDictionary<string, object> applicationProperties)
         {
-            Guard.NotNull(applicationProperties, nameof(applicationProperties), "Requires a set of application properties to retrieve the 'traceparent' property");
+            if (applicationProperties is null)
+            {
+                throw new ArgumentNullException(nameof(applicationProperties));
+            }
 
             if (applicationProperties.TryGetValue("Diagnostic-Id", out object value)
                 && value != null)

--- a/src/Arcus.Messaging.Abstractions/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/IServiceCollectionExtensions.cs
@@ -2,7 +2,6 @@
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.MessageHandling;
 using Arcus.Observability.Correlation;
-using GuardNet;
 using Microsoft.Extensions.Logging;
 
 // ReSharper disable once CheckNamespace
@@ -21,8 +20,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
         public static MessageHandlerCollection AddMessageRouting(this IServiceCollection services)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message routing");
-
             MessageHandlerCollection collection = AddMessageRouting(services, configureOptions: null);
             return collection;
         }
@@ -35,8 +32,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
         public static MessageHandlerCollection AddMessageRouting(this IServiceCollection services, Action<MessageRouterOptions> configureOptions)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message routing");
-            
             MessageHandlerCollection collection = AddMessageRouting(services, serviceProvider =>
             {
                 var options = new MessageRouterOptions();
@@ -61,8 +56,15 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<IServiceProvider, TMessageRouter> implementationFactory)
             where TMessageRouter : IMessageRouter
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message routing");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message router");
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (implementationFactory is null)
+            {
+                throw new ArgumentNullException(nameof(implementationFactory));
+            }
 
             services.AddApplicationInsightsTelemetryWorkerService();
 

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageBody.MessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageBody.MessageHandlerCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.MessageHandling;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -27,10 +26,7 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
             where TMessage : class
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, MessageContext>(messageBodyFilter);
+            return WithMessageHandler<TMessageHandler, TMessage, MessageContext>(services, messageBodyFilter);
         }
 
         /// <summary>
@@ -50,11 +46,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
-                messageBodyFilter, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
+            return WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
+                services, messageBodyFilter, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
         }
 
         /// <summary>
@@ -74,11 +67,7 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
             where TMessage : class
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent services");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, MessageContext>(messageBodyFilter, implementationFactory);
+            return WithMessageHandler<TMessageHandler, TMessage, MessageContext>(services, messageBodyFilter, implementationFactory);
         }
 
         /// <summary>
@@ -100,9 +89,20 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent services");
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (messageBodyFilter is null)
+            {
+                throw new ArgumentNullException(nameof(messageBodyFilter));
+            }
+
+            if (implementationFactory is null)
+            {
+                throw new ArgumentNullException(nameof(implementationFactory));
+            }
 
             services.AddMessageHandler(implementationFactory, messageBodyFilter: messageBodyFilter);
             return services;

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageBody.IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageBody.IServiceCollectionExtensions.cs
@@ -31,12 +31,7 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
             where TMessage : class
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent services");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, MessageContext>(messageContextFilter, messageBodyFilter, implementationFactory);
+            return WithMessageHandler<TMessageHandler, TMessage, MessageContext>(services, messageContextFilter, messageBodyFilter, implementationFactory);
         }
 
         /// <summary>
@@ -56,10 +51,6 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
             where TMessage : class
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-
             return WithMessageHandler<TMessageHandler, TMessage, MessageContext>(services, messageContextFilter, messageBodyFilter);
         }
 
@@ -82,12 +73,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-
-            return services.WithMessageHandler(
-                messageContextFilter, messageBodyFilter, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
+            return WithMessageHandler(
+                services, messageContextFilter, messageBodyFilter, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
         }
 
         /// <summary>
@@ -111,10 +98,25 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent services");
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (messageContextFilter is null)
+            {
+                throw new ArgumentNullException(nameof(messageContextFilter));
+            }
+
+            if (messageBodyFilter is null)
+            {
+                throw new ArgumentNullException(nameof(messageBodyFilter));
+            }
+
+            if (implementationFactory is null)
+            {
+                throw new ArgumentNullException(nameof(implementationFactory));
+            }
 
             services.AddMessageHandler(implementationFactory, messageBodyFilter, messageContextFilter);
             return services;

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageHandlerCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.MessageHandling;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -27,10 +26,7 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
             where TMessage : class
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, MessageContext>(messageContextFilter);
+            return WithMessageHandler<TMessageHandler, TMessage, MessageContext>(services, messageContextFilter);
         }
 
         /// <summary>
@@ -50,11 +46,7 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
             where TMessage : class
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent services");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, MessageContext>(messageContextFilter, implementationFactory);
+            return WithMessageHandler<TMessageHandler, TMessage, MessageContext>(services, messageContextFilter, implementationFactory);
         }
 
         /// <summary>
@@ -74,11 +66,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
-                messageContextFilter, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
+            return WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
+                services, messageContextFilter, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
         }
 
          /// <summary>
@@ -100,9 +89,20 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent services");
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (messageContextFilter is null)
+            {
+                throw new ArgumentNullException(nameof(messageContextFilter));
+            }
+
+            if (implementationFactory is null)
+            {
+                throw new ArgumentNullException(nameof(implementationFactory));
+            }
 
             services.AddMessageHandler(implementationFactory, messageContextFilter: messageContextFilter);
             return services;

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageSerializer.MessageBody.IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageSerializer.MessageBody.IServiceCollectionExtensions.cs
@@ -178,6 +178,11 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
+            if (messageBodySerializer is null)
+            {
+                throw new ArgumentNullException(nameof(messageBodySerializer));
+            }
+
             return WithMessageHandler(services, messageContextFilter, _ => messageBodySerializer, messageBodyFilter, implementationFactory);
         }
 

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageSerializer.MessageBody.IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageSerializer.MessageBody.IServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.MessageHandling;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -31,12 +30,7 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
             where TMessage : class
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, MessageContext>(messageContextFilter, messageBodySerializer, messageBodyFilter);
+            return WithMessageHandler<TMessageHandler, TMessage, MessageContext>(services, messageContextFilter, messageBodySerializer, messageBodyFilter);
         }
 
         /// <summary>
@@ -58,12 +52,7 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
             where TMessage : class
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, MessageContext>(messageContextFilter, messageBodySerializerImplementationFactory, messageBodyFilter);
+            return WithMessageHandler<TMessageHandler, TMessage, MessageContext>(services, messageContextFilter, messageBodySerializerImplementationFactory, messageBodyFilter);
         }
 
         /// <summary>
@@ -87,13 +76,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-
-            return services.WithMessageHandler(
-                messageContextFilter, messageBodySerializer, messageBodyFilter, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
+            return WithMessageHandler(
+                services, messageContextFilter, messageBodySerializer, messageBodyFilter, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
         }
 
         /// <summary>
@@ -117,13 +101,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-
-            return services.WithMessageHandler(
-                messageContextFilter, messageBodySerializerImplementationFactory, messageBodyFilter, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
+            return WithMessageHandler(
+                services, messageContextFilter, messageBodySerializerImplementationFactory, messageBodyFilter, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
         }
 
         /// <summary>
@@ -147,14 +126,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
             where TMessage : class
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent services");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, MessageContext>(
-                messageContextFilter, messageBodySerializer, messageBodyFilter, implementationFactory);
+            return WithMessageHandler<TMessageHandler, TMessage, MessageContext>(
+                services, messageContextFilter, messageBodySerializer, messageBodyFilter, implementationFactory);
         }
 
         /// <summary>
@@ -178,14 +151,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
             where TMessage : class
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-            Guard.NotNull(messageHandlerImplementationFactory, nameof(messageHandlerImplementationFactory), "Requires a function to create the message handler with dependent services");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, MessageContext>(
-                messageContextFilter, messageBodySerializerImplementationFactory, messageBodyFilter, messageHandlerImplementationFactory);
+            return WithMessageHandler<TMessageHandler, TMessage, MessageContext>(
+                services, messageContextFilter, messageBodySerializerImplementationFactory, messageBodyFilter, messageHandlerImplementationFactory);
         }
 
         /// <summary>
@@ -211,13 +178,7 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent services");
-
-            return services.WithMessageHandler(messageContextFilter, _ => messageBodySerializer, messageBodyFilter, implementationFactory);
+            return WithMessageHandler(services, messageContextFilter, _ => messageBodySerializer, messageBodyFilter, implementationFactory);
         }
 
         /// <summary>
@@ -243,11 +204,30 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-            Guard.NotNull(messageHandlerImplementationFactory, nameof(messageHandlerImplementationFactory), "Requires a function to create the message handler with dependent services");
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (messageContextFilter is null)
+            {
+                throw new ArgumentNullException(nameof(messageContextFilter));
+            }
+
+            if (messageBodySerializerImplementationFactory is null)
+            {
+                throw new ArgumentNullException(nameof(messageBodySerializerImplementationFactory));
+            }
+
+            if (messageBodyFilter is null)
+            {
+                throw new ArgumentNullException(nameof(messageBodyFilter));
+            }
+
+            if (messageHandlerImplementationFactory is null)
+            {
+                throw new ArgumentNullException(nameof(messageHandlerImplementationFactory));
+            }
 
             services.AddMessageHandler(messageHandlerImplementationFactory, messageBodyFilter, messageContextFilter, messageBodySerializerImplementationFactory);
             return services;

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageSerializer.MessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageSerializer.MessageHandlerCollectionExtensions.cs
@@ -138,6 +138,11 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
+            if (messageBodySerializer is null)
+            {
+                throw new ArgumentNullException(nameof(messageBodySerializer));
+            }
+
             return WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
                 services, messageContextFilter: messageContextFilter, messageBodySerializerImplementationFactory: _ => messageBodySerializer, messageHandlerImplementationFactory);
         }

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageSerializer.MessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageSerializer.MessageHandlerCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.MessageHandling;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -28,11 +27,7 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
             where TMessage : class
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, MessageContext>(messageContextFilter, messageBodySerializer);
+            return WithMessageHandler<TMessageHandler, TMessage, MessageContext>(services, messageContextFilter, messageBodySerializer);
         }
 
         /// <summary>
@@ -51,11 +46,7 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
             where TMessage : class
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create an custom message body serializer to deserialize the incoming message for the message handler");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, MessageContext>(messageContextFilter, messageBodySerializerImplementationFactory);
+            return WithMessageHandler<TMessageHandler, TMessage, MessageContext>(services, messageContextFilter, messageBodySerializerImplementationFactory);
         }
 
         /// <summary>
@@ -76,13 +67,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
             where TMessage : class
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageHandlerImplementationFactory, nameof(messageHandlerImplementationFactory), "Requires a function to create the message handler with dependent services");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, MessageContext>(
-                messageContextFilter, messageBodySerializer, messageHandlerImplementationFactory);
+            return WithMessageHandler<TMessageHandler, TMessage, MessageContext>(
+                services, messageContextFilter, messageBodySerializer, messageHandlerImplementationFactory);
         }
 
         /// <summary>
@@ -103,12 +89,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
             where TMessage : class
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create an custom message body serializer to deserialize the incoming message for the message handler");
-            Guard.NotNull(messageHandlerImplementationFactory, nameof(messageHandlerImplementationFactory), "Requires a function to create the message handler with dependent services");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, MessageContext>(
+            return WithMessageHandler<TMessageHandler, TMessage, MessageContext>(
+                services,
                 messageContextFilter, 
                 messageBodySerializerImplementationFactory, 
                 messageHandlerImplementationFactory);
@@ -132,12 +114,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
-                messageContextFilter, messageBodySerializer, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
+            return WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
+                services, messageContextFilter, messageBodySerializer, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
         }
 
         /// <summary>
@@ -160,13 +138,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageHandlerImplementationFactory, nameof(messageHandlerImplementationFactory), "Requires a function to create the message handler with dependent services");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
-                messageContextFilter: messageContextFilter, messageBodySerializerImplementationFactory: _ => messageBodySerializer, messageHandlerImplementationFactory);
+            return WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
+                services, messageContextFilter: messageContextFilter, messageBodySerializerImplementationFactory: _ => messageBodySerializer, messageHandlerImplementationFactory);
         }
 
         /// <summary>
@@ -187,12 +160,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create an custom message body serializer to deserialize the incoming message for the message handler");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
-                messageContextFilter, messageBodySerializerImplementationFactory, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
+            return WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
+                services, messageContextFilter, messageBodySerializerImplementationFactory, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
         }
 
         /// <summary>
@@ -215,10 +184,25 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageHandlerImplementationFactory, nameof(messageHandlerImplementationFactory), "Requires a function to create the message handler with dependent services");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create an custom message body serializer to deserialize the incoming message for the message handler");
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (messageContextFilter is null)
+            {
+                throw new ArgumentNullException(nameof(messageContextFilter));
+            }
+
+            if (messageHandlerImplementationFactory is null)
+            {
+                throw new ArgumentNullException(nameof(messageHandlerImplementationFactory));
+            }
+
+            if (messageBodySerializerImplementationFactory is null)
+            {
+                throw new ArgumentNullException(nameof(messageBodySerializerImplementationFactory));
+            }
 
             services.AddMessageHandler(
                 messageHandlerImplementationFactory, 

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageHandlerCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.MessageHandling;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -24,10 +23,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
             where TMessage : class
         {
-            Guard.NotNull(collection, nameof(collection), "Requires a set of collection to add the message handler");
-
-            return collection.WithMessageHandler<TMessageHandler, TMessage, MessageContext>(
-                serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
+            return WithMessageHandler<TMessageHandler, TMessage, MessageContext>(
+                collection, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
         }
 
         /// <summary>
@@ -45,10 +42,7 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
             where TMessage : class
         {
-            Guard.NotNull(collection, nameof(collection), "Requires a set of collection to add the message handler");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent collection");
-
-            return collection.WithMessageHandler<TMessageHandler, TMessage, MessageContext>(implementationFactory);
+            return WithMessageHandler<TMessageHandler, TMessage, MessageContext>(collection, implementationFactory);
         }
 
         /// <summary>
@@ -65,10 +59,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(collection, nameof(collection), "Requires a set of collection to add the message handler");
-
-            return collection.WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
-                serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
+            return WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
+                collection, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
         }
 
         /// <summary>
@@ -88,8 +80,15 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(collection, nameof(collection), "Requires a set of collection to add the message handler");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent collection");
+            if (collection is null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
+
+            if (implementationFactory is null)
+            {
+                throw new ArgumentNullException(nameof(implementationFactory));
+            }
 
             collection.AddMessageHandler(implementationFactory);
             return collection;
@@ -104,10 +103,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static MessageHandlerCollection WithFallbackMessageHandler<TMessageHandler>(this MessageHandlerCollection collection)
             where TMessageHandler : IFallbackMessageHandler<string, MessageContext>
         {
-            Guard.NotNull(collection, nameof(collection), "Requires a collection collection to add the fallback message handler to");
-
-            collection.WithFallbackMessageHandler(serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
-            return collection;
+            return WithFallbackMessageHandler(collection, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
         }
 
         /// <summary>
@@ -121,10 +117,7 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : IFallbackMessageHandler<string, TMessageContext>
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(collection, nameof(collection), "Requires a collection collection to add the fallback message handler to");
-
-            collection.WithFallbackMessageHandler<TMessageHandler, TMessageContext>(serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
-            return collection;
+            return WithFallbackMessageHandler<TMessageHandler, TMessageContext>(collection, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
         }
 
         /// <summary>
@@ -139,8 +132,15 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<IServiceProvider, TMessageHandler> createImplementation)
             where TMessageHandler : IFallbackMessageHandler<string, MessageContext>
         {
-            Guard.NotNull(collection, nameof(collection), "Requires a collection collection to add the fallback message handler to");
-            Guard.NotNull(createImplementation, nameof(createImplementation), "Requires a function to create the fallback message handler");
+            if (collection is null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
+
+            if (createImplementation is null)
+            {
+                throw new ArgumentNullException(nameof(createImplementation));
+            }
 
             collection.AddFallbackMessageHandler<TMessageHandler, string, MessageContext>(createImplementation);
             return collection;
@@ -160,8 +160,15 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : IFallbackMessageHandler<string, TMessageContext> 
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(collection, nameof(collection), "Requires a collection collection to add the fallback message handler to");
-            Guard.NotNull(createImplementation, nameof(createImplementation), "Requires a function to create the fallback message handler");
+            if (collection is null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
+
+            if (createImplementation is null)
+            {
+                throw new ArgumentNullException(nameof(createImplementation));
+            }
 
             collection.AddFallbackMessageHandler<TMessageHandler, string, TMessageContext>(createImplementation);
             return collection;

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageSerializer.MessageBody.IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageSerializer.MessageBody.IServiceCollectionExtensions.cs
@@ -164,6 +164,11 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
+            if (messageBodySerializer is null)
+            {
+                throw new ArgumentNullException(nameof(messageBodySerializer));
+            }
+
             return WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
                 services,
                 messageBodySerializerImplementationFactory: _ => messageBodySerializer,

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageSerializer.MessageBody.IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageSerializer.MessageBody.IServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.MessageHandling;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -29,10 +28,6 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
             where TMessage : class
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-
             return WithMessageHandler<TMessageHandler, TMessage, MessageContext>(services, messageBodySerializer, messageBodyFilter);
         }
 
@@ -53,10 +48,6 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
             where TMessage : class
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create an custom message body serializer to deserialize the incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-
             return WithMessageHandler<TMessageHandler, TMessage, MessageContext>(services, messageBodySerializerImplementationFactory, messageBodyFilter);
         }
 
@@ -79,12 +70,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
-                messageBodySerializer, messageBodyFilter, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
+            return WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
+                services, messageBodySerializer, messageBodyFilter, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
         }
 
         /// <summary>
@@ -106,12 +93,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create an custom message body serializer to deserialize the incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
-                messageBodySerializerImplementationFactory, messageBodyFilter, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
+            return WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
+                services, messageBodySerializerImplementationFactory, messageBodyFilter, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
         }
 
         /// <summary>
@@ -133,13 +116,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
             where TMessage : class
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent services");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, MessageContext>(
-                messageBodySerializer, messageBodyFilter, implementationFactory);
+            return WithMessageHandler<TMessageHandler, TMessage, MessageContext>(
+                services, messageBodySerializer, messageBodyFilter, implementationFactory);
         }
 
         /// <summary>
@@ -161,13 +139,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
             where TMessage : class
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create an custom message body serializer to deserialize the incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-            Guard.NotNull(messageHandlerImplementationFactory, nameof(messageHandlerImplementationFactory), "Requires a function to create the message handler with dependent services");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, MessageContext>(
-                messageBodySerializerImplementationFactory, messageBodyFilter, messageHandlerImplementationFactory);
+            return WithMessageHandler<TMessageHandler, TMessage, MessageContext>(
+                services, messageBodySerializerImplementationFactory, messageBodyFilter, messageHandlerImplementationFactory);
         }
 
         /// <summary>
@@ -191,12 +164,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent services");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
+            return WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
+                services,
                 messageBodySerializerImplementationFactory: _ => messageBodySerializer,
                 messageBodyFilter: messageBodyFilter,
                 messageHandlerImplementationFactory: implementationFactory);
@@ -223,10 +192,25 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create an custom message body serializer to deserialize the incoming message for the message handler");
-            Guard.NotNull(messageHandlerImplementationFactory, nameof(messageHandlerImplementationFactory), "Requires a function to create the message handler with dependent services");
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (messageBodyFilter is null)
+            {
+                throw new ArgumentNullException(nameof(messageBodyFilter));
+            }
+
+            if (messageBodySerializerImplementationFactory is null)
+            {
+                throw new ArgumentNullException(nameof(messageBodySerializerImplementationFactory));
+            }
+
+            if (messageHandlerImplementationFactory is null)
+            {
+                throw new ArgumentNullException(nameof(messageHandlerImplementationFactory));
+            }
 
             services.AddMessageHandler(
                 messageHandlerImplementationFactory, 

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageSerializer.MessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageSerializer.MessageHandlerCollectionExtensions.cs
@@ -84,6 +84,11 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
+            if (messageBodySerializer is null)
+            {
+                throw new ArgumentNullException(nameof(messageBodySerializer));
+            }
+
             return WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
                 services,
                 messageBodySerializerImplementationFactory: _ => messageBodySerializer, 

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageSerializer.MessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageSerializer.MessageHandlerCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.MessageHandling;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -26,10 +25,7 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
             where TMessage : class
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, MessageContext>(messageBodySerializer);
+            return WithMessageHandler<TMessageHandler, TMessage, MessageContext>(services, messageBodySerializer);
         }
 
         /// <summary>
@@ -48,11 +44,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
-                messageBodySerializer, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
+            return WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
+                services, messageBodySerializer, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
         }
 
         /// <summary>
@@ -70,11 +63,7 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
             where TMessage : class
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent services");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, MessageContext>(messageBodySerializer, implementationFactory);
+            return WithMessageHandler<TMessageHandler, TMessage, MessageContext>(services, messageBodySerializer, implementationFactory);
         }
 
         /// <summary>
@@ -95,11 +84,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent services");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
+            return WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
+                services,
                 messageBodySerializerImplementationFactory: _ => messageBodySerializer, 
                 messageHandlerImplementationFactory: implementationFactory);
         }
@@ -118,10 +104,7 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
             where TMessage : class
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, MessageContext>(messageBodySerializerImplementationFactory);
+            return WithMessageHandler<TMessageHandler, TMessage, MessageContext>(services, messageBodySerializerImplementationFactory);
         }
 
         /// <summary>
@@ -140,10 +123,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
+            return WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
+                services,
                 messageBodySerializerImplementationFactory, 
                 serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
         }
@@ -163,11 +144,8 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
             where TMessage : class
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageHandlerImplementationFactory, nameof(messageHandlerImplementationFactory));
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create an custom message body serializer instance to deserialize incoming message for the message handler");
-
-            return services.WithMessageHandler<TMessageHandler, TMessage, MessageContext>(
+            return WithMessageHandler<TMessageHandler, TMessage, MessageContext>(
+                services,
                 messageBodySerializerImplementationFactory,
                 messageHandlerImplementationFactory);
         }
@@ -190,9 +168,20 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the message handler");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageHandlerImplementationFactory, nameof(messageHandlerImplementationFactory), "Requires a function to create the message handler with dependent services");
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (messageBodySerializerImplementationFactory is null)
+            {
+                throw new ArgumentNullException(nameof(messageBodySerializerImplementationFactory));
+            }
+
+            if (messageHandlerImplementationFactory is null)
+            {
+                throw new ArgumentNullException(nameof(messageHandlerImplementationFactory));
+            }
 
             services.AddMessageHandler(messageHandlerImplementationFactory, implementationFactoryMessageBodySerializer: messageBodySerializerImplementationFactory);
             return services;

--- a/src/Arcus.Messaging.Abstractions/MessageContext.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageContext.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using GuardNet;
 
 namespace Arcus.Messaging.Abstractions
 {
@@ -18,11 +17,13 @@ namespace Arcus.Messaging.Abstractions
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="properties"/> is <c>null</c>.</exception>
         public MessageContext(string messageId, IDictionary<string, object> properties)
         {
-            Guard.NotNullOrEmpty(messageId, nameof(messageId));
-            Guard.NotNull(properties, nameof(properties));
+            if (string.IsNullOrWhiteSpace(messageId))
+            {
+                throw new ArgumentException("Requires a non-blank message ID", nameof(messageId));
+            }
 
             MessageId = messageId;
-            Properties = properties;
+            Properties = properties ?? throw new ArgumentNullException(nameof(properties));
         }
 
         /// <summary>
@@ -35,13 +36,19 @@ namespace Arcus.Messaging.Abstractions
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="properties"/> is <c>null</c>.</exception>
         public MessageContext(string messageId, string jobId, IDictionary<string, object> properties)
         {
-            Guard.NotNullOrEmpty(messageId, nameof(messageId));
-            Guard.NotNullOrWhitespace(jobId, nameof(jobId));
-            Guard.NotNull(properties, nameof(properties));
+            if (string.IsNullOrWhiteSpace(messageId))
+            {
+                throw new ArgumentException("Requires a non-blank message ID", nameof(messageId));
+            }
+
+            if (string.IsNullOrWhiteSpace(jobId))
+            {
+                throw new ArgumentException("Requires a non-blank job ID", nameof(jobId));
+            }
 
             MessageId = messageId;
             JobId = jobId;
-            Properties = properties;
+            Properties = properties ?? throw new ArgumentNullException(nameof(properties));
         }
 
         /// <summary>

--- a/src/Arcus.Messaging.Abstractions/MessageCorrelationInfoAccessor.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageCorrelationInfoAccessor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.Observability.Correlation;
-using GuardNet;
 
 namespace Arcus.Messaging.Abstractions
 {
@@ -18,8 +17,7 @@ namespace Arcus.Messaging.Abstractions
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="implementation"/> is <c>null</c>.</exception>
         public MessageCorrelationInfoAccessor(ICorrelationInfoAccessor<MessageCorrelationInfo> implementation)
         {
-            Guard.NotNull(implementation, nameof(implementation), "Requires an implementation of the correlation info accessor using the messaging correlation information");
-            _implementation = implementation;
+            _implementation = implementation ?? throw new ArgumentNullException(nameof(implementation));
         }
 
         /// <summary>

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/FallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/FallbackMessageHandler.cs
@@ -24,12 +24,11 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             string jobId,
             ILogger logger)
         {
-            Guard.NotNull(messageHandlerInstance, nameof(messageHandlerInstance));
-
             _jobId = jobId;
             _logger = logger ?? NullLogger.Instance;
+
+            MessageHandlerInstance = messageHandlerInstance ?? throw new ArgumentNullException(nameof(messageHandlerInstance));
             MessageHandlerType = messageHandlerInstance.GetType();
-            MessageHandlerInstance = messageHandlerInstance;
         }
 
         /// <summary>
@@ -54,8 +53,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             string jobId,
             ILogger<IFallbackMessageHandler<TMessage, TMessageContext>> logger)
         {
-            Guard.NotNull(messageHandlerInstance, nameof(messageHandlerInstance), "Requires the original instance of the fallback message handler");
-            return new FallbackMessageHandler<TMessage, TMessageContext>(messageHandlerInstance, jobId, logger);
+            return new FallbackMessageHandler<TMessage, TMessageContext>(messageHandlerInstance ?? throw new ArgumentNullException(nameof(messageHandlerInstance)), jobId, logger);
         }
 
         /// <summary>
@@ -64,8 +62,11 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// <param name="messageContext">The context in which the incoming message is processed.</param>
         public bool CanProcessMessageBasedOnContext(TMessageContext messageContext)
         {
-            Guard.NotNull(messageContext, nameof(messageContext), "Requires an message context instance to determine if the fallback message handler can process the message");
-           
+            if (messageContext is null)
+            {
+                throw new ArgumentNullException(nameof(messageContext));
+            }
+
             return _jobId is null || messageContext.JobId == _jobId;
         }
 
@@ -85,9 +86,20 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             MessageCorrelationInfo correlationInfo,
             CancellationToken cancellationToken)
         {
-            Guard.NotNull(message, nameof(message), "Requires message content to process the message fallback operation");
-            Guard.NotNull(messageContext, nameof(messageContext), "Requires a message context to send to the fallback message handler");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires correlation information to send to the fallback message handler");
+            if (message is null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            if (messageContext is null)
+            {
+                throw new ArgumentNullException(nameof(messageContext));
+            }
+
+            if (correlationInfo is null)
+            {
+                throw new ArgumentNullException(nameof(correlationInfo));
+            }
 
             if (CanProcessMessageBasedOnContext(messageContext))
             {

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageCorrelationEnricherOptions.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageCorrelationEnricherOptions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions.Telemetry;
 using Arcus.Observability.Telemetry.Serilog.Enrichers.Configuration;
-using GuardNet;
 
 namespace Arcus.Messaging.Abstractions.MessageHandling
 {
@@ -21,7 +20,11 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             get => _cycleIdPropertyName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank property name to enrich the log event with the correlation information cycle ID");
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentException("Requires a non-blank property name for the cycle ID", nameof(value));
+                }
+
                 _cycleIdPropertyName = value;
             }
         }

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageCorrelationOptions.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageCorrelationOptions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 
 namespace Arcus.Messaging.Abstractions.MessageHandling
 {
@@ -28,7 +27,11 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             get => _transactionIdPropertyName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Transaction ID message property name for the message cannot be blank");
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentException("Requires a non-blank property name for the transaction ID", nameof(value));
+                }
+
                 _transactionIdPropertyName = value;
             }
         }
@@ -45,7 +48,11 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             get => _operationParentIdPropertyName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Operation parent ID message property name for the message cannot be blank");
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentException("Requires a non-blank property name for the operation parent ID", nameof(value));
+                }
+
                 _operationParentIdPropertyName = value;
             }
         }

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageHandlerCollection.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageHandlerCollection.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -18,8 +17,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
         public MessageHandlerCollection(IServiceCollection services)
         {
-            Guard.NotNull(services, nameof(services), "Requires a collection of services to register the message handling logic into");
-            Services = services;
+            Services = services ?? throw new ArgumentNullException(nameof(services));
         }
 
         /// <summary>
@@ -50,7 +48,10 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             Func<IServiceProvider, IMessageBodySerializer> implementationFactoryMessageBodySerializer = null)
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create a message handler implementation to register the handler within the application services");
+            if (implementationFactory is null)
+            {
+                throw new ArgumentNullException(nameof(implementationFactory));
+            }
             
             Services.AddTransient(
                 serviceProvider => MessageHandler.Create(
@@ -76,7 +77,10 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the user-defined fallback message handler");
+            if (implementationFactory is null)
+            {
+                throw new ArgumentNullException(nameof(implementationFactory));
+            }
 
             Services.AddSingleton(
                 serviceProvider => FallbackMessageHandler<TMessage, TMessageContext>.Create(

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageResult.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageResult.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 
 namespace Arcus.Messaging.Abstractions.MessageHandling
 {
@@ -64,8 +63,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// <param name="message">The deserialized message instance.</param>
         public static MessageResult Success(object message)
         {
-            Guard.NotNull(message, nameof(message), "Requires a deserialized message instance when the message deserialization was successful");
-            return new MessageResult(message);
+            return new MessageResult(message ?? throw new ArgumentNullException(nameof(message)));
         }
 
         /// <summary>
@@ -75,7 +73,11 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// <exception cref="ArgumentException">Thrown when the <paramref name="errorMessage"/> is blank.</exception>
         public static MessageResult Failure(string errorMessage)
         {
-            Guard.NotNullOrWhitespace(errorMessage, nameof(errorMessage), "Requires a non-blank error message describing the deserialization failure");
+            if (string.IsNullOrWhiteSpace(errorMessage))
+            {
+                throw new ArgumentException("Requires a non-blank error message describing the deserialization failure", nameof(errorMessage));
+            }
+
             return new MessageResult(errorMessage);
         }
 
@@ -86,8 +88,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="exception"/> is <c>null</c>.</exception>
         public static MessageResult Failure(Exception exception)
         {
-            Guard.NotNull(exception, nameof(exception), "Requires an exception describing the deserialization failure");
-            return new MessageResult(exception);
+            return new MessageResult(exception ?? throw new ArgumentNullException(nameof(exception)));
         }
     }
 }

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Arcus.Messaging.Abstractions.Telemetry;
-using GuardNet;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -30,7 +29,6 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         public MessageRouter(IServiceProvider serviceProvider, MessageRouterOptions options, ILogger<MessageRouter> logger)
             : this(serviceProvider, options, (ILogger) logger)
         {
-            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires a service provider instance to retrieve all the registered message handlers");
         }
         
         /// <summary>
@@ -42,7 +40,6 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         public MessageRouter(IServiceProvider serviceProvider, MessageRouterOptions options)
             : this(serviceProvider, options, NullLogger.Instance)
         {
-            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires a service provider instance to retrieve all the registered message handlers");
         }
 
         /// <summary>
@@ -54,7 +51,6 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         public MessageRouter(IServiceProvider serviceProvider, ILogger<MessageRouter> logger)
             : this(serviceProvider, new MessageRouterOptions(), (ILogger) logger)
         {
-            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires a service provider instance to retrieve all the registered message handlers");
         }
 
         /// <summary>
@@ -65,7 +61,6 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         public MessageRouter(IServiceProvider serviceProvider)
             : this(serviceProvider, new MessageRouterOptions(), NullLogger.Instance)
         {
-            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires a service provider instance to retrieve all the registered message handlers");
         }
         
         /// <summary>
@@ -77,7 +72,6 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         protected MessageRouter(IServiceProvider serviceProvider, ILogger logger)
             : this(serviceProvider, new MessageRouterOptions(), logger)
         {
-            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires a service provider instance to retrieve all the registered message handlers");
         }
 
         /// <summary>
@@ -89,9 +83,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
         protected MessageRouter(IServiceProvider serviceProvider, MessageRouterOptions options, ILogger logger)
         {
-            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires a service provider instance to retrieve all the registered message handlers");
-
-            ServiceProvider = serviceProvider;
+            ServiceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
             Options = options ?? new MessageRouterOptions();
             Logger = logger ?? NullLogger<MessageRouter>.Instance;
         }
@@ -133,9 +125,20 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             CancellationToken cancellationToken)
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(message, nameof(message), "Requires message content to deserialize and process the message");
-            Guard.NotNull(messageContext, nameof(messageContext), "Requires a message context to send to the message handler");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires correlation information to send to the message handler");
+            if (message is null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            if (messageContext is null)
+            {
+                throw new ArgumentNullException(nameof(messageContext));
+            }
+
+            if (correlationInfo is null)
+            {
+                throw new ArgumentNullException(nameof(correlationInfo));
+            }
 
             using (IServiceScope serviceScope = ServiceProvider.CreateScope())
             using (LogContext.Push(new MessageCorrelationInfoEnricher(correlationInfo, Options.CorrelationEnricher)))
@@ -167,9 +170,20 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             CancellationToken cancellationToken)
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(message, nameof(message), "Requires message content to deserialize and process the message");
-            Guard.NotNull(messageContext, nameof(messageContext), "Requires a message context to send to the message handler");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires correlation information to send to the message handler");
+            if (message is null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            if (messageContext is null)
+            {
+                throw new ArgumentNullException(nameof(messageContext));
+            }
+
+            if (correlationInfo is null)
+            {
+                throw new ArgumentNullException(nameof(correlationInfo));
+            }
 
             using (IServiceScope serviceScope = ServiceProvider.CreateScope())
             using (LogContext.Push(new MessageCorrelationInfoEnricher(correlationInfo, Options.CorrelationEnricher)))
@@ -260,8 +274,11 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
         protected IEnumerable<MessageHandler> GetRegisteredMessageHandlers(IServiceProvider serviceProvider)
         {
-            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires a service provider to extract the registered services from");
-            
+            if (serviceProvider is null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider));
+            }
+
             IEnumerable<MessageHandler> handlers = MessageHandler.SubtractFrom(serviceProvider, Logger);
             return handlers;
         }
@@ -283,7 +300,10 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             MessageHandler handler)
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(handler, nameof(handler), "Requires an message handler instance for which the incoming message can be deserialized");
+            if (handler is null)
+            {
+                throw new ArgumentNullException(nameof(handler));
+            }
 
             Type messageHandlerType = handler.GetMessageHandlerType();
             Logger.LogTrace("Determine if message handler '{MessageHandlerType}' can process the message...", messageHandlerType.Name);
@@ -348,8 +368,15 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             CancellationToken cancellationToken)
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(messageContext, nameof(messageContext), "Requires a message context to send to the message handler");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires correlation information to send to the message handler");
+            if (messageContext is null)
+            {
+                throw new ArgumentNullException(nameof(messageContext));
+            }
+
+            if (correlationInfo is null)
+            {
+                throw new ArgumentNullException(nameof(correlationInfo));
+            }
 
             bool isProcessedByTypedContext = await TryFallbackProcessMessageByContextAsync(message, messageContext, correlationInfo, cancellationToken);
             if (isProcessedByTypedContext)
@@ -421,7 +448,10 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             where TMessage : class
             where TMessageContext : MessageContext
         {
-            Guard.NotNull(messageContext, nameof(messageContext), "Requires a message context to filter out fallback message handlers that are registered with the same message context's Job ID");
+            if (messageContext is null)
+            {
+                throw new ArgumentNullException(nameof(messageContext));
+            }
 
             return ServiceProvider.GetServices<FallbackMessageHandler<TMessage, TMessageContext>>()
                                   .Where(handler => handler.CanProcessMessageBasedOnContext(messageContext))
@@ -440,7 +470,11 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// <exception cref="ArgumentException">Thrown when the <paramref name="messageType"/> is blank.</exception>
         protected virtual bool TryDeserializeToMessageFormat(string message, Type messageType, out object result)
         {
-            Guard.NotNullOrWhitespace(message, nameof(message), "Can't parse a blank raw message against a message handler's contract");
+            if (string.IsNullOrWhiteSpace(message))
+            {
+                throw new ArgumentException("Requires a non-blank message to deserialize to a given type", nameof(message));
+            }
+
             Logger.LogTrace("Try to JSON deserialize incoming message to message type '{MessageType}'...", messageType.Name);
 
             var success = true;

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageTelemetryOptions.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageTelemetryOptions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 
 namespace Arcus.Messaging.Abstractions.MessageHandling
 {
@@ -19,7 +18,11 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             get => _operationName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Operation name for the message cannot be blank");
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentException("Requires a non-blank operation name", nameof(value));
+                }
+
                 _operationName = value;
             }
         }

--- a/src/Arcus.Messaging.Abstractions/Telemetry/MessageCorrelationInfoEnricher.cs
+++ b/src/Arcus.Messaging.Abstractions/Telemetry/MessageCorrelationInfoEnricher.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions.MessageHandling;
-using GuardNet;
 using Serilog.Core;
 using Serilog.Events;
 
@@ -22,11 +21,8 @@ namespace Arcus.Messaging.Abstractions.Telemetry
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="messageCorrelationInfo"/> or <paramref name="options"/> is <c>null</c>.</exception>
         public MessageCorrelationInfoEnricher(MessageCorrelationInfo messageCorrelationInfo, MessageCorrelationEnricherOptions options)
         {
-            Guard.NotNull(messageCorrelationInfo, nameof(messageCorrelationInfo), "Requires a message correlation instance to enrich the log events");
-            Guard.NotNull(options, nameof(options), "Requires a set of options to control the message correlation enrichment on the log events");
-
-            _messageCorrelationInfo = messageCorrelationInfo;
-            _options = options;
+            _messageCorrelationInfo = messageCorrelationInfo ?? throw new ArgumentNullException(nameof(messageCorrelationInfo));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
         }
 
         /// <summary>

--- a/src/Arcus.Messaging.Health/Arcus.Messaging.Health.csproj
+++ b/src/Arcus.Messaging.Health/Arcus.Messaging.Health.csproj
@@ -27,7 +27,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Guard.NET" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>

--- a/src/Arcus.Messaging.Health/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Health/Extensions/IServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Health.Publishing;
 using Arcus.Messaging.Health.Tcp;
-using GuardNet;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 // ReSharper disable once CheckNamespace
@@ -38,8 +37,15 @@ namespace Microsoft.Extensions.DependencyInjection
             Action<TcpHealthListenerOptions> configureTcpListenerOptions = null,
             Action<HealthCheckPublisherOptions> configureHealthCheckPublisherOptions = null)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the TCP health probe to");
-            Guard.NotNullOrWhitespace(tcpConfigurationKey, nameof(tcpConfigurationKey), "Requires a non-blank configuration key to retrieve the TCP port");
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (string.IsNullOrWhiteSpace(tcpConfigurationKey))
+            {
+                throw new ArgumentException("Requires a non-blank configuration key for the TCP port", nameof(tcpConfigurationKey));
+            }
 
             IHealthChecksBuilder healthCheckBuilder = services.AddHealthChecks();
             configureHealthChecks?.Invoke(healthCheckBuilder);

--- a/src/Arcus.Messaging.Health/Publishing/TcpHealthCheckPublisher.cs
+++ b/src/Arcus.Messaging.Health/Publishing/TcpHealthCheckPublisher.cs
@@ -2,7 +2,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Arcus.Messaging.Health.Tcp;
-using GuardNet;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -40,13 +39,9 @@ namespace Arcus.Messaging.Health.Publishing
         /// <exception cref="ArgumentException">Thrown when the <paramref name="options"/> doesn't have a filled-out value.</exception>
         public TcpHealthCheckPublisher(TcpHealthListener healthListener, TcpHealthListenerOptions options, ILogger<TcpHealthCheckPublisher> logger)
         {
-            Guard.NotNull(healthListener, nameof(healthListener), "Requires a TCP health listener to accept or reject TCP connections");
-            Guard.NotNull(options, nameof(options), "Requires a set of registered options to determine if the TCP connections should be accepted or rejected based on the health report");
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to write diagnostic trace messages when TCP connections are accepted or rejected");
-            
-            _healthListener = healthListener;
-            _options = options;
-            _logger = logger;
+            _healthListener = healthListener ?? throw new ArgumentNullException(nameof(healthListener));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _logger = logger ?? NullLogger<TcpHealthCheckPublisher>.Instance;
         }
         
         /// <summary>
@@ -58,7 +53,10 @@ namespace Arcus.Messaging.Health.Publishing
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="report"/> is <c>null</c>.</exception>
         public Task PublishAsync(HealthReport report, CancellationToken cancellationToken)
         {
-            Guard.NotNull(report, nameof(report), "Requires a health report to determine whether or not to accept or reject TCP connections");
+            if (report is null)
+            {
+                throw new ArgumentNullException(nameof(report));
+            }
 
             if (_options.RejectTcpConnectionWhenUnhealthy)
             {

--- a/src/Arcus.Messaging.Health/Tcp/TcpHealthListenerOptions.cs
+++ b/src/Arcus.Messaging.Health/Tcp/TcpHealthListenerOptions.cs
@@ -1,4 +1,4 @@
-﻿using GuardNet;
+﻿using System;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Arcus.Messaging.Health.Tcp
@@ -23,7 +23,11 @@ namespace Arcus.Messaging.Health.Tcp
             get => _tcpHealthPort;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank configuration key for the TCP health port");
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentException("Requires a non-blank configuration key for the TCP port", nameof(value));
+                }
+
                 _tcpHealthPort = value;
             }
         }

--- a/src/Arcus.Messaging.Pumps.Abstractions/Arcus.Messaging.Pumps.Abstractions.csproj
+++ b/src/Arcus.Messaging.Pumps.Abstractions/Arcus.Messaging.Pumps.Abstractions.csproj
@@ -28,7 +28,6 @@
 
   <ItemGroup>
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[3.0.0,4.0.0)" />
-    <PackageReference Include="Guard.NET" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.0" />

--- a/src/Arcus.Messaging.Pumps.Abstractions/Arcus.Messaging.Pumps.Abstractions.csproj
+++ b/src/Arcus.Messaging.Pumps.Abstractions/Arcus.Messaging.Pumps.Abstractions.csproj
@@ -27,7 +27,6 @@
   </ItemGroup>
 
   <ItemGroup>
-
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.0" />

--- a/src/Arcus.Messaging.Pumps.Abstractions/DefaultMessagePumpLifetime.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/DefaultMessagePumpLifetime.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using GuardNet;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -25,8 +24,7 @@ namespace Arcus.Messaging.Pumps.Abstractions
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
         public DefaultMessagePumpLifetime(IServiceProvider serviceProvider)
         {
-            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires a service provider instance to retrieve the registered message pumps");
-            _serviceProvider = serviceProvider;
+            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
             _logger = serviceProvider.GetService<ILogger<DefaultMessagePumpLifetime>>() ?? NullLogger<DefaultMessagePumpLifetime>.Instance;
         }
 
@@ -38,7 +36,10 @@ namespace Arcus.Messaging.Pumps.Abstractions
         /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
         public async Task StartProcessingMessagesAsync(string jobId, CancellationToken cancellationToken)
         {
-            Guard.NotNullOrWhitespace(jobId, nameof(jobId), "Requires a message pump job ID to retrieve the registered message pump in the application services");
+            if (string.IsNullOrWhiteSpace(jobId))
+            {
+                throw new ArgumentException("Requires a non-blank job ID to distinguish message pumps", nameof(jobId));
+            }
 
             MessagePump messagePump = GetMessagePump(jobId);
             
@@ -57,7 +58,10 @@ namespace Arcus.Messaging.Pumps.Abstractions
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="duration"/> is a negative time range.</exception>
         public async Task PauseProcessingMessagesAsync(string jobId, TimeSpan duration, CancellationToken cancellationToken)
         {
-            Guard.NotNullOrWhitespace(jobId, nameof(jobId), "Requires a message pump job ID to retrieve the registered message pump in the application services");
+            if (string.IsNullOrWhiteSpace(jobId))
+            {
+                throw new ArgumentException("Requires a non-blank job ID to distinguish message pumps", nameof(jobId));
+            }
 
             MessagePump messagePump = GetMessagePump(jobId);
             _logger.LogTrace("Stopping message pump '{JobId}' via message pump lifetime...", jobId);
@@ -81,7 +85,10 @@ namespace Arcus.Messaging.Pumps.Abstractions
         /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
         public async Task StopProcessingMessagesAsync(string jobId, CancellationToken cancellationToken)
         {
-            Guard.NotNullOrWhitespace(jobId, nameof(jobId), "Requires a message pump job ID to retrieve the registered message pump in the application services");
+            if (string.IsNullOrWhiteSpace(jobId))
+            {
+                throw new ArgumentException("Requires a non-blank job ID to distinguish message pumps", nameof(jobId));
+            }
 
             MessagePump messagePump = GetMessagePump(jobId);
 

--- a/src/Arcus.Messaging.Pumps.Abstractions/MessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/MessagePump.cs
@@ -3,10 +3,11 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Arcus.Messaging.Pumps.Abstractions.Resiliency;
-using GuardNet;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using ArgumentException = System.ArgumentException;
 
 namespace Arcus.Messaging.Pumps.Abstractions
 {
@@ -26,11 +27,17 @@ namespace Arcus.Messaging.Pumps.Abstractions
         /// </exception>
         protected MessagePump(IConfiguration configuration, IServiceProvider serviceProvider, ILogger logger)
         {
-            Guard.NotNull(configuration, nameof(configuration));
-            Guard.NotNull(serviceProvider, nameof(serviceProvider));
-            Guard.NotNull(logger, nameof(logger));
+            if (configuration is null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
 
-            Logger = logger;
+            if (serviceProvider is null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider));
+            }
+
+            Logger = logger ?? NullLogger.Instance;
             Configuration = configuration;
             ServiceProvider = serviceProvider;
         }
@@ -177,7 +184,10 @@ namespace Arcus.Messaging.Pumps.Abstractions
         /// <param name="entityPath">Entity path that is being processed</param>
         protected void RegisterClientInformation(string clientId, string entityPath)
         {
-            Guard.NotNullOrWhitespace(clientId, nameof(clientId));
+            if (string.IsNullOrWhiteSpace(clientId))
+            {
+                throw new ArgumentException("Requires a non-blank client ID", nameof(clientId));
+            }
 
             ClientId = clientId;
             EntityPath = entityPath;

--- a/src/Arcus.Messaging.Pumps.Abstractions/Resiliency/MessagePumpCircuitBreakerOptions.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/Resiliency/MessagePumpCircuitBreakerOptions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 
 namespace Arcus.Messaging.Pumps.Abstractions.Resiliency
 {
@@ -24,7 +23,11 @@ namespace Arcus.Messaging.Pumps.Abstractions.Resiliency
             get => _messageRecoveryPeriod;
             set
             {
-                Guard.NotLessThanOrEqualTo(value, TimeSpan.Zero, nameof(value));
+                if (value <= TimeSpan.Zero)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), "Requires a positive time period for the message recovery");
+                }
+
                 _messageRecoveryPeriod = value;
             }
         }
@@ -42,7 +45,11 @@ namespace Arcus.Messaging.Pumps.Abstractions.Resiliency
             get => _messageIntervalDuringRecovery;
             set
             {
-                Guard.NotLessThanOrEqualTo(value, TimeSpan.Zero, nameof(value));
+                if (value <= TimeSpan.Zero)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), "Requires a positive time period for the message interval");
+                }
+
                 _messageIntervalDuringRecovery = value;
             }
         }


### PR DESCRIPTION
Remove the Guard.NET references from the abstractions libraries.

Relates to #449 