### PR TITLE
chore: remove guard.net references from eventhubs

### DIFF
--- a/src/Arcus.Messaging.Abstractions.EventHubs/AzureEventHubsMessageContext.cs
+++ b/src/Arcus.Messaging.Abstractions.EventHubs/AzureEventHubsMessageContext.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading;
 using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Producer;
-using GuardNet;
 
 namespace Arcus.Messaging.Abstractions.EventHubs
 {
@@ -13,7 +12,7 @@ namespace Arcus.Messaging.Abstractions.EventHubs
     public class AzureEventHubsMessageContext : MessageContext
     {
         private AzureEventHubsMessageContext(
-            EventData eventData, 
+            EventData eventData,
             string eventHubsName,
             string consumerGroup,
             string eventHubsNamespace,
@@ -125,8 +124,10 @@ namespace Arcus.Messaging.Abstractions.EventHubs
             EventData message,
             EventProcessorClient eventProcessor)
         {
-            Guard.NotNull(message, nameof(message), "Requires an Azure EventHubs event data message to retrieve the information to create a messaging context for this message");
-            Guard.NotNull(eventProcessor, nameof(eventProcessor), "Requires an Azure EventHubs event processor to retrieve the information to create a messaging context for the consumed event");
+            if (eventProcessor is null)
+            {
+                throw new ArgumentNullException(nameof(eventProcessor));
+            }
 
             return CreateFrom(
                 message,
@@ -157,11 +158,6 @@ namespace Arcus.Messaging.Abstractions.EventHubs
             string consumerGroup,
             string eventHubsName)
         {
-            Guard.NotNull(message, nameof(message), "Requires an Azure EventHubs event data message to retrieve the information to create a messaging context for this message");
-            Guard.NotNullOrWhitespace(eventHubsNamespace, nameof(eventHubsNamespace), "Requires a non-blank Azure EventHubs fully qualified namespace to relate the messaging context to the event message");
-            Guard.NotNullOrWhitespace(consumerGroup, nameof(consumerGroup), "Requires a non-blank Azure EventHubs consumer group to relate the messaging context to the event message");
-            Guard.NotNullOrWhitespace(eventHubsName, nameof(eventHubsName), "Requires a non-blank Azure EventHubs name to relate the messaging context to the event message");
-
             return CreateFrom(message, eventHubsNamespace, consumerGroup, eventHubsName, "<not-defined>");
         }
 
@@ -179,9 +175,10 @@ namespace Arcus.Messaging.Abstractions.EventHubs
             EventProcessorClient eventProcessor,
             string jobId)
         {
-            Guard.NotNull(message, nameof(message), "Requires an Azure EventHubs event data message to retrieve the information to create a messaging context for this message");
-            Guard.NotNull(eventProcessor, nameof(eventProcessor), "Requires an Azure EventHubs event processor to retrieve the information to create a messaging context for the consumed event");
-            Guard.NotNullOrWhitespace(jobId, nameof(jobId), "Requires a non-blank job ID to link this message context to a message pump that processes the event message");
+            if (eventProcessor is null)
+            {
+                throw new ArgumentNullException(nameof(eventProcessor));
+            }
 
             return CreateFrom(
                 message,
@@ -213,11 +210,30 @@ namespace Arcus.Messaging.Abstractions.EventHubs
             string eventHubsName,
             string jobId)
         {
-            Guard.NotNull(message, nameof(message), "Requires an Azure EventHubs event data message to retrieve the information to create a messaging context for this message");
-            Guard.NotNullOrWhitespace(eventHubsNamespace, nameof(eventHubsNamespace), "Requires a non-blank Azure EventHubs fully qualified namespace to relate the messaging context to the event message");
-            Guard.NotNullOrWhitespace(consumerGroup, nameof(consumerGroup), "Requires a non-blank Azure EventHubs consumer group to relate the messaging context to the event message");
-            Guard.NotNullOrWhitespace(eventHubsName, nameof(eventHubsName), "Requires a non-blank Azure EventHubs name to relate the messaging context to the event message");
-            Guard.NotNullOrWhitespace(jobId, nameof(jobId), "Requires a non-blank job ID to link this message context to a message pump that processes the event message");
+            if (message is null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            if (string.IsNullOrWhiteSpace(eventHubsNamespace))
+            {
+                throw new ArgumentException("Requires a non-blank Azure EventHubs fully qualified namespace to relate the messaging context to the event message", nameof(eventHubsNamespace));
+            }
+
+            if (string.IsNullOrWhiteSpace(consumerGroup))
+            {
+                throw new ArgumentException("Requires a non-blank Azure EventHubs consumer group to relate the messaging context to the event message", nameof(consumerGroup));
+            }
+
+            if (string.IsNullOrWhiteSpace(eventHubsName))
+            {
+                throw new ArgumentException("Requires a non-blank Azure EventHubs name to relate the messaging context to the event message", nameof(eventHubsName));
+            }
+
+            if (string.IsNullOrWhiteSpace(jobId))
+            {
+                throw new ArgumentException("Requires a non-blank job ID to link this message context to a message pump that processes the event message", nameof(jobId));
+            }
 
             return new AzureEventHubsMessageContext(message, eventHubsName, consumerGroup, eventHubsNamespace, jobId);
         }

--- a/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/EventDataExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/EventDataExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions.EventHubs;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Azure.Messaging.EventHubs
@@ -20,10 +19,6 @@ namespace Azure.Messaging.EventHubs
         /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
         public static AzureEventHubsMessageContext GetMessageContext(this EventData message, EventProcessorClient eventProcessor, string jobId)
         {
-            Guard.NotNull(message, nameof(message), "Requires an event data to retrieve the Azure EventHubs message context");
-            Guard.NotNull(eventProcessor, nameof(eventProcessor), "Requires an Azure EventHubs event processor to retrieve the information to create a messaging context for the consumed event");
-            Guard.NotNullOrWhitespace(jobId, nameof(jobId), "Requires a non-blank job ID to link this message context to a message pump that processes the event message");
-
             return AzureEventHubsMessageContext.CreateFrom(message, eventProcessor, jobId);
         }
 
@@ -44,12 +39,6 @@ namespace Azure.Messaging.EventHubs
         /// </exception>
         public static AzureEventHubsMessageContext GetMessageContext(this EventData message, string eventHubsNamespace, string eventHubsName, string consumerGroup, string jobId)
         {
-            Guard.NotNull(message, nameof(message), "Requires an event data to retrieve the Azure EventHubs message context");
-            Guard.NotNullOrWhitespace(eventHubsNamespace, nameof(eventHubsNamespace), "Requires an Azure EventHubs namespace to built-up the message context");
-            Guard.NotNullOrWhitespace(eventHubsName, nameof(eventHubsName), "Requires an Azure EventHubs name to built-up the message context");
-            Guard.NotNullOrWhitespace(consumerGroup, nameof(consumerGroup), "Requires an Azure EventHubs consumer group to built-up the message context");
-            Guard.NotNullOrWhitespace(jobId, nameof(jobId), "Requires a non-blank job ID to link this message context to a message pump that processes the event message");
-
             return AzureEventHubsMessageContext.CreateFrom(message, eventHubsNamespace, consumerGroup, eventHubsName, jobId);
         }
     }

--- a/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/EventHubsMessageHandlerExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/EventHubsMessageHandlerExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions.EventHubs;
 using Arcus.Messaging.Abstractions.EventHubs.MessageHandling;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -24,7 +23,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureEventHubsMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureEventHubsMessageContext>();
             return handlers;
@@ -45,8 +47,15 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureEventHubsMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent handlers");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
+
+            if (implementationFactory is null)
+            {
+                throw new ArgumentNullException(nameof(implementationFactory));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureEventHubsMessageContext>(implementationFactory);
             return handlers;

--- a/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/IServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions.EventHubs.MessageHandling;
-using GuardNet;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 
@@ -22,8 +21,6 @@ namespace Microsoft.Extensions.DependencyInjection
         public static EventHubsMessageHandlerCollection AddEventHubsMessageRouting(
             this IServiceCollection services)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to register the Azure EventHubs message routing");
-
             return AddEventHubsMessageRouting(services, configureOptions: null);
         }
 
@@ -38,8 +35,6 @@ namespace Microsoft.Extensions.DependencyInjection
             this IServiceCollection services,
             Action<AzureEventHubsMessageRouterOptions> configureOptions)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to register the Azure EventHubs message routing");
-
             return AddEventHubsMessageRouting(services, (serviceProvider, options) =>
             {
                 var logger = serviceProvider.GetService<ILogger<AzureEventHubsMessageRouter>>();
@@ -60,9 +55,6 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<IServiceProvider, TMessageRouter> implementationFactory)
             where TMessageRouter : IAzureEventHubsMessageRouter
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to register the Azure EventHubs message routing");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the Azure EventHubs message router");
-
             return AddEventHubsMessageRouting(services, (serviceProvider, options) => implementationFactory(serviceProvider), configureOptions: null);
         }
 
@@ -81,8 +73,15 @@ namespace Microsoft.Extensions.DependencyInjection
             Action<AzureEventHubsMessageRouterOptions> configureOptions)
             where TMessageRouter : IAzureEventHubsMessageRouter
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to register the Azure EventHubs message routing");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the Azure EventHubs message router");
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (implementationFactory is null)
+            {
+                throw new ArgumentNullException(nameof(implementationFactory));
+            }
 
             services.TryAddSingleton<IAzureEventHubsMessageRouter>(serviceProvider =>
             {

--- a/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/Message.EventHubsMessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/Message.EventHubsMessageHandlerCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions.EventHubs;
 using Arcus.Messaging.Abstractions.EventHubs.MessageHandling;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -27,8 +26,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureEventHubsMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureEventHubsMessageContext>(messageBodyFilter);
             return handlers;
@@ -51,9 +52,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureEventHubsMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent handlers");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureEventHubsMessageContext>(messageBodyFilter, implementationFactory);
             return handlers;

--- a/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/MessageContext.EventHubsMessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/MessageContext.EventHubsMessageHandlerCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions.EventHubs;
 using Arcus.Messaging.Abstractions.EventHubs.MessageHandling;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -27,8 +26,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureEventHubsMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureEventHubsMessageContext>(
                 messageContextFilter, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
@@ -53,9 +54,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureEventHubsMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent handlers");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureEventHubsMessageContext>(messageContextFilter, implementationFactory);
             return handlers;

--- a/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/MessageContext.Message.EventHubsMessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/MessageContext.Message.EventHubsMessageHandlerCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions.EventHubs;
 using Arcus.Messaging.Abstractions.EventHubs.MessageHandling;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -29,8 +28,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureEventHubsMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureEventHubsMessageContext>(messageContextFilter, messageBodyFilter);
             return handlers;
@@ -55,12 +56,12 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureEventHubsMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent handlers");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
-            handlers.WithMessageHandler<TMessageHandler, TMessage, AzureEventHubsMessageContext>(messageContextFilter, messageBodyFilter, implementationFactory);
+            handlers.WithMessageHandler(messageContextFilter, messageBodyFilter, implementationFactory);
             return handlers;
         }
     }

--- a/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/MessageContext.MessageSerializer.EventHubsMessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/MessageContext.MessageSerializer.EventHubsMessageHandlerCollectionExtensions.cs
@@ -1,8 +1,7 @@
 ﻿using System;
-using Arcus.Messaging.Abstractions.MessageHandling;
 using Arcus.Messaging.Abstractions.EventHubs;
 using Arcus.Messaging.Abstractions.EventHubs.MessageHandling;
-using GuardNet;
+using Arcus.Messaging.Abstractions.MessageHandling;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -30,9 +29,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureEventHubsMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureEventHubsMessageContext>(messageContextFilter, messageBodySerializer);
             return handlers;
@@ -55,9 +55,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureEventHubsMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create an custom message body serializer instance to deserialize incoming message for the message handler");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureEventHubsMessageContext>(messageContextFilter, messageBodySerializerImplementationFactory);
             return handlers;
@@ -82,10 +83,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureEventHubsMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureEventHubsMessageContext>(messageContextFilter, messageBodySerializer, implementationFactory);
             return handlers;
@@ -110,10 +111,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureEventHubsMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageHandlerImplementationFactory, nameof(messageHandlerImplementationFactory), "Requires a function to create the message handler");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureEventHubsMessageContext>(messageContextFilter, messageBodySerializerImplementationFactory, messageHandlerImplementationFactory);
             return handlers;

--- a/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/MessageContext.MessageSerializer.Message.EventHubsMessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/MessageContext.MessageSerializer.Message.EventHubsMessageHandlerCollectionExtensions.cs
@@ -1,8 +1,7 @@
 ﻿using System;
-using Arcus.Messaging.Abstractions.MessageHandling;
 using Arcus.Messaging.Abstractions.EventHubs;
 using Arcus.Messaging.Abstractions.EventHubs.MessageHandling;
-using GuardNet;
+using Arcus.Messaging.Abstractions.MessageHandling;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -32,9 +31,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureEventHubsMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureEventHubsMessageContext>(messageContextFilter, messageBodySerializer, messageBodyFilter);
             return handlers;
@@ -59,9 +59,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureEventHubsMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureEventHubsMessageContext>(messageContextFilter, messageBodySerializerImplementationFactory, messageBodyFilter);
             return handlers;
@@ -88,12 +89,12 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureEventHubsMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
-            handlers.WithMessageHandler<TMessageHandler, TMessage, AzureEventHubsMessageContext>(messageContextFilter, messageBodySerializer, messageBodyFilter, implementationFactory);
+            handlers.WithMessageHandler(messageContextFilter, messageBodySerializer, messageBodyFilter, implementationFactory);
             return handlers;
         }
 
@@ -118,12 +119,12 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureEventHubsMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-            Guard.NotNull(messageHandlerImplementationFactory, nameof(messageHandlerImplementationFactory), "Requires a function to create the message handler");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
-            handlers.WithMessageHandler<TMessageHandler, TMessage, AzureEventHubsMessageContext>(messageContextFilter, messageBodySerializerImplementationFactory, messageBodyFilter, messageHandlerImplementationFactory);
+            handlers.WithMessageHandler(messageContextFilter, messageBodySerializerImplementationFactory, messageBodyFilter, messageHandlerImplementationFactory);
             return handlers;
         }
     }

--- a/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/MessageSerializer.EventHubsMessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/MessageSerializer.EventHubsMessageHandlerCollectionExtensions.cs
@@ -1,8 +1,7 @@
 ﻿using System;
-using Arcus.Messaging.Abstractions.MessageHandling;
 using Arcus.Messaging.Abstractions.EventHubs;
 using Arcus.Messaging.Abstractions.EventHubs.MessageHandling;
-using GuardNet;
+using Arcus.Messaging.Abstractions.MessageHandling;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -28,8 +27,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureEventHubsMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureEventHubsMessageContext>(messageBodySerializer);
             return handlers;
@@ -50,8 +51,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureEventHubsMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create the custom message body serializer instance to deserialize incoming message for the message handler");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureEventHubsMessageContext>(messageBodySerializerImplementationFactory);
             return handlers;
@@ -74,9 +77,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureEventHubsMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureEventHubsMessageContext>(messageBodySerializer, implementationFactory);
             return handlers;
@@ -99,9 +103,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureEventHubsMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create the custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageHandlerImplementationFactory, nameof(messageHandlerImplementationFactory), "Requires a function to create the message handler");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureEventHubsMessageContext>(messageBodySerializerImplementationFactory, messageHandlerImplementationFactory);
             return handlers;

--- a/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/MessageSerializer.Message.EventHubsMessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/MessageSerializer.Message.EventHubsMessageHandlerCollectionExtensions.cs
@@ -1,8 +1,7 @@
 ﻿using System;
-using Arcus.Messaging.Abstractions.MessageHandling;
 using Arcus.Messaging.Abstractions.EventHubs;
 using Arcus.Messaging.Abstractions.EventHubs.MessageHandling;
-using GuardNet;
+using Arcus.Messaging.Abstractions.MessageHandling;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -30,9 +29,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureEventHubsMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureEventHubsMessageContext>(messageBodySerializer, messageBodyFilter);
             return handlers;
@@ -57,10 +57,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureEventHubsMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent handlers");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureEventHubsMessageContext>(messageBodySerializer, messageBodyFilter, implementationFactory);
             return handlers;
@@ -83,9 +83,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureEventHubsMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create the custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureEventHubsMessageContext>(messageBodySerializerImplementationFactory, messageBodyFilter);
             return handlers;
@@ -110,10 +111,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureEventHubsMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create the custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-            Guard.NotNull(messageHandlerImplementationFactory, nameof(messageHandlerImplementationFactory), "Requires a function to create the message handler with dependent handlers");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureEventHubsMessageContext>(messageBodySerializerImplementationFactory, messageBodyFilter, messageHandlerImplementationFactory);
             return handlers;

--- a/src/Arcus.Messaging.AzureFunctions.EventHubs/AzureFunctionsInProcessMessageCorrelation.cs
+++ b/src/Arcus.Messaging.AzureFunctions.EventHubs/AzureFunctionsInProcessMessageCorrelation.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions;
 using Azure.Messaging.EventHubs;
-using GuardNet;
 using Microsoft.ApplicationInsights;
 
 namespace Arcus.Messaging.AzureFunctions.EventHubs
@@ -20,8 +19,7 @@ namespace Arcus.Messaging.AzureFunctions.EventHubs
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="client"/> is <c>null</c>.</exception>
         public AzureFunctionsInProcessMessageCorrelation(TelemetryClient client)
         {
-            Guard.NotNull(client, nameof(client), "Requires a Microsoft telemetry client to automatically track outgoing built-in Microsoft dependencies");
-            _telemetryClient = client;
+            _telemetryClient = client ?? throw new ArgumentNullException(nameof(client));
         }
 
         /// <summary>
@@ -32,7 +30,10 @@ namespace Arcus.Messaging.AzureFunctions.EventHubs
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> is <c>null</c>.</exception>
         public MessageCorrelationResult CorrelateMessage(EventData message)
         {
-            Guard.NotNull(message, nameof(message), "Requires an incoming Azure EventHubs message to W3C correlate the message");
+            if (message is null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
 
             (string transactionId, string operationParentId) = message.Properties.GetTraceParent();
             return MessageCorrelationResult.Create(_telemetryClient, transactionId, operationParentId);

--- a/src/Arcus.Messaging.AzureFunctions.EventHubs/Extensions/IFunctionsHostBuilderExtensions.cs
+++ b/src/Arcus.Messaging.AzureFunctions.EventHubs/Extensions/IFunctionsHostBuilderExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions.EventHubs.MessageHandling;
 using Arcus.Messaging.AzureFunctions.EventHubs;
-using GuardNet;
 using Microsoft.Extensions.DependencyInjection;
 
 // ReSharper disable once CheckNamespace
@@ -22,8 +21,6 @@ namespace Microsoft.Azure.Functions.Extensions.DependencyInjection
         public static EventHubsMessageHandlerCollection AddEventHubsMessageRouting(
             this IFunctionsHostBuilder builder)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a functions host builder to add the Azure EventHubs message router");
-
             return AddEventHubsMessageRouting(builder, configureOptions: null);
         }
 
@@ -38,7 +35,10 @@ namespace Microsoft.Azure.Functions.Extensions.DependencyInjection
             this IFunctionsHostBuilder builder,
             Action<AzureEventHubsMessageRouterOptions> configureOptions)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a functions host builder to add the Azure EventHubs message router");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
 
             return builder.Services.AddSingleton<AzureFunctionsInProcessMessageCorrelation>()
                           .AddEventHubsMessageRouting(configureOptions);
@@ -57,9 +57,6 @@ namespace Microsoft.Azure.Functions.Extensions.DependencyInjection
             Func<IServiceProvider, TMessageRouter> implementationFactory)
             where TMessageRouter : IAzureEventHubsMessageRouter
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a functions host builder to add the Azure EventHubs message router");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the Azure EventHubs message router");
-
             return AddEventHubsMessageRouting(builder, (provider, options) => implementationFactory(provider), configureOptions: null);
         }
 
@@ -78,8 +75,15 @@ namespace Microsoft.Azure.Functions.Extensions.DependencyInjection
             Action<AzureEventHubsMessageRouterOptions> configureOptions)
             where TMessageRouter : IAzureEventHubsMessageRouter
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a functions host builder to add the Azure EventHubs message router");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the Azure EventHubs message router");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (implementationFactory is null)
+            {
+                throw new ArgumentNullException(nameof(implementationFactory));
+            }
 
             return builder.Services.AddSingleton<AzureFunctionsInProcessMessageCorrelation>()
                           .AddEventHubsMessageRouting(implementationFactory, configureOptions);

--- a/src/Arcus.Messaging.EventHubs.Core/EventDataBuilder.cs
+++ b/src/Arcus.Messaging.EventHubs.Core/EventDataBuilder.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Text;
 using Arcus.Messaging.Abstractions;
-using GuardNet;
 using Newtonsoft.Json;
 
 // ReSharper disable once CheckNamespace
@@ -31,7 +30,6 @@ namespace Azure.Messaging.EventHubs
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="eventBody"/> or the is <c>null</c>.</exception>
         public static EventDataBuilder CreateForBody(object eventBody)
         {
-            Guard.NotNull(eventBody, nameof(eventBody), "Requires a message body to include in the to-be-created Azure EventHubs message");
             return CreateForBody(eventBody, Encoding.UTF8);
         }
 
@@ -43,10 +41,9 @@ namespace Azure.Messaging.EventHubs
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="eventBody"/> or the <paramref name="encoding"/> is <c>null</c>.</exception>
         public static EventDataBuilder CreateForBody(object eventBody, Encoding encoding)
         {
-            Guard.NotNull(eventBody, nameof(eventBody), "Requires a message body to include in the to-be-created Azure EventHubs message");
-            Guard.NotNull(encoding, nameof(encoding), "Requires an encoding instance to encode the passed-in message body so it can be included in the Azure EventHubs message");
-
-            return new EventDataBuilder(eventBody, encoding);
+            return new EventDataBuilder(
+                eventBody ?? throw new ArgumentNullException(nameof(eventBody)),
+                encoding ?? throw new ArgumentNullException(nameof(encoding)));
         }
 
         /// <summary>
@@ -110,7 +107,7 @@ namespace Azure.Messaging.EventHubs
             {
                 _transactionIdProperty = new KeyValuePair<string, object>(
                     transactionIdPropertyName ?? PropertyNames.TransactionId,
-                    transactionId); 
+                    transactionId);
             }
 
             return this;
@@ -145,7 +142,7 @@ namespace Azure.Messaging.EventHubs
             {
                 _operationParentIdProperty = new KeyValuePair<string, object>(
                     operationParentIdPropertyName ?? PropertyNames.OperationParentId,
-                    operationParentId); 
+                    operationParentId);
             }
 
             return this;
@@ -170,7 +167,7 @@ namespace Azure.Messaging.EventHubs
             if (_operationIdProperty.Key is null && _operationIdProperty.Value is not null)
             {
                 eventData.CorrelationId = _operationIdProperty.Value?.ToString();
-            } 
+            }
             else if (_operationIdProperty.Value is not null)
             {
                 eventData.Properties.Add(_operationIdProperty);

--- a/src/Arcus.Messaging.EventHubs.Core/EventHubProducerClientMessageCorrelationOptions.cs
+++ b/src/Arcus.Messaging.EventHubs.Core/EventHubProducerClientMessageCorrelationOptions.cs
@@ -5,7 +5,6 @@ using Arcus.Messaging.Abstractions;
 using Arcus.Observability.Correlation;
 using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Producer;
-using GuardNet;
 using Microsoft.Extensions.Logging;
 
 namespace Arcus.Messaging.EventHubs.Core
@@ -28,7 +27,11 @@ namespace Arcus.Messaging.EventHubs.Core
             get => _transactionIdPropertyName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank value for the message correlation transaction ID Azure Service Bus application property name");
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentException("Requires a non-blank value for the message correlation transaction ID Azure Service Bus application property name", nameof(value));
+                }
+
                 _transactionIdPropertyName = value;
             }
         }
@@ -42,7 +45,11 @@ namespace Arcus.Messaging.EventHubs.Core
             get => _upstreamServicePropertyName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank value for the message correlation upstream service Azure Service Bus application property name");
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentException("Requires a non-blank value for the message correlation upstream service Azure Service Bus application property name", nameof(value));
+                }
+
                 _upstreamServicePropertyName = value;
             }
         }
@@ -53,11 +60,7 @@ namespace Arcus.Messaging.EventHubs.Core
         public Func<string> GenerateDependencyId
         {
             get => _generateDependencyId;
-            set
-            {
-                Guard.NotNull(value, nameof(value), "Requires a function to generate the dependency ID used when tracking Azure Service Bus dependencies");
-                _generateDependencyId = value;
-            }
+            set => _generateDependencyId = value ?? throw new ArgumentNullException(nameof(value));
         }
 
         /// <summary>
@@ -72,7 +75,11 @@ namespace Arcus.Messaging.EventHubs.Core
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="telemetryContext"/> is <c>null</c>.</exception>
         public void AddTelemetryContext(Dictionary<string, object> telemetryContext)
         {
-            Guard.NotNull(telemetryContext, nameof(telemetryContext), "Requires a telemetry context instance to add to the dependency tracking");
+            if (telemetryContext is null)
+            {
+                throw new ArgumentNullException(nameof(telemetryContext));
+            }
+
             foreach (KeyValuePair<string, object> item in telemetryContext)
             {
                 TelemetryContext[item.Key] = item.Value;

--- a/src/Arcus.Messaging.EventHubs.Core/Extensions/AzureClientFactoryBuilderExtensions.cs
+++ b/src/Arcus.Messaging.EventHubs.Core/Extensions/AzureClientFactoryBuilderExtensions.cs
@@ -2,13 +2,12 @@
 using Arcus.Security.Core;
 using Azure.Core.Extensions;
 using Azure.Messaging.EventHubs.Producer;
-using GuardNet;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 // ReSharper disable once CheckNamespace
-namespace  Microsoft.Extensions.Azure
+namespace Microsoft.Extensions.Azure
 {
     /// <summary>
     /// Extensions on the <see cref="IAzureClientFactoryBuilder"/> to add more easily Azure EventHubs producer clients with Arcus components.
@@ -41,9 +40,6 @@ namespace  Microsoft.Extensions.Azure
             this AzureClientFactoryBuilder builder,
             string connectionStringSecretName)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires an Azure client factory builder to add the Azure EventHubs producer client");
-            Guard.NotNullOrWhitespace(connectionStringSecretName, nameof(connectionStringSecretName), "Requires a non-blank secret name to retrieve the Azure EventHubs connection string from the Arcus secret store");
-
             return AddEventHubProducerClient(builder, connectionStringSecretName: connectionStringSecretName, configureOptions: null);
         }
 
@@ -75,8 +71,15 @@ namespace  Microsoft.Extensions.Azure
             string connectionStringSecretName,
             Action<EventHubProducerClientOptions> configureOptions)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires an Azure client factory builder to add the Azure EventHubs producer client");
-            Guard.NotNullOrWhitespace(connectionStringSecretName, nameof(connectionStringSecretName), "Requires a non-blank secret name to retrieve the Azure EventHubs connection string from the Arcus secret store");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (string.IsNullOrWhiteSpace(connectionStringSecretName))
+            {
+                throw new ArgumentException("Requires a non-blank secret name that points to an Azure Event Hubs connection string", nameof(connectionStringSecretName));
+            }
 
             return builder.AddClient<EventHubProducerClient, EventHubProducerClientOptions>((options, serviceProvider) =>
             {
@@ -87,7 +90,7 @@ namespace  Microsoft.Extensions.Azure
             });
         }
 
-         /// <summary>
+        /// <summary>
         /// Registers a <see cref="EventHubProducerClient" /> instance into the Azure client factory <paramref name="builder"/>
         /// via a connection string available via the <paramref name="connectionStringSecretName"/> in the Arcus secret store.
         /// </summary>
@@ -115,10 +118,6 @@ namespace  Microsoft.Extensions.Azure
             string connectionStringSecretName,
             string eventHubName)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires an Azure client factory builder to add the Azure EventHubs producer client");
-            Guard.NotNullOrWhitespace(connectionStringSecretName, nameof(connectionStringSecretName), "Requires a non-blank secret name to retrieve the Azure EventHubs connection string from the Arcus secret store");
-            Guard.NotNullOrWhitespace(eventHubName, nameof(eventHubName), "Requires a non-blank Azure EventHubs name to register the Azure EventHubs producer client");
-
             return AddEventHubProducerClient(builder, connectionStringSecretName: connectionStringSecretName, eventHubName, configureOptions: null);
         }
 
@@ -152,9 +151,20 @@ namespace  Microsoft.Extensions.Azure
             string eventHubName,
             Action<EventHubProducerClientOptions> configureOptions)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires an Azure client factory builder to add the Azure EventHubs producer client");
-            Guard.NotNullOrWhitespace(connectionStringSecretName, nameof(connectionStringSecretName), "Requires a non-blank secret name to retrieve the Azure EventHubs connection string from the Arcus secret store");
-            Guard.NotNullOrWhitespace(eventHubName, nameof(eventHubName), "Requires a non-blank Azure EventHubs name to register the Azure EventHubs producer client");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (string.IsNullOrWhiteSpace(connectionStringSecretName))
+            {
+                throw new ArgumentException("Requires a non-blank secret name that points to an Azure Event Hubs connection string", nameof(connectionStringSecretName));
+            }
+
+            if (string.IsNullOrWhiteSpace(eventHubName))
+            {
+                throw new ArgumentException("Requires a non-blank Azure EventHubs name to register the Azure EventHubs producer client", nameof(eventHubName));
+            }
 
             return builder.AddClient<EventHubProducerClient, EventHubProducerClientOptions>((options, serviceProvider) =>
             {
@@ -182,8 +192,8 @@ namespace  Microsoft.Extensions.Azure
             }
             catch (Exception exception)
             {
-                ILogger logger = 
-                    serviceProvider.GetService<ILogger<EventHubProducerClient>>() 
+                ILogger logger =
+                    serviceProvider.GetService<ILogger<EventHubProducerClient>>()
                     ?? NullLogger<EventHubProducerClient>.Instance;
 
                 logger.LogTrace(exception, "Cannot synchronously retrieve Azure EventHubs connection string secret for '{SecretName}', fallback on asynchronously", connectionStringSecretName);

--- a/src/Arcus.Messaging.EventHubs.Core/Extensions/EventDataExtensions.cs
+++ b/src/Arcus.Messaging.EventHubs.Core/Extensions/EventDataExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Azure.Messaging.EventHubs
@@ -22,7 +21,6 @@ namespace Azure.Messaging.EventHubs
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="eventData"/> is <c>null</c>.</exception>
         public static MessageCorrelationInfo GetCorrelationInfo(this EventData eventData)
         {
-            Guard.NotNull(eventData, nameof(eventData), "Requires an event data instance to retrieve the message correlation information");
             return GetCorrelationInfo(eventData, PropertyNames.TransactionId);
         }
 
@@ -44,9 +42,6 @@ namespace Azure.Messaging.EventHubs
             this EventData eventData,
             string transactionIdPropertyName)
         {
-            Guard.NotNull(eventData, nameof(eventData), "Requires an event data instance to retrieve the message correlation information");
-            Guard.NotNullOrWhitespace(transactionIdPropertyName, nameof(transactionIdPropertyName), "Requires a non-blank application property name to retrieve the transaction ID from the event data's properties");
-
             return GetCorrelationInfo(eventData, transactionIdPropertyName, PropertyNames.OperationParentId);
         }
 
@@ -74,9 +69,20 @@ namespace Azure.Messaging.EventHubs
             string transactionIdPropertyName,
             string operationParentIdPropertyName)
         {
-            Guard.NotNull(eventData, nameof(eventData), "Requires an event data instance to retrieve the message correlation information");
-            Guard.NotNullOrWhitespace(transactionIdPropertyName, nameof(transactionIdPropertyName), "Requires a non-blank application property name to retrieve the transaction ID from the event data's properties");
-            Guard.NotNullOrWhitespace(operationParentIdPropertyName, nameof(operationParentIdPropertyName), "Requires a non-blank application property name to retrieve the operation parent ID from the event data's properties");
+            if (eventData is null)
+            {
+                throw new ArgumentNullException(nameof(eventData));
+            }
+
+            if (string.IsNullOrWhiteSpace(transactionIdPropertyName))
+            {
+                throw new ArgumentException("Requires a non-blank application property name to retrieve the transaction ID from the event data's properties", nameof(transactionIdPropertyName));
+            }
+
+            if (string.IsNullOrWhiteSpace(operationParentIdPropertyName))
+            {
+                throw new ArgumentException("Requires a non-blank application property name to retrieve the operation parent ID from the event data's properties", nameof(operationParentIdPropertyName));
+            }
 
             string transactionId = DetermineTransactionId(eventData, transactionIdPropertyName);
             string operationId = DetermineOperationId(eventData.CorrelationId);

--- a/src/Arcus.Messaging.EventHubs.Core/Extensions/EventHubProducerClientExtensions.cs
+++ b/src/Arcus.Messaging.EventHubs.Core/Extensions/EventHubProducerClientExtensions.cs
@@ -4,11 +4,9 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
-using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.EventHubs.Core;
 using Arcus.Observability.Correlation;
 using Arcus.Observability.Telemetry.Core;
-using GuardNet;
 using Microsoft.Extensions.Logging;
 
 // ReSharper disable once CheckNamespace
@@ -55,13 +53,6 @@ namespace Azure.Messaging.EventHubs.Producer
             ILogger logger,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(client, nameof(client), "Requires an Azure EventHubs producer client while sending a correlated message");
-            Guard.NotNull(eventBatch, nameof(eventBatch), "Requires a series of Azure EventHubs messages to send as correlated messages");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a message correlation instance to include the transaction ID in the send out messages");
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure EventHubs dependency while sending the correlated messages");
-            Guard.NotAny(eventBatch, nameof(eventBatch), "Requires at least a single message to send to Azure EventHubs");
-            Guard.For(() => eventBatch.Any(message => message is null), new ArgumentException("Requires non-null items in Azure EventHubs message sequence", nameof(eventBatch)));
-
             await SendAsync(client, eventBatch, correlationInfo, logger, sendEventOptions: null, configureOptions: null, cancellationToken);
         }
 
@@ -103,13 +94,6 @@ namespace Azure.Messaging.EventHubs.Producer
             Action<EventHubProducerClientMessageCorrelationOptions> configureOptions,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(client, nameof(client), "Requires an Azure EventHubs producer client while sending a correlated message");
-            Guard.NotNull(eventBatch, nameof(eventBatch), "Requires a series of Azure EventHubs messages to send as correlated messages");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a message correlation instance to include the transaction ID in the send out messages");
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure EventHubs dependency while sending the correlated messages");
-            Guard.NotAny(eventBatch, nameof(eventBatch), "Requires at least a single message to send to Azure EventHubs");
-            Guard.For(() => eventBatch.Any(message => message is null), new ArgumentException("Requires non-null items in Azure EventHubs message sequence", nameof(eventBatch)));
-
             await SendAsync(client, eventBatch, correlationInfo, logger, sendEventOptions: null, configureOptions, cancellationToken);
         }
 
@@ -152,13 +136,6 @@ namespace Azure.Messaging.EventHubs.Producer
             SendEventOptions sendEventOptions,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(client, nameof(client), "Requires an Azure EventHubs producer client while sending a correlated message");
-            Guard.NotNull(eventBatch, nameof(eventBatch), "Requires a series of Azure EventHubs messages to send as correlated messages");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a message correlation instance to include the transaction ID in the send out messages");
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure EventHubs dependency while sending the correlated messages");
-            Guard.NotAny(eventBatch, nameof(eventBatch), "Requires at least a single message to send to Azure EventHubs");
-            Guard.For(() => eventBatch.Any(message => message is null), new ArgumentException("Requires non-null items in Azure EventHubs message sequence", nameof(eventBatch)));
-
             await SendAsync(client, eventBatch, correlationInfo, logger, sendEventOptions, configureOptions: null, cancellationToken);
         }
 
@@ -203,7 +180,9 @@ namespace Azure.Messaging.EventHubs.Producer
             Action<EventHubProducerClientMessageCorrelationOptions> configureOptions,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            EventData[] eventMessages = eventBatch.Select(ev => EventDataBuilder.CreateForBody(ev).Build()).ToArray();
+            object[] batchArr = eventBatch?.ToArray() ?? throw new ArgumentNullException(nameof(eventBatch));
+            EventData[] eventMessages = batchArr.Select(ev => EventDataBuilder.CreateForBody(ev).Build()).ToArray();
+
             await SendAsync(client, eventMessages, correlationInfo, logger, sendEventOptions, configureOptions, cancellationToken);
         }
 
@@ -243,13 +222,6 @@ namespace Azure.Messaging.EventHubs.Producer
             ILogger logger,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(client, nameof(client), "Requires an Azure EventHubs producer client while sending a correlated message");
-            Guard.NotNull(eventBatch, nameof(eventBatch), "Requires a series of Azure EventHubs messages to send as correlated messages");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a message correlation instance to include the transaction ID in the send out messages");
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure EventHubs dependency while sending the correlated messages");
-            Guard.NotAny(eventBatch, nameof(eventBatch), "Requires at least a single message to send to Azure EventHubs");
-            Guard.For(() => eventBatch.Any(message => message is null), new ArgumentException("Requires non-null items in Azure EventHubs message sequence", nameof(eventBatch)));
-
             await SendAsync(client, eventBatch, correlationInfo, logger, sendEventOptions: null, configureOptions: null, cancellationToken);
         }
 
@@ -291,13 +263,6 @@ namespace Azure.Messaging.EventHubs.Producer
             Action<EventHubProducerClientMessageCorrelationOptions> configureOptions,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(client, nameof(client), "Requires an Azure EventHubs producer client while sending a correlated message");
-            Guard.NotNull(eventBatch, nameof(eventBatch), "Requires a series of Azure EventHubs messages to send as correlated messages");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a message correlation instance to include the transaction ID in the send out messages");
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure EventHubs dependency while sending the correlated messages");
-            Guard.NotAny(eventBatch, nameof(eventBatch), "Requires at least a single message to send to Azure EventHubs");
-            Guard.For(() => eventBatch.Any(message => message is null), new ArgumentException("Requires non-null items in Azure EventHubs message sequence", nameof(eventBatch)));
-
             await SendAsync(client, eventBatch, correlationInfo, logger, sendEventOptions: null, configureOptions, cancellationToken);
         }
 
@@ -340,13 +305,6 @@ namespace Azure.Messaging.EventHubs.Producer
             SendEventOptions sendEventOptions,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(client, nameof(client), "Requires an Azure EventHubs producer client while sending a correlated message");
-            Guard.NotNull(eventBatch, nameof(eventBatch), "Requires a series of Azure EventHubs messages to send as correlated messages");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a message correlation instance to include the transaction ID in the send out messages");
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure EventHubs dependency while sending the correlated messages");
-            Guard.NotAny(eventBatch, nameof(eventBatch), "Requires at least a single message to send to Azure EventHubs");
-            Guard.For(() => eventBatch.Any(message => message is null), new ArgumentException("Requires non-null items in Azure EventHubs message sequence", nameof(eventBatch)));
-
             await SendAsync(client, eventBatch, correlationInfo, logger, sendEventOptions, configureOptions: null, cancellationToken);
         }
 
@@ -383,7 +341,7 @@ namespace Azure.Messaging.EventHubs.Producer
         ///     that is an unsupported type for serialization.  See the <see cref="EventData.Properties" /> remarks for details.
         /// </exception>
         public static async Task SendAsync(
-            this EventHubProducerClient client, 
+            this EventHubProducerClient client,
             IEnumerable<EventData> eventBatch,
             CorrelationInfo correlationInfo,
             ILogger logger,
@@ -391,12 +349,20 @@ namespace Azure.Messaging.EventHubs.Producer
             Action<EventHubProducerClientMessageCorrelationOptions> configureOptions,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(client, nameof(client), "Requires an Azure EventHubs producer client while sending a correlated message");
-            Guard.NotNull(eventBatch, nameof(eventBatch), "Requires a series of Azure EventHubs messages to send as correlated messages");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a message correlation instance to include the transaction ID in the send out messages");
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure EventHubs dependency while sending the correlated messages");
-            Guard.NotAny(eventBatch, nameof(eventBatch), "Requires at least a single message to send to Azure EventHubs");
-            Guard.For(() => eventBatch.Any(message => message is null), new ArgumentException("Requires non-null items in Azure EventHubs message sequence", nameof(eventBatch)));
+            if (client is null)
+            {
+                throw new ArgumentNullException(nameof(client));
+            }
+
+            if (eventBatch is null)
+            {
+                throw new ArgumentNullException(nameof(eventBatch));
+            }
+
+            if (correlationInfo is null)
+            {
+                throw new ArgumentNullException(nameof(correlationInfo));
+            }
 
             var options = new EventHubProducerClientMessageCorrelationOptions();
             configureOptions?.Invoke(options);

--- a/src/Arcus.Messaging.EventHubs.Core/Extensions/EventHubProducerClientExtensions.cs
+++ b/src/Arcus.Messaging.EventHubs.Core/Extensions/EventHubProducerClientExtensions.cs
@@ -364,6 +364,11 @@ namespace Azure.Messaging.EventHubs.Producer
                 throw new ArgumentNullException(nameof(correlationInfo));
             }
 
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
             var options = new EventHubProducerClientMessageCorrelationOptions();
             configureOptions?.Invoke(options);
 


### PR DESCRIPTION
Remove all calls that use the Guard.NET library in the EventHubs-related projects.

Relates to #449 