### PR TITLE
chore: remove guard.net references from servicebus

### DIFF
--- a/src/Arcus.Messaging.Abstractions.ServiceBus/AzureServiceBusMessageContext.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/AzureServiceBusMessageContext.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using GuardNet;
 using Microsoft.Extensions.Logging;
 
 namespace Arcus.Messaging.Abstractions.ServiceBus
@@ -21,7 +20,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="systemProperties"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
         public AzureServiceBusMessageContext(
-            string messageId, 
+            string messageId,
             string jobId,
             AzureServiceBusSystemProperties systemProperties,
             IReadOnlyDictionary<string, object> properties)
@@ -45,12 +44,12 @@ namespace Arcus.Messaging.Abstractions.ServiceBus
             AzureServiceBusSystemProperties systemProperties,
             IReadOnlyDictionary<string, object> properties,
             ServiceBusEntityType entityType)
-            : base(messageId, jobId, properties.ToDictionary(item => item.Key, item => item.Value))
+            : base(messageId, jobId, properties?.ToDictionary(item => item.Key, item => item.Value) ?? throw new ArgumentNullException(nameof(properties)))
         {
-            Guard.NotNullOrWhitespace(messageId, nameof(messageId), "Requires an ID to identify the message");
-            Guard.NotNullOrWhitespace(jobId, nameof(jobId), "Requires an job ID that is not blank to identify the message pump");
-            Guard.NotNull(systemProperties, nameof(systemProperties), "Requires a set of system properties provided by the Azure Service Bus runtime");
-            Guard.NotNull(properties, nameof(properties), "Requires contextual properties provided by the message publisher");
+            if (systemProperties is null)
+            {
+                throw new ArgumentNullException(nameof(systemProperties));
+            }
 
             SystemProperties = systemProperties;
             LockToken = systemProperties.LockToken;

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/AzureServiceBusSystemProperties.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/AzureServiceBusSystemProperties.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Azure.Messaging.ServiceBus;
-using GuardNet;
 
 namespace Arcus.Messaging.Abstractions.ServiceBus
 {
@@ -11,8 +10,11 @@ namespace Arcus.Messaging.Abstractions.ServiceBus
     {
         private AzureServiceBusSystemProperties(ServiceBusReceivedMessage message)
         {
-            Guard.NotNull(message, nameof(message), "Requires an Azure Service Bus received message to construct a set of Azure Service Bus system properties");
-            
+            if (message is null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
             DeadLetterSource = message.DeadLetterSource;
             DeliveryCount = message.DeliveryCount;
             EnqueuedSequenceNumber = message.EnqueuedSequenceNumber;
@@ -32,8 +34,6 @@ namespace Arcus.Messaging.Abstractions.ServiceBus
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> is <c>null</c>.</exception>
         public static AzureServiceBusSystemProperties CreateFrom(ServiceBusReceivedMessage message)
         {
-            Guard.NotNull(message, nameof(message), "Requires an Azure Service Bus received message to construct a set of Azure Service Bus system properties");
-
             return new AzureServiceBusSystemProperties(message);
         }
 

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/IServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
-using GuardNet;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 
@@ -21,8 +20,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
         public static ServiceBusMessageHandlerCollection AddServiceBusMessageRouting(this IServiceCollection services)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to register the Azure Service Bus message routing");
-
             return AddServiceBusMessageRouting(services, configureOptions: null);
         }
 
@@ -37,8 +34,6 @@ namespace Microsoft.Extensions.DependencyInjection
             this IServiceCollection services,
             Action<AzureServiceBusMessageRouterOptions> configureOptions)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to register the Azure Service Bus message routing");
-            
             return AddServiceBusMessageRouting(services, serviceProvider =>
             {
                 var options = new AzureServiceBusMessageRouterOptions();
@@ -62,10 +57,7 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<IServiceProvider, TMessageRouter> implementationFactory)
             where TMessageRouter : IAzureServiceBusMessageRouter
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to register the Azure Service Bus message routing");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the Azure Service Bus message router");
-
-           return AddServiceBusMessageRouting(services, (provider, options) => implementationFactory(provider), configureOptions: null);
+            return AddServiceBusMessageRouting(services, (provider, options) => implementationFactory(provider), configureOptions: null);
         }
 
         /// <summary>
@@ -83,8 +75,15 @@ namespace Microsoft.Extensions.DependencyInjection
             Action<AzureServiceBusMessageRouterOptions> configureOptions)
             where TMessageRouter : IAzureServiceBusMessageRouter
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to register the Azure Service Bus message routing");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the Azure Service Bus message router");
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (implementationFactory is null)
+            {
+                throw new ArgumentNullException(nameof(implementationFactory));
+            }
 
             services.TryAddSingleton<IAzureServiceBusMessageRouter>(serviceProvider =>
             {

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/IServiceCollectionExtensions.cs
@@ -57,6 +57,11 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<IServiceProvider, TMessageRouter> implementationFactory)
             where TMessageRouter : IAzureServiceBusMessageRouter
         {
+            if (implementationFactory is null)
+            {
+                throw new ArgumentNullException(nameof(implementationFactory));
+            }
+
             return AddServiceBusMessageRouting(services, (provider, options) => implementationFactory(provider), configureOptions: null);
         }
 

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/Message.ServiceBusMessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/Message.ServiceBusMessageHandlerCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions.ServiceBus;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -27,8 +26,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureServiceBusMessageContext>(messageBodyFilter);
             return handlers;
@@ -51,9 +52,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent handlers");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureServiceBusMessageContext>(messageBodyFilter, implementationFactory);
             return handlers;

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/MessageContext.Message.ServiceBusMessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/MessageContext.Message.ServiceBusMessageHandlerCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions.ServiceBus;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -29,8 +28,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureServiceBusMessageContext>(messageContextFilter, messageBodyFilter);
             return handlers;
@@ -55,12 +56,12 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent handlers");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
-            handlers.WithMessageHandler<TMessageHandler, TMessage, AzureServiceBusMessageContext>(messageContextFilter, messageBodyFilter, implementationFactory);
+            handlers.WithMessageHandler(messageContextFilter, messageBodyFilter, implementationFactory);
             return handlers;
         }
     }

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/MessageContext.MessageSerializer.Message.ServiceBusMessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/MessageContext.MessageSerializer.Message.ServiceBusMessageHandlerCollectionExtensions.cs
@@ -2,7 +2,6 @@
 using Arcus.Messaging.Abstractions.MessageHandling;
 using Arcus.Messaging.Abstractions.ServiceBus;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -32,9 +31,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureServiceBusMessageContext>(messageContextFilter, messageBodySerializer, messageBodyFilter);
             return handlers;
@@ -48,7 +48,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="TMessage">The type of the message that the message handler will process.</typeparam>
         /// <param name="handlers">The collection of handlers to use in the application.</param>
         /// <param name="messageContextFilter">The function that determines if the message handler should handle the message based on the context.</param>
-        /// <param name="messageBodySerializerImplementationFactory">The function to create an custom <see cref="IMessageBodySerializer"/> to deserialize the incoming message for the <see cref="IAzureServiceBusMessageHandler{TMessage}"/>.</param>
+        /// <param name="messageBodySerializerImplementationFactory">The function to create a custom <see cref="IMessageBodySerializer"/> to deserialize the incoming message for the <see cref="IAzureServiceBusMessageHandler{TMessage}"/>.</param>
         /// <param name="messageBodyFilter">The filter to restrict the message processing based on the incoming message body.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="handlers"/>, <paramref name="messageContextFilter"/>, <paramref name="messageBodySerializerImplementationFactory"/>, or <paramref name="messageBodyFilter"/> is <c>null</c>.</exception>
         public static ServiceBusMessageHandlerCollection WithServiceBusMessageHandler<TMessageHandler, TMessage>(
@@ -59,9 +59,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureServiceBusMessageContext>(messageContextFilter, messageBodySerializerImplementationFactory, messageBodyFilter);
             return handlers;
@@ -88,12 +89,12 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
-            handlers.WithMessageHandler<TMessageHandler, TMessage, AzureServiceBusMessageContext>(messageContextFilter, messageBodySerializer, messageBodyFilter, implementationFactory);
+            handlers.WithMessageHandler(messageContextFilter, messageBodySerializer, messageBodyFilter, implementationFactory);
             return handlers;
         }
 
@@ -105,7 +106,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="TMessage">The type of the message that the message handler will process.</typeparam>
         /// <param name="handlers">The collection of handlers to use in the application.</param>
         /// <param name="messageContextFilter">The function that determines if the message handler should handle the message based on the context.</param>
-        /// <param name="messageBodySerializerImplementationFactory">The function to create an custom <see cref="IMessageBodySerializer"/> to deserialize the incoming message for the <see cref="IAzureServiceBusMessageHandler{TMessage}"/>.</param>
+        /// <param name="messageBodySerializerImplementationFactory">The function to create a custom <see cref="IMessageBodySerializer"/> to deserialize the incoming message for the <see cref="IAzureServiceBusMessageHandler{TMessage}"/>.</param>
         /// <param name="messageBodyFilter">The filter to restrict the message processing based on the incoming message body.</param>
         /// <param name="messageHandlerImplementationFactory">The that creates the message handler.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="handlers"/>, <paramref name="messageContextFilter"/>, <paramref name="messageBodySerializerImplementationFactory"/>, <paramref name="messageBodyFilter"/>, or <paramref name="messageHandlerImplementationFactory"/> is <c>null</c>.</exception>
@@ -118,12 +119,12 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-            Guard.NotNull(messageHandlerImplementationFactory, nameof(messageHandlerImplementationFactory), "Requires a function to create the message handler");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
-            handlers.WithMessageHandler<TMessageHandler, TMessage, AzureServiceBusMessageContext>(messageContextFilter, messageBodySerializerImplementationFactory, messageBodyFilter, messageHandlerImplementationFactory);
+            handlers.WithMessageHandler(messageContextFilter, messageBodySerializerImplementationFactory, messageBodyFilter, messageHandlerImplementationFactory);
             return handlers;
         }
     }

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/MessageContext.MessageSerializer.ServiceBusMessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/MessageContext.MessageSerializer.ServiceBusMessageHandlerCollectionExtensions.cs
@@ -2,7 +2,6 @@
 using Arcus.Messaging.Abstractions.MessageHandling;
 using Arcus.Messaging.Abstractions.ServiceBus;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -30,9 +29,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureServiceBusMessageContext>(messageContextFilter, messageBodySerializer);
             return handlers;
@@ -55,9 +55,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create an custom message body serializer instance to deserialize incoming message for the message handler");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureServiceBusMessageContext>(messageContextFilter, messageBodySerializerImplementationFactory);
             return handlers;
@@ -82,10 +83,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureServiceBusMessageContext>(messageContextFilter, messageBodySerializer, implementationFactory);
             return handlers;
@@ -110,10 +111,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageHandlerImplementationFactory, nameof(messageHandlerImplementationFactory), "Requires a function to create the message handler");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureServiceBusMessageContext>(messageContextFilter, messageBodySerializerImplementationFactory, messageHandlerImplementationFactory);
             return handlers;

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/MessageContext.ServiceBusMessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/MessageContext.ServiceBusMessageHandlerCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions.ServiceBus;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -27,8 +26,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureServiceBusMessageContext>(
                 messageContextFilter, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
@@ -53,9 +54,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageContextFilter,  nameof(messageContextFilter), "Requires a filter to restrict the message processing within a certain message context");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent handlers");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureServiceBusMessageContext>(messageContextFilter, implementationFactory);
             return handlers;

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/MessageSerializer.Message.ServiceBusMessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/MessageSerializer.Message.ServiceBusMessageHandlerCollectionExtensions.cs
@@ -2,7 +2,6 @@
 using Arcus.Messaging.Abstractions.MessageHandling;
 using Arcus.Messaging.Abstractions.ServiceBus;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -30,9 +29,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureServiceBusMessageContext>(messageBodySerializer, messageBodyFilter);
             return handlers;
@@ -57,10 +57,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent handlers");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureServiceBusMessageContext>(messageBodySerializer, messageBodyFilter, implementationFactory);
             return handlers;
@@ -83,9 +83,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create the custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureServiceBusMessageContext>(messageBodySerializerImplementationFactory, messageBodyFilter);
             return handlers;
@@ -110,10 +111,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create the custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageBodyFilter, nameof(messageBodyFilter), "Requires a filter to restrict the message processing based on the incoming message body");
-            Guard.NotNull(messageHandlerImplementationFactory, nameof(messageHandlerImplementationFactory), "Requires a function to create the message handler with dependent handlers");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureServiceBusMessageContext>(messageBodySerializerImplementationFactory, messageBodyFilter, messageHandlerImplementationFactory);
             return handlers;

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/MessageSerializer.ServiceBusMessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/MessageSerializer.ServiceBusMessageHandlerCollectionExtensions.cs
@@ -2,7 +2,6 @@
 using Arcus.Messaging.Abstractions.MessageHandling;
 using Arcus.Messaging.Abstractions.ServiceBus;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -28,8 +27,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureServiceBusMessageContext>(messageBodySerializer);
             return handlers;
@@ -50,8 +51,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create the custom message body serializer instance to deserialize incoming message for the message handler");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureServiceBusMessageContext>(messageBodySerializerImplementationFactory);
             return handlers;
@@ -74,9 +77,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodySerializer, nameof(messageBodySerializer), "Requires an custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureServiceBusMessageContext>(messageBodySerializer, implementationFactory);
             return handlers;
@@ -99,9 +103,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(messageBodySerializerImplementationFactory, nameof(messageBodySerializerImplementationFactory), "Requires a function to create the custom message body serializer instance to deserialize incoming message for the message handler");
-            Guard.NotNull(messageHandlerImplementationFactory, nameof(messageHandlerImplementationFactory), "Requires a function to create the message handler");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureServiceBusMessageContext>(messageBodySerializerImplementationFactory, messageHandlerImplementationFactory);
             return handlers;

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/ProcessMessageEventArgsExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/ProcessMessageEventArgsExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Reflection;
 using Arcus.Messaging.Abstractions.MessageHandling;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Azure.Messaging.ServiceBus
@@ -22,7 +21,10 @@ namespace Azure.Messaging.ServiceBus
         [Obsolete("Service Bus receiver is used internally instead, no need to go via the processor")]
         public static ServiceBusReceiver GetServiceBusReceiver(this ProcessMessageEventArgs args)
         {
-            Guard.NotNull(args, nameof(args), "Requires an event args instance to retrieve the original Service Bus message receiver");
+            if (args is null)
+            {
+                throw new ArgumentNullException(nameof(args));
+            }
 
             FieldInfo receiverField = args.GetType().GetField("_receiver", BindingFlags.Instance | BindingFlags.NonPublic);
             if (receiverField is null)

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/ServiceBusMessageHandlerExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/ServiceBusMessageHandlerExtensions.cs
@@ -2,7 +2,6 @@
 using Arcus.Messaging.Abstractions.ServiceBus;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 using Azure.Messaging.ServiceBus;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -25,7 +24,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureServiceBusMessageContext>();
             return handlers;
@@ -46,8 +48,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
             where TMessage : class
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a set of handlers to add the message handler");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the message handler with dependent handlers");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithMessageHandler<TMessageHandler, TMessage, AzureServiceBusMessageContext>(implementationFactory);
             return handlers;
@@ -63,7 +67,10 @@ namespace Microsoft.Extensions.DependencyInjection
             this ServiceBusMessageHandlerCollection handlers)
             where TMessageHandler : IAzureServiceBusFallbackMessageHandler
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a handlers collection to add the Azure Service Bus fallback message handler to");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.WithServiceBusFallbackMessageHandler(serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
             return handlers;
@@ -81,8 +88,10 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<IServiceProvider, TMessageHandler> createImplementation)
             where TMessageHandler : IAzureServiceBusFallbackMessageHandler
         {
-            Guard.NotNull(handlers, nameof(handlers), "Requires a handlers collection to add the fallback message handler to");
-            Guard.NotNull(createImplementation, nameof(createImplementation), "Requires a function to create the fallback message handler");
+            if (handlers is null)
+            {
+                throw new ArgumentNullException(nameof(handlers));
+            }
 
             handlers.AddFallbackMessageHandler<TMessageHandler, ServiceBusReceivedMessage, AzureServiceBusMessageContext>(createImplementation);
             return handlers;

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/ServiceBusReceivedMessageExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/ServiceBusReceivedMessageExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions.ServiceBus;
-using GuardNet;
 using Microsoft.Extensions.Logging;
 
 // ReSharper disable once CheckNamespace
@@ -18,7 +17,10 @@ namespace Azure.Messaging.ServiceBus
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> is <c>null</c>.</exception>
         public static AzureServiceBusSystemProperties GetSystemProperties(this ServiceBusReceivedMessage message)
         {
-            Guard.NotNull(message, nameof(message), "Requires an Azure Service Bus received message to construct a set of Azure Service Bus system properties");
+            if (message is null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
 
             return AzureServiceBusSystemProperties.CreateFrom(message);
         }
@@ -32,9 +34,11 @@ namespace Azure.Messaging.ServiceBus
         /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
         public static AzureServiceBusMessageContext GetMessageContext(this ServiceBusReceivedMessage message, string jobId)
         {
-            Guard.NotNull(message, nameof(message), "Requires an Azure Service Bus received message to construct an Azure Service Bus messaging context");
-            Guard.NotNullOrWhitespace(jobId, nameof(jobId), "Requires an job ID that is not blank to identify the messaging job, pump or router");
-            
+            if (message is null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
             return message.GetMessageContext(jobId, ServiceBusEntityType.Unknown);
         }
 
@@ -48,9 +52,11 @@ namespace Azure.Messaging.ServiceBus
         /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
         public static AzureServiceBusMessageContext GetMessageContext(this ServiceBusReceivedMessage message, string jobId, ServiceBusEntityType entityType)
         {
-            Guard.NotNull(message, nameof(message), "Requires an Azure Service Bus received message to construct an Azure Service Bus messaging context");
-            Guard.NotNullOrWhitespace(jobId, nameof(jobId), "Requires an job ID that is not blank to identify the messaging job, pump or router");
-            
+            if (message is null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
             return new AzureServiceBusMessageContext(message.MessageId, jobId, message.GetSystemProperties(), message.ApplicationProperties, entityType);
         }
     }

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusFallbackMessageHandler.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
-using GuardNet;
 using Microsoft.Extensions.Logging;
 
 namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
@@ -45,14 +44,17 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         /// <exception cref="InvalidOperationException">Thrown when the message handler was not initialized yet.</exception>
         protected async Task CompleteMessageAsync(ServiceBusReceivedMessage message)
         {
-            Guard.NotNull(message, nameof(message), "Requires a message to be completed");
+            if (message is null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
 
             if (EventArgs is null)
             {
                 throw new InvalidOperationException(
                     "Cannot complete the Azure Service Bus message because the message handler running Azure Service Bus-specific operations was not yet initialized correctly");
             }
-            
+
             Logger.LogTrace("Completing message '{MessageId}'...", message.MessageId);
             await EventArgs.CompleteMessageAsync(message, EventArgs.CancellationToken);
             Logger.LogTrace("Message '{MessageId}' is completed!", message.MessageId);
@@ -68,7 +70,10 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         /// <exception cref="InvalidOperationException">Thrown when the message handler was not initialized yet.</exception>
         protected async Task DeadLetterMessageAsync(ServiceBusReceivedMessage message, IDictionary<string, object> newMessageProperties = null)
         {
-            Guard.NotNull(message, nameof(message), "Requires a message to be dead lettered");
+            if (message is null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
 
             if (EventArgs is null)
             {
@@ -92,8 +97,15 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         /// <exception cref="InvalidOperationException">Thrown when the message handler was not initialized yet.</exception>
         protected async Task DeadLetterMessageAsync(ServiceBusReceivedMessage message, string deadLetterReason, string deadLetterErrorDescription = null)
         {
-            Guard.NotNull(message, nameof(message), "Requires a message to be dead lettered");
-            Guard.NotNullOrWhitespace(deadLetterReason, nameof(deadLetterReason), "Requires a non-blank dead letter reason for the message");
+            if (message is null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            if (string.IsNullOrWhiteSpace(deadLetterReason))
+            {
+                throw new ArgumentException("Requires a non-blank dead letter reason for the message", nameof(deadLetterReason));
+            }
 
             if (EventArgs is null)
             {
@@ -103,7 +115,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
 
             Logger.LogTrace("Dead-lettering message '{MessageId}' because '{Reason}'...", message.MessageId, deadLetterReason);
             await EventArgs.DeadLetterMessageAsync(message, deadLetterReason, deadLetterErrorDescription, EventArgs.CancellationToken);
-            Logger.LogTrace("Message '{MessageId}' is dead-lettered because '{Reason}'!", message.MessageId,  deadLetterReason);
+            Logger.LogTrace("Message '{MessageId}' is dead-lettered because '{Reason}'!", message.MessageId, deadLetterReason);
         }
 
         /// <summary>
@@ -121,7 +133,10 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         /// <exception cref="InvalidOperationException">Thrown when the message handler was not initialized yet.</exception>
         protected async Task AbandonMessageAsync(ServiceBusReceivedMessage message, IDictionary<string, object> newMessageProperties = null)
         {
-            Guard.NotNull(message, nameof(message), "Requires a message to be abandoned");
+            if (message is null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
 
             if (EventArgs is null)
             {

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageHandler.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageHandler.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using GuardNet;
 using Microsoft.Extensions.Logging;
 
 namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
@@ -78,7 +77,10 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         /// <exception cref="InvalidOperationException">Thrown when the message handler was not initialized yet.</exception>
         protected async Task DeadLetterMessageAsync(string deadLetterReason, string deadLetterErrorDescription = null)
         {
-            Guard.NotNullOrWhitespace(deadLetterReason, nameof(deadLetterReason), "Requires a non-blank dead letter reason for the message");
+            if (string.IsNullOrWhiteSpace(deadLetterReason))
+            {
+                throw new ArgumentException("Requires a non-blank dead letter reason for the message", nameof(deadLetterReason));
+            }
 
             if (EventArgs is null)
             {

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageHandlerTemplate.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageHandlerTemplate.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Azure.Messaging.ServiceBus;
-using GuardNet;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -24,7 +23,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         /// Gets the current event args of the received Azure Service Bus message to run message-specific operations.
         /// </summary>
         internal ProcessMessageEventArgs EventArgs { get; private set; }
-        
+
         /// <summary>
         /// Gets the logger to write diagnostic messages during the handling of the message.
         /// </summary>
@@ -38,8 +37,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="args"/> is <c>null</c>.</exception>
         internal void SetProcessMessageEventArgs(ProcessMessageEventArgs args)
         {
-            Guard.NotNull(args, nameof(args), "Requires a messaging event args instance to run Azure Service Bus message-specific operations during the message handling");
-            EventArgs = args;
+            EventArgs = args ?? throw new ArgumentNullException(nameof(args));
         }
     }
 }

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
@@ -7,7 +7,6 @@ using Arcus.Messaging.Abstractions.MessageHandling;
 using Arcus.Messaging.Abstractions.Telemetry;
 using Arcus.Observability.Telemetry.Core;
 using Azure.Messaging.ServiceBus;
-using GuardNet;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -32,7 +31,6 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         public AzureServiceBusMessageRouter(IServiceProvider serviceProvider, AzureServiceBusMessageRouterOptions options, ILogger<AzureServiceBusMessageRouter> logger)
             : this(serviceProvider, options, (ILogger) logger)
         {
-            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires an service provider to retrieve the registered message handlers");
         }
 
         /// <summary>
@@ -44,7 +42,6 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         public AzureServiceBusMessageRouter(IServiceProvider serviceProvider, AzureServiceBusMessageRouterOptions options)
             : this(serviceProvider, options, NullLogger.Instance)
         {
-            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires an service provider to retrieve the registered message handlers");
         }
 
         /// <summary>
@@ -56,7 +53,6 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         public AzureServiceBusMessageRouter(IServiceProvider serviceProvider, ILogger<AzureServiceBusMessageRouter> logger)
             : this(serviceProvider, new AzureServiceBusMessageRouterOptions(), (ILogger) logger)
         {
-            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires an service provider to retrieve the registered message handlers");
         }
 
         /// <summary>
@@ -67,7 +63,6 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         public AzureServiceBusMessageRouter(IServiceProvider serviceProvider)
             : this(serviceProvider, new AzureServiceBusMessageRouterOptions(), NullLogger.Instance)
         {
-            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires an service provider to retrieve the registered message handlers");
         }
 
         /// <summary>
@@ -79,7 +74,6 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         protected AzureServiceBusMessageRouter(IServiceProvider serviceProvider, ILogger logger)
             : this(serviceProvider, new AzureServiceBusMessageRouterOptions(), logger)
         {
-            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires an service provider to retrieve the registered message handlers");
         }
 
         /// <summary>
@@ -92,8 +86,6 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         protected AzureServiceBusMessageRouter(IServiceProvider serviceProvider, AzureServiceBusMessageRouterOptions options, ILogger logger)
             : base(serviceProvider, options, logger ?? NullLogger<AzureServiceBusMessageRouter>.Instance)
         {
-            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires an service provider to retrieve the registered message handlers");
-
             ServiceBusOptions = options;
         }
 
@@ -165,10 +157,6 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
             MessageCorrelationInfo correlationInfo,
             CancellationToken cancellationToken)
         {
-            Guard.NotNull(message, nameof(message), "Requires an Azure Service Bus message to be processed by the registered message handlers");
-            Guard.NotNull(messageContext, nameof(messageContext), "Requires an Azure Service Bus message context in which the incoming message can be processed");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires an correlation information to correlate between incoming Azure Service Bus messages");
-
             return await RouteMessageWithPotentialFallbackAsync(
                 messageReceiver: null,
                 message: message,
@@ -201,11 +189,6 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
             MessageCorrelationInfo correlationInfo,
             CancellationToken cancellationToken)
         {
-            Guard.NotNull(messageReceiver, nameof(messageReceiver), "Requires an Azure Service Bus message receiver while processing the message, so message handlers can call Azure Service Bus specific operations");
-            Guard.NotNull(message, nameof(message), "Requires an Azure Service Bus message to be processed by the registered message handlers");
-            Guard.NotNull(messageContext, nameof(messageContext), "Requires an Azure Service Bus message context in which the incoming message can be processed");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires an correlation information to correlate between incoming Azure Service Bus messages");
-
             return await RouteMessageWithPotentialFallbackAsync(messageReceiver, message, messageContext, correlationInfo, cancellationToken);
         }
 
@@ -233,9 +216,20 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
             MessageCorrelationInfo correlationInfo,
             CancellationToken cancellationToken)
         {
-            Guard.NotNull(message, nameof(message), "Requires an Azure Service Bus message to be processed by the registered message handlers");
-            Guard.NotNull(messageContext, nameof(messageContext), "Requires an Azure Service Bus message context in which the incoming message can be processed");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires an correlation information to correlate between incoming Azure Service Bus messages");
+            if (message is null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            if (messageContext is null)
+            {
+                throw new ArgumentNullException(nameof(messageContext));
+            }
+
+            if (correlationInfo is null)
+            {
+                throw new ArgumentNullException(nameof(correlationInfo));
+            }
 
             string entityName = messageReceiver?.EntityPath ?? "<not-available>";
             string serviceBusNamespace = messageReceiver?.FullyQualifiedNamespace ?? "<not-available>";
@@ -381,8 +375,15 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
             ProcessMessageEventArgs eventArgs,
             AzureServiceBusMessageContext messageContext)
         {
-            Guard.NotNull(messageHandler, nameof(messageHandler), "Requires an Azure Service Bus message handler to set the specific Service Bus properties");
-            Guard.NotNull(messageContext, nameof(messageContext), "Requires an Azure Service Bus message context in which the incoming message can be processed");
+            if (messageHandler is null)
+            {
+                throw new ArgumentNullException(nameof(messageHandler));
+            }
+
+            if (messageContext is null)
+            {
+                throw new ArgumentNullException(nameof(messageContext));
+            }
 
             object messageHandlerInstance = messageHandler.GetMessageHandlerInstance();
             Type messageHandlerType = messageHandlerInstance.GetType();
@@ -420,9 +421,20 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
             MessageCorrelationInfo correlationInfo,
             CancellationToken cancellationToken)
         {
-            Guard.NotNull(message, nameof(message), "Requires an Azure Service Bus message to be processed by the registered fallback message handler");
-            Guard.NotNull(messageContext, nameof(messageContext), "Requires an Azure Service Bus message context in which the incoming message can be processed");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires an correlation information to correlate between incoming Azure Service Bus messages");
+            if (message is null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            if (messageContext is null)
+            {
+                throw new ArgumentNullException(nameof(messageContext));
+            }
+
+            if (correlationInfo is null)
+            {
+                throw new ArgumentNullException(nameof(correlationInfo));
+            }
 
             ServiceBusFallbackMessageHandler[] fallbackHandlers =
                 GetAvailableFallbackMessageHandlersByContext<ServiceBusReceivedMessage, AzureServiceBusMessageContext>(messageContext);

--- a/src/Arcus.Messaging.AzureFunctions.ServiceBus/AzureFunctionsInProcessMessageCorrelation.cs
+++ b/src/Arcus.Messaging.AzureFunctions.ServiceBus/AzureFunctionsInProcessMessageCorrelation.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions;
 using Azure.Messaging.ServiceBus;
-using GuardNet;
 using Microsoft.ApplicationInsights;
 
 namespace Arcus.Messaging.AzureFunctions.ServiceBus
@@ -20,8 +19,7 @@ namespace Arcus.Messaging.AzureFunctions.ServiceBus
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="client"/> is <c>null</c>.</exception>
         public AzureFunctionsInProcessMessageCorrelation(TelemetryClient client)
         {
-            Guard.NotNull(client, nameof(client), "Requires a Microsoft telemetry client to automatically track outgoing built-in Microsoft dependencies");
-            _telemetryClient = client;
+            _telemetryClient = client ?? throw new ArgumentNullException(nameof(client));
         }
 
         /// <summary>
@@ -32,7 +30,10 @@ namespace Arcus.Messaging.AzureFunctions.ServiceBus
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> is <c>null</c>.</exception>
         public MessageCorrelationResult CorrelateMessage(ServiceBusReceivedMessage message)
         {
-            Guard.NotNull(message, nameof(message), "Requires an incoming Azure Service Bus message to W3C correlate the message");
+            if (message is null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
 
             (string transactionId, string operationParentId) = message.ApplicationProperties.GetTraceParent();
             return MessageCorrelationResult.Create(_telemetryClient, transactionId, operationParentId);

--- a/src/Arcus.Messaging.AzureFunctions.ServiceBus/AzureFunctionsMessageCorrelation.cs
+++ b/src/Arcus.Messaging.AzureFunctions.ServiceBus/AzureFunctionsMessageCorrelation.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions;
 using Azure.Messaging.ServiceBus;
-using GuardNet;
 using Microsoft.ApplicationInsights;
 
 namespace Arcus.Messaging.AzureFunctions.ServiceBus
@@ -20,8 +19,7 @@ namespace Arcus.Messaging.AzureFunctions.ServiceBus
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="client"/> is <c>null</c>.</exception>
         public AzureFunctionsMessageCorrelation(TelemetryClient client)
         {
-            Guard.NotNull(client, nameof(client), "Requires a Microsoft telemetry client to automatically track outgoing built-in Microsoft dependencies");
-            _telemetryClient = client;
+            _telemetryClient = client ?? throw new ArgumentNullException(nameof(client));
         }
 
         /// <summary>
@@ -32,7 +30,10 @@ namespace Arcus.Messaging.AzureFunctions.ServiceBus
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> is <c>null</c>.</exception>
         public MessageCorrelationResult CorrelateMessage(ServiceBusReceivedMessage message)
         {
-            Guard.NotNull(message, nameof(message), "Requires an incoming Azure Service Bus message to W3C correlate the message");
+            if (message is null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
 
             (string transactionId, string operationParentId) = message.ApplicationProperties.GetTraceParent();
             return MessageCorrelationResult.Create(_telemetryClient, transactionId, operationParentId);

--- a/src/Arcus.Messaging.AzureFunctions.ServiceBus/Extensions/IFunctionsHostBuilderExtensions.cs
+++ b/src/Arcus.Messaging.AzureFunctions.ServiceBus/Extensions/IFunctionsHostBuilderExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 using Arcus.Messaging.AzureFunctions.ServiceBus;
-using GuardNet;
 using Microsoft.Extensions.DependencyInjection;
 
 // ReSharper disable once CheckNamespace
@@ -20,8 +19,6 @@ namespace Microsoft.Azure.Functions.Extensions.DependencyInjection
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="builder"/> is <c>null</c>.</exception>
         public static ServiceBusMessageHandlerCollection AddServiceBusMessageRouting(this IFunctionsHostBuilder builder)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a set of builder to register the Azure Service Bus message routing");
-
             return AddServiceBusMessageRouting(builder, configureOptions: null);
         }
 
@@ -35,7 +32,10 @@ namespace Microsoft.Azure.Functions.Extensions.DependencyInjection
             this IFunctionsHostBuilder builder,
             Action<AzureServiceBusMessageRouterOptions> configureOptions)
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a set of builder to register the Azure Service Bus message routing");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
 
             return builder.Services.AddSingleton<AzureFunctionsInProcessMessageCorrelation>()
                                    .AddServiceBusMessageRouting(configureOptions);
@@ -53,9 +53,6 @@ namespace Microsoft.Azure.Functions.Extensions.DependencyInjection
             Func<IServiceProvider, TMessageRouter> implementationFactory)
             where TMessageRouter : IAzureServiceBusMessageRouter
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a set of builder to register the Azure Service Bus message routing");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the Azure Service Bus message router");
-
             return AddServiceBusMessageRouting(builder, (provider, options) => implementationFactory(provider), configureOptions: null);
         }
 
@@ -73,8 +70,10 @@ namespace Microsoft.Azure.Functions.Extensions.DependencyInjection
             Action<AzureServiceBusMessageRouterOptions> configureOptions)
             where TMessageRouter : IAzureServiceBusMessageRouter
         {
-            Guard.NotNull(builder, nameof(builder), "Requires a set of builder to register the Azure Service Bus message routing");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a function to create the Azure Service Bus message router");
+            if (builder is null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
 
             return builder.Services.AddSingleton<AzureFunctionsInProcessMessageCorrelation>()
                                    .AddServiceBusMessageRouting(implementationFactory, configureOptions);

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Arcus.Messaging.Pumps.ServiceBus.csproj
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Arcus.Messaging.Pumps.ServiceBus.csproj
@@ -29,7 +29,6 @@
   <ItemGroup>
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="[2.0.0,3.0.0)" />
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
-    <PackageReference Include="Guard.NET" Version="3.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="2.1.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.0" />
   </ItemGroup>

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusNamespace.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusNamespace.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using GuardNet;
 using Microsoft.Extensions.Logging;
 
 namespace Arcus.Messaging.Pumps.ServiceBus
@@ -24,20 +23,35 @@ namespace Arcus.Messaging.Pumps.ServiceBus
         public AzureServiceBusNamespace(
             string resourceGroup,
             string @namespace,
-            ServiceBusEntityType entity, 
+            ServiceBusEntityType entity,
             string entityName,
             string authorizationRuleName)
         {
-            Guard.NotNullOrWhitespace(resourceGroup, nameof(resourceGroup));
-            Guard.NotNullOrWhitespace(@namespace, nameof(@namespace));
-            Guard.NotNullOrWhitespace(entityName, nameof(entityName));
-            Guard.NotNullOrWhitespace(authorizationRuleName, nameof(authorizationRuleName));
-            Guard.For<ArgumentException>(
-                () => !Enum.IsDefined(typeof(ServiceBusEntityType), entity), 
-                $"Azure Service Bus entity '{entity}' is not defined in the '{nameof(ServiceBusEntityType)}' enumeration");
-            Guard.For<ArgumentOutOfRangeException>(
-                () => entity is ServiceBusEntityType.Unknown, "Azure Service Bus entity type 'Unknown' is not supported here");
-            
+            if (string.IsNullOrWhiteSpace(resourceGroup))
+            {
+                throw new ArgumentException("Requires a non-blank resource group name", nameof(resourceGroup));
+            }
+
+            if (string.IsNullOrWhiteSpace(@namespace))
+            {
+                throw new ArgumentException("Requires a non-blank namespace", nameof(@namespace));
+            }
+
+            if (string.IsNullOrWhiteSpace(entityName))
+            {
+                throw new ArgumentException("Requires a non-blank Azure Service bus entity name", nameof(entityName));
+            }
+
+            if (string.IsNullOrWhiteSpace(authorizationRuleName))
+            {
+                throw new ArgumentException("Requires a non-blank authorization rule name", nameof(authorizationRuleName));
+            }
+
+            if (!Enum.IsDefined(entity) || entity is ServiceBusEntityType.Unknown)
+            {
+                throw new ArgumentException($"Requires either a '{ServiceBusEntityType.Topic}' or '{ServiceBusEntityType.Queue}' as Azure Service bus entity type", nameof(entity));
+            }
+
             ResourceGroup = resourceGroup;
             Namespace = @namespace;
             Entity = entity;
@@ -59,7 +73,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
         /// Gets the entity type of the Azure Service Bus resource.
         /// </summary>
         public ServiceBusEntityType Entity { get; }
-        
+
         /// <summary>
         /// Gets the entity name of the Azure Service Bus resource.
         /// </summary>

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusNamespace.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusNamespace.cs
@@ -47,7 +47,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
                 throw new ArgumentException("Requires a non-blank authorization rule name", nameof(authorizationRuleName));
             }
 
-            if (!Enum.IsDefined(entity) || entity is ServiceBusEntityType.Unknown)
+            if (!Enum.IsDefined(typeof(ServiceBusEntityType), entity) || entity is ServiceBusEntityType.Unknown)
             {
                 throw new ArgumentException($"Requires either a '{ServiceBusEntityType.Topic}' or '{ServiceBusEntityType.Queue}' as Azure Service bus entity type", nameof(entity));
             }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusCorrelationOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusCorrelationOptions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.MessageHandling;
-using GuardNet;
 
 namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
 {
@@ -13,7 +12,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
     public class AzureServiceBusCorrelationOptions
     {
         private readonly MessageCorrelationOptions _correlationOptions;
-        
+
         private string _transactionIdPropertyName = PropertyNames.TransactionId,
                        _operationParentIdPropertyName = PropertyNames.OperationParentId;
 
@@ -50,7 +49,11 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
             get => _transactionIdPropertyName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Transaction ID message property name for the Azure Service Bus message cannot be blank");
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentException("Transaction ID message property name for the Azure Service Bus message cannot be blank", nameof(value));
+                }
+
                 _transactionIdPropertyName = value;
                 _correlationOptions.TransactionIdPropertyName = value;
             }
@@ -65,7 +68,11 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
             get => _operationParentIdPropertyName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Operation parent ID message property name for the Azure Service Bus message cannot be blank");
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentException("Operation parent ID message property name for the Azure Service Bus message cannot be blank", nameof(value));
+                }
+
                 _operationParentIdPropertyName = value;
                 _correlationOptions.OperationParentIdPropertyName = value;
             }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
-using GuardNet;
 
 namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
 {
@@ -42,7 +41,10 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
             get => _maxConcurrentCalls;
             set
             {
-                Guard.For<ArgumentException>(() => value <= 0, "Max concurrent calls has to be 1 or above.");
+                if (value <= 0)
+                {
+                    throw new ArgumentException("Max concurrent calls has to be 1 or above", nameof(value));
+                }
 
                 _maxConcurrentCalls = value;
             }
@@ -60,7 +62,11 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
             get => _prefetchCount;
             set
             {
-                Guard.For<ArgumentException>(() => value < 0, "PrefetchCount has to be 0 or above.");
+                if (value < 0)
+                {
+                    throw new ArgumentException("PrefetchCount has to be 0 or above", nameof(value));
+                }
+
                 _prefetchCount = value;
             }
         }
@@ -85,7 +91,11 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
             get => _jobId;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank job identifier for the Azure Service Bus message pump");
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentException("Requires a non-blank job identifier for the Azure Service Bus message pump", nameof(value));
+                }
+
                 _jobId = value;
             }
         }
@@ -99,7 +109,11 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
             get => _keyRotationTimeout;
             set
             {
-                Guard.NotLessThan(value, TimeSpan.Zero, nameof(value), "Key rotation timeout cannot be less than a zero time range");
+                if (value < TimeSpan.Zero)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), value, "Key rotation timeout cannot be less than a zero time range");
+                }
+
                 _keyRotationTimeout = value;
             }
         }
@@ -114,7 +128,11 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
             get => _maximumUnauthorizedExceptionsBeforeRestart;
             set
             {
-                Guard.NotLessThan(value, 0, nameof(value), "Requires an unauthorized exceptions count that's greater than zero");
+                if (value < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), value, "Requires an unauthorized exceptions count that's greater than zero");
+                }
+
                 _maximumUnauthorizedExceptionsBeforeRestart = value;
             }
         }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpSettings.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpSettings.cs
@@ -6,7 +6,6 @@ using Arcus.Security.Core.Caching;
 using Azure.Core;
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
-using GuardNet;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -48,25 +47,36 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
             AzureServiceBusMessagePumpOptions options,
             IServiceProvider serviceProvider)
         {
-            Guard.For<ArgumentException>(
-                () => getConnectionStringFromConfigurationFunc is null && getConnectionStringFromSecretFunc is null,
-                $"Requires an function that determines the connection string from either either an {nameof(IConfiguration)} or {nameof(ISecretProvider)} instance");
-            Guard.NotNull(options, nameof(options), "Requires message pump options that influence the behavior of the message pump");
-            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires a service provider to get additional registered services during the lifetime of the message pump");
-            Guard.For<ArgumentException>(
-                () => !Enum.IsDefined(typeof(ServiceBusEntityType), serviceBusEntity),
-                $"Azure Service Bus entity '{serviceBusEntity}' is not defined in the '{nameof(ServiceBusEntityType)}' enumeration");
-            Guard.For<ArgumentOutOfRangeException>(
-                () => serviceBusEntity is ServiceBusEntityType.Unknown, "Azure Service Bus entity type 'Unknown' is not supported here");
+            if (string.IsNullOrWhiteSpace(entityName))
+            {
+                throw new ArgumentException("Requires a non-blank Azure Service bus entity name", nameof(entityName));
+            }
 
-            _serviceProvider = serviceProvider;
+            if (serviceBusEntity is ServiceBusEntityType.Topic && string.IsNullOrWhiteSpace(subscriptionName))
+            {
+                throw new ArgumentException("Requires a non-blank Azure Service bus topic subscription name", nameof(subscriptionName));
+            }
+
+            if (getConnectionStringFromConfigurationFunc is null && getConnectionStringFromSecretFunc is null)
+            {
+                throw new ArgumentException(
+                    $"Requires an function that determines the connection string from either either an {nameof(IConfiguration)} or {nameof(ISecretProvider)} instance");
+            }
+
+            if (!Enum.IsDefined(typeof(ServiceBusEntityType), serviceBusEntity) || serviceBusEntity is ServiceBusEntityType.Unknown)
+            {
+                throw new ArgumentException(
+                    $"Azure Service Bus entity type should either be '{ServiceBusEntityType.Queue}' or '{ServiceBusEntityType.Topic}'", nameof(serviceBusEntity));
+            }
+
+            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
             _getConnectionStringFromConfigurationFunc = getConnectionStringFromConfigurationFunc;
             _getConnectionStringFromSecretFunc = getConnectionStringFromSecretFunc;
 
             EntityName = entityName;
             SubscriptionName = subscriptionName;
             ServiceBusEntity = serviceBusEntity;
-            Options = options;
+            Options = options ?? throw new ArgumentNullException(nameof(options));
         }
 
         /// <summary>
@@ -99,23 +109,34 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
             AzureServiceBusMessagePumpOptions options,
             IServiceProvider serviceProvider)
         {
-            Guard.NotNull(options, nameof(options), "Requires message pump options that influence the behavior of the message pump");
-            Guard.NotNull(serviceProvider, nameof(serviceProvider), "Requires a service provider to get additional registered services during the lifetime of the message pump");
-            Guard.NotNull(tokenCredential, nameof(tokenCredential), "Requires a token credential instance to authenticate with the Azure Service Bus");
-            Guard.NotNullOrWhitespace(entityName, nameof(entityName), "Requires a non-blank entity name for the Azure Service Bus when using the token credentials");
-            Guard.NotNullOrWhitespace(serviceBusNamespace, nameof(serviceBusNamespace), "Requires a non-blank fully qualified Azure Service Bus namespace when using the token credentials");
-            Guard.For<ArgumentException>(() => !Enum.IsDefined(typeof(ServiceBusEntityType), serviceBusEntity),
-                $"Azure Service Bus entity '{serviceBusEntity}' is not defined in the '{nameof(ServiceBusEntityType)}' enumeration");
-            Guard.For<ArgumentOutOfRangeException>(() => serviceBusEntity is ServiceBusEntityType.Unknown,
-                "Azure Service Bus entity type 'Unknown' is not supported here");
+            if (string.IsNullOrWhiteSpace(entityName))
+            {
+                throw new ArgumentException("Requires a non-blank Azure Service bus entity name", nameof(entityName));
+            }
 
-            _serviceProvider = serviceProvider;
-            _tokenCredential = tokenCredential;
+            if (serviceBusEntity is ServiceBusEntityType.Topic && string.IsNullOrWhiteSpace(subscriptionName))
+            {
+                throw new ArgumentException("Requires a non-blank Azure Service bus topic subscription name", nameof(subscriptionName));
+            }
+
+            if (!Enum.IsDefined(typeof(ServiceBusEntityType), serviceBusEntity) || serviceBusEntity is ServiceBusEntityType.Unknown)
+            {
+                throw new ArgumentException(
+                    $"Azure Service Bus entity type should either be '{ServiceBusEntityType.Queue}' or '{ServiceBusEntityType.Topic}'", nameof(serviceBusEntity));
+            }
+
+            if (string.IsNullOrWhiteSpace(serviceBusNamespace))
+            {
+                throw new ArgumentException("Requires a non-blank fully qualified Azure Service Bus namespace when using the token credentials", nameof(serviceBusNamespace));
+            }
+
+            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+            _tokenCredential = tokenCredential ?? throw new ArgumentNullException(nameof(tokenCredential));
 
             EntityName = entityName;
             SubscriptionName = subscriptionName;
             ServiceBusEntity = serviceBusEntity;
-            Options = options;
+            Options = options ?? throw new ArgumentNullException(nameof(options));
 
             if (serviceBusNamespace.EndsWith(".servicebus.windows.net"))
             {
@@ -246,17 +267,6 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
             }
 
             return EntityName;
-        }
-
-        private ServiceBusReceiverOptions DetermineMessageReceiverOptions()
-        {
-            var options = new ServiceBusReceiverOptions();
-            if (Options != null)
-            {
-                options.PrefetchCount = Options.PrefetchCount;
-            }
-
-            return options;
         }
 
         private async Task<string> GetConnectionStringAsync()

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpSettings.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpSettings.cs
@@ -47,11 +47,6 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
             AzureServiceBusMessagePumpOptions options,
             IServiceProvider serviceProvider)
         {
-            if (string.IsNullOrWhiteSpace(entityName))
-            {
-                throw new ArgumentException("Requires a non-blank Azure Service bus entity name", nameof(entityName));
-            }
-
             if (serviceBusEntity is ServiceBusEntityType.Topic && string.IsNullOrWhiteSpace(subscriptionName))
             {
                 throw new ArgumentException("Requires a non-blank Azure Service bus topic subscription name", nameof(subscriptionName));

--- a/src/Arcus.Messaging.Pumps.ServiceBus/DefaultAzureServiceBusManagementAuthentication.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/DefaultAzureServiceBusManagementAuthentication.cs
@@ -2,7 +2,6 @@
 using System.Security.Authentication;
 using System.Threading.Tasks;
 using Arcus.Security.Core;
-using GuardNet;
 using Microsoft.Azure.Management.ServiceBus;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.Rest;
@@ -38,11 +37,30 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             string tenantId,
             ISecretProvider secretProvider)
         {
-            Guard.NotNullOrWhitespace(clientId, nameof(clientId), "Requires an client ID with the necessary permissions to rotate Azure Service Bus connection string keys");
-            Guard.NotNullOrWhitespace(clientSecretKey, nameof(clientSecretKey), "Requires an secret name that points to the client secret with the necessary permissions to rotate Azure Service Bus connection string keys");
-            Guard.NotNullOrWhitespace(subscriptionId, nameof(subscriptionId), "Requires an account subscription ID that is in change of managing the Azure Service Bus resource");
-            Guard.NotNullOrWhitespace(tenantId, nameof(tenantId), "Requires an tenant ID where the Azure Service Bus resource is located");
-            Guard.NotNull(secretProvider, nameof(secretProvider), $"Requires an '{nameof(ISecretProvider)}' implementation to retrieve the client secret by requesting the '{nameof(clientSecretKey)}'");
+            if (string.IsNullOrWhiteSpace(clientId))
+            {
+                throw new ArgumentException("Requires an client ID with the necessary permissions to rotate Azure Service Bus connection string keys", nameof(clientId));
+            }
+
+            if (string.IsNullOrWhiteSpace(clientSecretKey))
+            {
+                throw new ArgumentException("Requires an secret name that points to the client secret with the necessary permissions to rotate Azure Service Bus connection string keys", nameof(clientSecretKey));
+            }
+
+            if (string.IsNullOrWhiteSpace(subscriptionId))
+            {
+                throw new ArgumentException("Requires an account subscription ID that is in change of managing the Azure Service Bus resource", nameof(subscriptionId));
+            }
+
+            if (string.IsNullOrWhiteSpace(tenantId))
+            {
+                throw new ArgumentException("Requires an tenant ID where the Azure Service Bus resource is located", nameof(tenantId));
+            }
+
+            if (secretProvider is null)
+            {
+                throw new ArgumentNullException(nameof(secretProvider));
+            }
 
             _secretProvider = secretProvider;
             _clientId = clientId;

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
@@ -6,7 +6,6 @@ using Arcus.Messaging.Pumps.ServiceBus.Configuration;
 using Arcus.Security.Core;
 using Azure.Core;
 using Azure.Identity;
-using GuardNet;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -126,6 +125,11 @@ namespace Microsoft.Extensions.DependencyInjection
             string secretName,
             Action<IAzureServiceBusQueueMessagePumpOptions> configureMessagePump = null)
         {
+            if (string.IsNullOrWhiteSpace(queueName))
+            {
+                throw new ArgumentException("Requires a non-blank Azure Service bus entity name", nameof(queueName));
+            }
+
             if (string.IsNullOrWhiteSpace(secretName))
             {
                 throw new ArgumentException("Requires a non-blank secret name", nameof(secretName));
@@ -161,6 +165,11 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<ISecretProvider, Task<string>> getConnectionStringFromSecretFunc,
             Action<IAzureServiceBusQueueMessagePumpOptions> configureMessagePump = null)
         {
+            if (string.IsNullOrWhiteSpace(queueName))
+            {
+                throw new ArgumentException("Requires a non-blank Azure Service bus entity name", nameof(queueName));
+            }
+
             var collection = AddServiceBusQueueMessagePump(
                 services,
                 entityName: queueName,
@@ -187,6 +196,11 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<IConfiguration, string> getConnectionStringFromConfigurationFunc,
             Action<IAzureServiceBusQueueMessagePumpOptions> configureMessagePump = null)
         {
+            if (string.IsNullOrWhiteSpace(queueName))
+            {
+                throw new ArgumentException("Requires a non-blank Azure Service bus entity name", nameof(queueName));
+            }
+
             var collection = AddServiceBusQueueMessagePump(
                 services,
                 entityName: queueName,
@@ -216,6 +230,11 @@ namespace Microsoft.Extensions.DependencyInjection
             string clientId = null,
             Action<IAzureServiceBusQueueMessagePumpOptions> configureMessagePump = null)
         {
+            if (string.IsNullOrWhiteSpace(queueName))
+            {
+                throw new ArgumentException("Requires a non-blank Azure Service bus entity name", nameof(queueName));
+            }
+
             var collection = AddServiceBusQueueMessagePump(
                 services,
                 entityName: queueName,
@@ -375,10 +394,10 @@ namespace Microsoft.Extensions.DependencyInjection
             string secretName,
             Action<IAzureServiceBusTopicMessagePumpOptions> configureMessagePump = null)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure Service Bus Topic message pump");
-            Guard.NotNullOrWhitespace(topicName, nameof(topicName), "Requires a non-blank Azure Service Bus Topic name");
-            Guard.NotNullOrWhitespace(subscriptionName, nameof(subscriptionName), "Requires a non-blank Azure Service Bus Topic subscription name");
-            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to look up the connection string to authenticate with the Azure Service Bus Topic");
+            if (string.IsNullOrWhiteSpace(topicName))
+            {
+                throw new ArgumentException("Requires a non-blank Azure Service bus entity name", nameof(topicName));
+            }
 
             var collection = AddServiceBusTopicMessagePump(
                 services,
@@ -411,6 +430,11 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<ISecretProvider, Task<string>> getConnectionStringFromSecretFunc,
             Action<IAzureServiceBusTopicMessagePumpOptions> configureMessagePump = null)
         {
+            if (string.IsNullOrWhiteSpace(topicName))
+            {
+                throw new ArgumentException("Requires a non-blank Azure Service bus entity name", nameof(topicName));
+            }
+
             var collection = AddServiceBusTopicMessagePump(
                 services,
                 entityName: topicName,
@@ -440,6 +464,11 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<IConfiguration, string> getConnectionStringFromConfigurationFunc,
             Action<IAzureServiceBusTopicMessagePumpOptions> configureMessagePump = null)
         {
+            if (string.IsNullOrWhiteSpace(topicName))
+            {
+                throw new ArgumentException("Requires a non-blank Azure Service bus entity name", nameof(topicName));
+            }
+
             var collection = AddServiceBusTopicMessagePump(
                 services,
                 entityName: topicName,
@@ -474,6 +503,11 @@ namespace Microsoft.Extensions.DependencyInjection
             string clientId = null,
             Action<IAzureServiceBusTopicMessagePumpOptions> configureMessagePump = null)
         {
+            if (string.IsNullOrWhiteSpace(topicName))
+            {
+                throw new ArgumentException("Requires a non-blank Azure Service bus entity name", nameof(topicName));
+            }
+
             var collection = AddServiceBusTopicMessagePump(
                 services,
                 entityName: topicName,
@@ -616,6 +650,11 @@ namespace Microsoft.Extensions.DependencyInjection
             string secretName,
             Action<IAzureServiceBusTopicMessagePumpOptions> configureMessagePump = null)
         {
+            if (string.IsNullOrWhiteSpace(topicName))
+            {
+                throw new ArgumentException("Requires a non-blank Azure Service bus entity name", nameof(topicName));
+            }
+
             if (string.IsNullOrWhiteSpace(secretName))
             {
                 throw new ArgumentException("Requires a non-blank secret name", nameof(secretName));
@@ -654,6 +693,11 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<ISecretProvider, Task<string>> getConnectionStringFromSecretFunc,
             Action<IAzureServiceBusTopicMessagePumpOptions> configureMessagePump = null)
         {
+            if (string.IsNullOrWhiteSpace(topicName))
+            {
+                throw new ArgumentException("Requires a non-blank Azure Service bus entity name", nameof(topicName));
+            }
+
             var collection = AddServiceBusTopicMessagePumpWithPrefix(
                 services,
                 entityName: topicName,
@@ -685,6 +729,11 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<IConfiguration, string> getConnectionStringFromConfigurationFunc,
             Action<IAzureServiceBusTopicMessagePumpOptions> configureMessagePump = null)
         {
+            if (string.IsNullOrWhiteSpace(topicName))
+            {
+                throw new ArgumentException("Requires a non-blank Azure Service bus entity name", nameof(topicName));
+            }
+
             var collection = AddServiceBusTopicMessagePumpWithPrefix(
                 services,
                 entityName: topicName,
@@ -721,6 +770,11 @@ namespace Microsoft.Extensions.DependencyInjection
             string clientId = null,
             Action<IAzureServiceBusTopicMessagePumpOptions> configureMessagePump = null)
         {
+            if (string.IsNullOrWhiteSpace(topicName))
+            {
+                throw new ArgumentException("Requires a non-blank Azure Service bus entity name", nameof(topicName));
+            }
+
             var collection = AddServiceBusTopicMessagePumpWithPrefix(
                 services,
                 entityName: topicName,
@@ -802,11 +856,6 @@ namespace Microsoft.Extensions.DependencyInjection
             if (services is null)
             {
                 throw new ArgumentNullException(nameof(services));
-            }
-
-            if (string.IsNullOrWhiteSpace(entityName))
-            {
-                throw new ArgumentException("Requires a non-blank Azure Service bus entity name", nameof(entityName));
             }
 
             if (serviceBusEntity is ServiceBusEntityType.Topic && string.IsNullOrWhiteSpace(subscriptionName))

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 using Arcus.Messaging.Pumps.ServiceBus;
 using Arcus.Messaging.Pumps.ServiceBus.Configuration;
-using Arcus.Observability.Correlation;
 using Arcus.Security.Core;
 using Azure.Core;
 using Azure.Identity;
@@ -38,9 +36,6 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<ISecretProvider, Task<string>> getConnectionStringFromSecretFunc,
             Action<IAzureServiceBusQueueMessagePumpOptions> configureMessagePump = null)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure Service Bus Queue message pump");
-            Guard.NotNull(getConnectionStringFromSecretFunc, nameof(getConnectionStringFromSecretFunc), "Requires a function to retrieve the connection string scoped to the Azure Service Bus Queue to authenticate to authenticate with the queue");
-            
             var collection = AddServiceBusQueueMessagePump(
                 services,
                 entityName: null,
@@ -67,9 +62,6 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<IConfiguration, string> getConnectionStringFromConfigurationFunc,
             Action<IAzureServiceBusQueueMessagePumpOptions> configureMessagePump = null)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure Service Bus Queue message pump");
-            Guard.NotNull(getConnectionStringFromConfigurationFunc, nameof(getConnectionStringFromConfigurationFunc), "Requires a function to retrieve the connection string scoped to the Azure Service Bus Queue to authenticate with the queue");
-            
             var collection = AddServiceBusQueueMessagePump(
                 services,
                 entityName: null,
@@ -99,9 +91,11 @@ namespace Microsoft.Extensions.DependencyInjection
             string secretName,
             Action<IAzureServiceBusQueueMessagePumpOptions> configureMessagePump = null)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure Service Bus Queue message pump");
-            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to look up the connection string scoped to the Azure Service Bus Queue to authenticate with the queue");
-            
+            if (string.IsNullOrWhiteSpace(secretName))
+            {
+                throw new ArgumentException("Requires a non-blank secret name", nameof(secretName));
+            }
+
             var collection = AddServiceBusQueueMessagePump(
                 services,
                 entityName: null,
@@ -132,10 +126,11 @@ namespace Microsoft.Extensions.DependencyInjection
             string secretName,
             Action<IAzureServiceBusQueueMessagePumpOptions> configureMessagePump = null)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure Service Bus Queue message pump");
-            Guard.NotNullOrWhitespace(queueName, nameof(queueName), "Requires a non-blank name for the Azure Service Bus Queue");
-            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to look up the connection string scoped to the Azure Service Bus Queue to authenticate with the queue");
-            
+            if (string.IsNullOrWhiteSpace(secretName))
+            {
+                throw new ArgumentException("Requires a non-blank secret name", nameof(secretName));
+            }
+
             var collection = AddServiceBusQueueMessagePump(
                 services,
                 entityName: queueName,
@@ -166,10 +161,6 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<ISecretProvider, Task<string>> getConnectionStringFromSecretFunc,
             Action<IAzureServiceBusQueueMessagePumpOptions> configureMessagePump = null)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure Service Bus Queue message pump");
-            Guard.NotNullOrWhitespace(queueName, nameof(queueName), "Requires a non-blank name for the Azure Service Bus Queue");
-            Guard.NotNull(getConnectionStringFromSecretFunc, nameof(getConnectionStringFromSecretFunc), "Requires a function to retrieve the connection string to authenticate with the Azure Service Bus Queue");
-            
             var collection = AddServiceBusQueueMessagePump(
                 services,
                 entityName: queueName,
@@ -196,10 +187,6 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<IConfiguration, string> getConnectionStringFromConfigurationFunc,
             Action<IAzureServiceBusQueueMessagePumpOptions> configureMessagePump = null)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure Service Bus Queue message pump");
-            Guard.NotNullOrWhitespace(queueName, nameof(queueName), "Requires a non-blank name for the Azure Service Bus Queue");
-            Guard.NotNull(getConnectionStringFromConfigurationFunc, nameof(getConnectionStringFromConfigurationFunc), "Requires a function to retrieve the connection string to authenticate with the Azure Service Bus Queue");
-            
             var collection = AddServiceBusQueueMessagePump(
                 services,
                 entityName: queueName,
@@ -229,10 +216,6 @@ namespace Microsoft.Extensions.DependencyInjection
             string clientId = null,
             Action<IAzureServiceBusQueueMessagePumpOptions> configureMessagePump = null)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure Service Bus Queue message pump");
-            Guard.NotNullOrWhitespace(queueName, nameof(queueName), "Requires a non-blank name for the Azure Service Bus Queue");
-            Guard.NotNullOrWhitespace(serviceBusNamespace, nameof(serviceBusNamespace), "Requires a non-blank fully qualified namespace for the Azure Service Bus Queue");
-            
             var collection = AddServiceBusQueueMessagePump(
                 services,
                 entityName: queueName,
@@ -252,8 +235,6 @@ namespace Microsoft.Extensions.DependencyInjection
             TokenCredential tokenCredential = null,
             Action<IAzureServiceBusQueueMessagePumpOptions> configureQueueMessagePump = null)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure Service Bus Queue message pump");
-
             var collection = AddServiceBusMessagePump(
                 services,
                 entityName,
@@ -290,10 +271,11 @@ namespace Microsoft.Extensions.DependencyInjection
             string secretName,
             Action<IAzureServiceBusTopicMessagePumpOptions> configureMessagePump = null)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure Service Bus Topic message pump");
-            Guard.NotNullOrWhitespace(subscriptionName, nameof(subscriptionName), "Requires a non-blank Azure Service Bus Topic subscription name");
-            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to look up the connection string scoped to the Azure Service Bus Topic to authenticate with the topic");
-            
+            if (string.IsNullOrWhiteSpace(secretName))
+            {
+                throw new ArgumentException("Requires a non-blank secret name", nameof(secretName));
+            }
+
             var collection = AddServiceBusTopicMessagePump(
                 services,
                 entityName: null,
@@ -327,10 +309,6 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<ISecretProvider, Task<string>> getConnectionStringFromSecretFunc,
             Action<IAzureServiceBusTopicMessagePumpOptions> configureMessagePump = null)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure Service Bus Queue message pump");
-            Guard.NotNullOrWhitespace(subscriptionName, nameof(subscriptionName), "Requires a non-blank Azure Service Bus Topic subscription name");
-            Guard.NotNull(getConnectionStringFromSecretFunc, nameof(getConnectionStringFromSecretFunc), "Requires a function to look up the connection string scoped to the Azure Service Bus Topic to authenticate with the topic");
-            
             var collection = AddServiceBusTopicMessagePump(
                 services,
                 entityName: null,
@@ -361,10 +339,6 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<IConfiguration, string> getConnectionStringFromConfigurationFunc,
             Action<IAzureServiceBusTopicMessagePumpOptions> configureMessagePump = null)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure Service Bus Topic message pump");
-            Guard.NotNullOrWhitespace(subscriptionName, nameof(subscriptionName), "Requires a non-blank Azure Service Bus Topic subscription name");
-            Guard.NotNull(getConnectionStringFromConfigurationFunc, nameof(getConnectionStringFromConfigurationFunc), "Requires a function to retrieve the connection string scoped to the Azure Service Bus Topic to authenticate with the topic");
-            
             var collection = AddServiceBusTopicMessagePump(
                 services,
                 entityName: null,
@@ -405,7 +379,7 @@ namespace Microsoft.Extensions.DependencyInjection
             Guard.NotNullOrWhitespace(topicName, nameof(topicName), "Requires a non-blank Azure Service Bus Topic name");
             Guard.NotNullOrWhitespace(subscriptionName, nameof(subscriptionName), "Requires a non-blank Azure Service Bus Topic subscription name");
             Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to look up the connection string to authenticate with the Azure Service Bus Topic");
-            
+
             var collection = AddServiceBusTopicMessagePump(
                 services,
                 entityName: topicName,
@@ -437,11 +411,6 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<ISecretProvider, Task<string>> getConnectionStringFromSecretFunc,
             Action<IAzureServiceBusTopicMessagePumpOptions> configureMessagePump = null)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure Service Bus Topic message pump");
-            Guard.NotNullOrWhitespace(topicName, nameof(topicName), "Requires a non-blank name for the Azure Service Bus Topic");
-            Guard.NotNullOrWhitespace(subscriptionName, nameof(subscriptionName), "Requires a non-blank Azure Service Bus Topic subscription name");
-            Guard.NotNull(getConnectionStringFromSecretFunc, nameof(getConnectionStringFromSecretFunc), "Requires a function to retrieve the connection string to authenticate with the Azure Service Bus Topic");
-            
             var collection = AddServiceBusTopicMessagePump(
                 services,
                 entityName: topicName,
@@ -471,11 +440,6 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<IConfiguration, string> getConnectionStringFromConfigurationFunc,
             Action<IAzureServiceBusTopicMessagePumpOptions> configureMessagePump = null)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure Service Bus Queue message pump");
-            Guard.NotNullOrWhitespace(topicName, nameof(topicName), "Requires a non-blank name for the Azure Service Bus Topic name");
-            Guard.NotNullOrWhitespace(subscriptionName, nameof(subscriptionName), "Requires a non-blank Azure Service Bus Topic subscription name");
-            Guard.NotNull(getConnectionStringFromConfigurationFunc, nameof(getConnectionStringFromConfigurationFunc), "Requires a function to retrieve the connection string to authenticate with the Azure Service Bus Topic");
-            
             var collection = AddServiceBusTopicMessagePump(
                 services,
                 entityName: topicName,
@@ -510,11 +474,6 @@ namespace Microsoft.Extensions.DependencyInjection
             string clientId = null,
             Action<IAzureServiceBusTopicMessagePumpOptions> configureMessagePump = null)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure Service Bus Queue message pump");
-            Guard.NotNullOrWhitespace(topicName, nameof(topicName), "Requires a non-blank name for the Azure Service Bus Topic");
-            Guard.NotNullOrWhitespace(subscriptionName, nameof(subscriptionName), "Requires a non-blank Azure Service Bus Topic subscription name");
-            Guard.NotNullOrWhitespace(serviceBusNamespace, nameof(serviceBusNamespace), "Requires a non-blank fully qualified namespace for the Azure Service Bus Topic");
-            
             var collection = AddServiceBusTopicMessagePump(
                 services,
                 entityName: topicName,
@@ -550,10 +509,11 @@ namespace Microsoft.Extensions.DependencyInjection
             string secretName,
             Action<IAzureServiceBusTopicMessagePumpOptions> configureMessagePump = null)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure Service Bus Queue message pump");
-            Guard.NotNullOrWhitespace(subscriptionPrefix, nameof(subscriptionPrefix), "Requires a non-blank prefix for the Azure Service Bus Topic subscription");
-            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to retrieve the connection string scoped to the Azure Service Bus Topic to authenticate with the topic");
-            
+            if (string.IsNullOrWhiteSpace(secretName))
+            {
+                throw new ArgumentException("Requires a non-blank secret name", nameof(secretName));
+            }
+
             var collection = AddServiceBusTopicMessagePumpWithPrefix(
                 services,
                 entityName: null,
@@ -586,10 +546,6 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<ISecretProvider, Task<string>> getConnectionStringFromSecretFunc,
             Action<IAzureServiceBusTopicMessagePumpOptions> configureMessagePump = null)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure Service Bus Queue message pump");
-            Guard.NotNullOrWhitespace(subscriptionPrefix, nameof(subscriptionPrefix), "Requires a non-blank prefix for the Azure Service Bus Topic subscription");
-            Guard.NotNull(getConnectionStringFromSecretFunc, nameof(getConnectionStringFromSecretFunc), "Requires a function to retrieve the connection string scoped to the Azure Service Bus Topic to authenticate with the topic");
-            
             var collection = AddServiceBusTopicMessagePumpWithPrefix(
                 services,
                 entityName: null,
@@ -622,10 +578,6 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<IConfiguration, string> getConnectionStringFromConfigurationFunc,
             Action<IAzureServiceBusTopicMessagePumpOptions> configureMessagePump = null)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure Service Bus Topic message pump");
-            Guard.NotNullOrWhitespace(subscriptionPrefix, nameof(subscriptionPrefix), "Requires a non-blank prefix for the Azure Service Bus Topic subscription");
-            Guard.NotNull(getConnectionStringFromConfigurationFunc, nameof(getConnectionStringFromConfigurationFunc), "Requires a function to retrieve the connection string scoped to the Azure Service Bus Topic to authenticate with the topic");
-            
             var collection = AddServiceBusTopicMessagePumpWithPrefix(
                 services,
                 entityName: null,
@@ -664,10 +616,10 @@ namespace Microsoft.Extensions.DependencyInjection
             string secretName,
             Action<IAzureServiceBusTopicMessagePumpOptions> configureMessagePump = null)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure Service Bus Topic message pump");
-            Guard.NotNullOrWhitespace(topicName, nameof(topicName), "Requires a non-blank name for the Azure Service Bus Topic");
-            Guard.NotNullOrWhitespace(subscriptionPrefix, nameof(subscriptionPrefix), "Requires a non-blank prefix for the Azure Service Bus Topic subscription");
-            Guard.NotNullOrWhitespace(secretName, nameof(secretName), "Requires a non-blank secret name to retrieve the connection string scoped to the Azure Service Bus Topic to authenticate with the topic");
+            if (string.IsNullOrWhiteSpace(secretName))
+            {
+                throw new ArgumentException("Requires a non-blank secret name", nameof(secretName));
+            }
 
             var collection = AddServiceBusTopicMessagePumpWithPrefix(
                 services,
@@ -702,11 +654,6 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<ISecretProvider, Task<string>> getConnectionStringFromSecretFunc,
             Action<IAzureServiceBusTopicMessagePumpOptions> configureMessagePump = null)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure Service Bus Queue message pump");
-            Guard.NotNullOrWhitespace(topicName, nameof(topicName), "Requires a non-blank name for the Azure Service Bus Topic");
-            Guard.NotNullOrWhitespace(subscriptionPrefix, nameof(subscriptionPrefix), "Requires a non-blank prefix for the Azure Service Bus Topic subscription");
-            Guard.NotNull(getConnectionStringFromSecretFunc, nameof(getConnectionStringFromSecretFunc), "Requires a function to retrieve the connection string scoped to the Azure Service Bus Topic to authenticate with the topic");
-            
             var collection = AddServiceBusTopicMessagePumpWithPrefix(
                 services,
                 entityName: topicName,
@@ -738,11 +685,6 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<IConfiguration, string> getConnectionStringFromConfigurationFunc,
             Action<IAzureServiceBusTopicMessagePumpOptions> configureMessagePump = null)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure Service Bus Queue message pump");
-            Guard.NotNullOrWhitespace(topicName, nameof(topicName), "Requires a non-blank name for the Azure Service Bus Topic subscription");
-            Guard.NotNullOrWhitespace(subscriptionPrefix, nameof(subscriptionPrefix), "Requires a non-blank prefix for the Azure Service Bus Topic subscription");
-            Guard.NotNull(getConnectionStringFromConfigurationFunc, nameof(getConnectionStringFromConfigurationFunc), "Requires a function to retrieve the connection string scoped to the Azure Service Bus Topic to authenticate with the topic");
-            
             var collection = AddServiceBusTopicMessagePumpWithPrefix(
                 services,
                 entityName: topicName,
@@ -779,11 +721,6 @@ namespace Microsoft.Extensions.DependencyInjection
             string clientId = null,
             Action<IAzureServiceBusTopicMessagePumpOptions> configureMessagePump = null)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure Service Bus Queue message pump");
-            Guard.NotNullOrWhitespace(topicName, nameof(topicName), "Requires a non-blank name for the Azure Service Bus Topic");
-            Guard.NotNullOrWhitespace(subscriptionPrefix, nameof(subscriptionPrefix), "Requires a prefix for the Azure Service Bus Topic subscription");
-            Guard.NotNullOrWhitespace(serviceBusNamespace, nameof(serviceBusNamespace), "Requires a non-blank fully qualified namespace for the Azure Service Bus Topic");
-            
             var collection = AddServiceBusTopicMessagePumpWithPrefix(
                 services,
                 entityName: topicName,
@@ -805,6 +742,11 @@ namespace Microsoft.Extensions.DependencyInjection
             TokenCredential tokenCredential = null,
             Action<IAzureServiceBusTopicMessagePumpOptions> configureTopicMessagePump = null)
         {
+            if (string.IsNullOrWhiteSpace(subscriptionPrefix))
+            {
+                throw new ArgumentException("Requires a non-blank Azure Service bus topic subscription prefix", nameof(subscriptionPrefix));
+            }
+
             var messagePumpOptions = AzureServiceBusMessagePumpOptions.DefaultTopicOptions;
             string subscriptionName = $"{subscriptionPrefix}-{messagePumpOptions.JobId}";
 
@@ -831,8 +773,6 @@ namespace Microsoft.Extensions.DependencyInjection
             TokenCredential tokenCredential = null,
             Action<IAzureServiceBusTopicMessagePumpOptions> configureTopicMessagePump = null)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure Service Bus Queue message pump");
-
             ServiceBusMessageHandlerCollection collection = AddServiceBusMessagePump(
                 services,
                 entityName,
@@ -859,9 +799,22 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<ISecretProvider, Task<string>> getConnectionStringFromSecretFunc = null,
             TokenCredential tokenCredential = null)
         {
-            Guard.NotNull(services, nameof(services), "Requires a set of services to add the Azure Service Bus Queue message pump");
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
 
-            AzureServiceBusMessagePumpOptions options = 
+            if (string.IsNullOrWhiteSpace(entityName))
+            {
+                throw new ArgumentException("Requires a non-blank Azure Service bus entity name", nameof(entityName));
+            }
+
+            if (serviceBusEntity is ServiceBusEntityType.Topic && string.IsNullOrWhiteSpace(subscriptionName))
+            {
+                throw new ArgumentException("Requires a non-blank Azure Service bus topic subscription name", nameof(subscriptionName));
+            }
+
+            AzureServiceBusMessagePumpOptions options =
                 DetermineAzureServiceBusMessagePumpOptions(serviceBusEntity, configureQueueMessagePump, configureTopicMessagePump);
 
             ServiceBusMessageHandlerCollection collection = services.AddServiceBusMessageRouting(provider =>
@@ -879,17 +832,17 @@ namespace Microsoft.Extensions.DependencyInjection
                     logger.LogWarning("Azure Service Bus Topic subscription name was truncated to 50 characters");
                     subscriptionName = subscriptionName.Substring(0, 50);
                 }
-                
-                AzureServiceBusMessagePumpSettings settings; 
+
+                AzureServiceBusMessagePumpSettings settings;
                 if (tokenCredential is null)
                 {
                     settings = new AzureServiceBusMessagePumpSettings(
-                        entityName, subscriptionName, serviceBusEntity, getConnectionStringFromConfigurationFunc, getConnectionStringFromSecretFunc, options, serviceProvider); 
+                        entityName, subscriptionName, serviceBusEntity, getConnectionStringFromConfigurationFunc, getConnectionStringFromSecretFunc, options, serviceProvider);
                 }
                 else
                 {
                     settings = new AzureServiceBusMessagePumpSettings(
-                        entityName, subscriptionName, serviceBusEntity, serviceBusNamespace, tokenCredential, options, serviceProvider); 
+                        entityName, subscriptionName, serviceBusEntity, serviceBusNamespace, tokenCredential, options, serviceProvider);
                 }
 
                 var configuration = serviceProvider.GetRequiredService<IConfiguration>();
@@ -912,13 +865,13 @@ namespace Microsoft.Extensions.DependencyInjection
                     configureQueueMessagePump?.Invoke(queueMessagePumpOptions);
 
                     return queueMessagePumpOptions;
-                
+
                 case ServiceBusEntityType.Topic:
                     var topicMessagePumpOptions = AzureServiceBusMessagePumpOptions.DefaultTopicOptions;
                     configureTopicMessagePump?.Invoke(topicMessagePumpOptions);
 
                     return topicMessagePumpOptions;
-                
+
                 default:
                     throw new ArgumentOutOfRangeException(nameof(serviceBusEntity), serviceBusEntity, "Unknown Azure Service Bus entity");
             }

--- a/src/Arcus.Messaging.ServiceBus.Core/Arcus.Messaging.ServiceBus.Core.csproj
+++ b/src/Arcus.Messaging.ServiceBus.Core/Arcus.Messaging.ServiceBus.Core.csproj
@@ -27,7 +27,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Guard.NET" Version="3.0.0" />
     <PackageReference Include="Arcus.Security.Core" Version="[2.0.0,3.0.0)" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.16.2" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.4" />

--- a/src/Arcus.Messaging.ServiceBus.Core/Extensions/MessageContextExtensions.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/Extensions/MessageContextExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Text;
-using GuardNet;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -20,8 +19,6 @@ namespace Arcus.Messaging.Abstractions
         /// <param name="messageContext">The context of the message.</param>
         public static Encoding GetMessageEncodingProperty(this MessageContext messageContext)
         {
-            Guard.NotNull(messageContext, nameof(messageContext));
-
             Encoding encoding = GetMessageEncodingProperty(messageContext, NullLogger.Instance);
             return encoding;
         }
@@ -33,8 +30,12 @@ namespace Arcus.Messaging.Abstractions
         /// <param name="logger"></param>
         public static Encoding GetMessageEncodingProperty(this MessageContext messageContext, ILogger logger)
         {
-            Guard.NotNull(messageContext, nameof(messageContext));
-            logger = logger ?? NullLogger.Instance;
+            if (messageContext is null)
+            {
+                throw new ArgumentNullException(nameof(messageContext));
+            }
+
+            logger ??= NullLogger.Instance;
 
             if (messageContext.Properties.TryGetValue(PropertyNames.Encoding, out object annotatedEncoding))
             {

--- a/src/Arcus.Messaging.ServiceBus.Core/Extensions/MessageExtensions.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/Extensions/MessageExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.ServiceBus
         {
             if (message is null)
             {
-                throw new ArgumentNullException(nameof(message))
+                throw new ArgumentNullException(nameof(message));
             }
 
             if (string.IsNullOrWhiteSpace(key))

--- a/src/Arcus.Messaging.ServiceBus.Core/Extensions/MessageExtensions.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/Extensions/MessageExtensions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using Arcus.Messaging.Abstractions;
 using Azure.Messaging.ServiceBus;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Azure.ServiceBus
@@ -25,9 +24,16 @@ namespace Microsoft.Azure.ServiceBus
         [Obsolete("Use the 'GetApplicationProperty' extension in the 'Azure.Messaging.ServiceBus' namespace, remove the 'Microsoft.Azure.ServiceBus' namespace from your using statements")]
         public static TProperty GetApplicationProperty<TProperty>(this ServiceBusReceivedMessage message, string key)
         {
-            Guard.NotNull(message, nameof(message), "Requires an received Azure Service Bus message to retrieve the application property");
-            Guard.NotNullOrWhitespace(key, nameof(key), "Requires an application property key to retrieve the application property from the received Azure Service Bus message");
-            
+            if (message is null)
+            {
+                throw new ArgumentNullException(nameof(message))
+            }
+
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                throw new ArgumentException("Requires an application property key to retrieve the application property from the received Azure Service Bus message", nameof(key));
+            }
+
             if (message.ApplicationProperties.TryGetValue(key, out object value))
             {
                 if (value is TProperty typed)
@@ -56,8 +62,6 @@ namespace Microsoft.Azure.ServiceBus
         [Obsolete("Use the 'GetCorrelationInfo' extension in the 'Azure.Messaging.ServiceBus' namespace, remove the 'Microsoft.Azure.ServiceBus' namespace from your using statements")]
         public static MessageCorrelationInfo GetCorrelationInfo(this ServiceBusReceivedMessage message)
         {
-            Guard.NotNull(message, nameof(message), "Requires an received Azure Service Bus message to retrieve the correlation information");
-
             return GetCorrelationInfo(message, PropertyNames.TransactionId);
         }
 
@@ -76,10 +80,7 @@ namespace Microsoft.Azure.ServiceBus
         [Obsolete("Use the 'GetCorrelationInfo' extension in the 'Azure.Messaging.ServiceBus' namespace, remove the 'Microsoft.Azure.ServiceBus' namespace from your using statements")]
         public static MessageCorrelationInfo GetCorrelationInfo(this ServiceBusReceivedMessage message, string transactionIdPropertyName)
         {
-            Guard.NotNull(message, nameof(message), "Requires an received Azure Service Bus message to retrieve the correlation information");
-            Guard.NotNullOrWhitespace(transactionIdPropertyName, nameof(transactionIdPropertyName), "Requires a non-blank property name to retrieve the correlation transaction ID from the received Azure Service Bus message");
-
-            MessageCorrelationInfo messageCorrelationInfo = 
+            MessageCorrelationInfo messageCorrelationInfo =
                 GetCorrelationInfo(message, transactionIdPropertyName, PropertyNames.OperationParentId);
 
             return messageCorrelationInfo;
@@ -106,9 +107,20 @@ namespace Microsoft.Azure.ServiceBus
             string transactionIdPropertyName,
             string operationParentIdPropertyName)
         {
-            Guard.NotNull(message, nameof(message), "Requires an received Azure Service Bus message to retrieve the correlation information");
-            Guard.NotNullOrWhitespace(transactionIdPropertyName, nameof(transactionIdPropertyName), "Requires a non-blank property name to retrieve the correlation transaction ID from the received Azure Service Bus message");
-            Guard.NotNullOrWhitespace(operationParentIdPropertyName, nameof(operationParentIdPropertyName), "Requires a non-blank property name to retrieve the correlation operation parent ID from the received Azure Service Bus message");
+            if (message is null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            if (string.IsNullOrWhiteSpace(transactionIdPropertyName))
+            {
+                throw new ArgumentException("Requires a non-blank transaction ID property name", nameof(transactionIdPropertyName));
+            }
+
+            if (string.IsNullOrWhiteSpace(operationParentIdPropertyName))
+            {
+                throw new ArgumentException("Requires a non-blank operation parent ID property name", nameof(operationParentIdPropertyName));
+            }
 
             string transactionId = DetermineTransactionId(message, transactionIdPropertyName);
             string operationId = DetermineOperationId(message.CorrelationId);
@@ -152,8 +164,6 @@ namespace Microsoft.Azure.ServiceBus
         [Obsolete("Use the 'GetTransactionId' extension in the 'Azure.Messaging.ServiceBus' namespace, remove the 'Microsoft.Azure.ServiceBus' namespace from your using statements")]
         public static string GetTransactionId(this ServiceBusReceivedMessage message)
         {
-            Guard.NotNull(message,nameof(message), "Requires an received Azure Service Bus message to retrieve the correlation transaction ID");
-
             return GetTransactionId(message, PropertyNames.TransactionId);
         }
 
@@ -170,8 +180,15 @@ namespace Microsoft.Azure.ServiceBus
         [Obsolete("Use the 'GetTransactionId' extension in the 'Azure.Messaging.ServiceBus' namespace, remove the 'Microsoft.Azure.ServiceBus' namespace from your using statements")]
         public static string GetTransactionId(this ServiceBusReceivedMessage message, string transactionIdPropertyName)
         {
-            Guard.NotNull(message, nameof(message), "Requires an received Azure Service Bus message to retrieve the correlation transaction ID");
-            Guard.NotNullOrWhitespace(transactionIdPropertyName, nameof(transactionIdPropertyName), "Requires a non-blank property name to retrieve the correlation transaction ID from the received Azure Service Bus message");
+            if (message is null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            if (string.IsNullOrWhiteSpace(transactionIdPropertyName))
+            {
+                throw new ArgumentException("Requires a non-blank transaction ID property name", nameof(transactionIdPropertyName));
+            }
 
             return GetOptionalUserProperty(message, transactionIdPropertyName);
         }

--- a/src/Arcus.Messaging.ServiceBus.Core/Extensions/ServiceBusReceivedMessageExtensions.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/Extensions/ServiceBusReceivedMessageExtensions.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using Arcus.Messaging.Abstractions;
-using Arcus.Messaging.Abstractions.MessageHandling;
-using Arcus.Messaging.ServiceBus.Core;
-using GuardNet;
-using Microsoft.ApplicationInsights;
 
 // ReSharper disable once CheckNamespace
 namespace Azure.Messaging.ServiceBus
@@ -26,9 +22,16 @@ namespace Azure.Messaging.ServiceBus
         /// <exception cref="InvalidCastException">Thrown when the application property's value cannot be cast to the provided <typeparamref name="TProperty"/> type.</exception>
         public static TProperty GetApplicationProperty<TProperty>(this ServiceBusReceivedMessage message, string key)
         {
-            Guard.NotNull(message, nameof(message), "Requires an received Azure Service Bus message to retrieve the application property");
-            Guard.NotNullOrWhitespace(key, nameof(key), "Requires an application property key to retrieve the application property from the received Azure Service Bus message");
-            
+            if (message is null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            if (string.IsNullOrWhiteSpace(key))
+            {
+                throw new ArgumentException("Requires an application property key to retrieve the application property from the received Azure Service Bus message", nameof(key));
+            }
+
             if (message.ApplicationProperties.TryGetValue(key, out object value))
             {
                 if (value is TProperty typed)
@@ -60,8 +63,6 @@ namespace Azure.Messaging.ServiceBus
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> is <c>null</c>.</exception>
         public static MessageCorrelationInfo GetCorrelationInfo(this ServiceBusReceivedMessage message)
         {
-            Guard.NotNull(message, nameof(message), "Requires an received Azure Service Bus message to retrieve the correlation information");
-
             return GetCorrelationInfo(message, PropertyNames.TransactionId);
         }
 
@@ -83,10 +84,7 @@ namespace Azure.Messaging.ServiceBus
         /// <exception cref="ArgumentException">Thrown when the <paramref name="transactionIdPropertyName"/> is blank.</exception>
         public static MessageCorrelationInfo GetCorrelationInfo(this ServiceBusReceivedMessage message, string transactionIdPropertyName)
         {
-            Guard.NotNull(message, nameof(message), "Requires an received Azure Service Bus message to retrieve the correlation information");
-            Guard.NotNullOrWhitespace(transactionIdPropertyName, nameof(transactionIdPropertyName), "Requires a non-blank property name to retrieve the correlation transaction ID from the received Azure Service Bus message");
-
-            MessageCorrelationInfo messageCorrelationInfo = 
+            MessageCorrelationInfo messageCorrelationInfo =
                 GetCorrelationInfo(message, transactionIdPropertyName, PropertyNames.OperationParentId);
 
             return messageCorrelationInfo;
@@ -116,9 +114,20 @@ namespace Azure.Messaging.ServiceBus
             string transactionIdPropertyName,
             string operationParentIdPropertyName)
         {
-            Guard.NotNull(message, nameof(message), "Requires an received Azure Service Bus message to retrieve the correlation information");
-            Guard.NotNullOrWhitespace(transactionIdPropertyName, nameof(transactionIdPropertyName), "Requires a non-blank property name to retrieve the correlation transaction ID from the received Azure Service Bus message");
-            Guard.NotNullOrWhitespace(operationParentIdPropertyName, nameof(operationParentIdPropertyName), "Requires a non-blank property name to retrieve the correlation operation parent ID from the received Azure Service Bus message");
+            if (message is null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            if (string.IsNullOrWhiteSpace(transactionIdPropertyName))
+            {
+                throw new ArgumentException("Requires a non-blank property name to retrieve the correlation transaction ID from the received Azure Service Bus message", nameof(transactionIdPropertyName));
+            }
+
+            if (string.IsNullOrWhiteSpace(operationParentIdPropertyName))
+            {
+                throw new ArgumentException("Requires a non-blank property name to retrieve the correlation operation parent ID from the received Azure Service Bus message", nameof(operationParentIdPropertyName));
+            }
 
             string transactionId = DetermineTransactionId(message, transactionIdPropertyName);
             string operationId = DetermineOperationId(message.CorrelationId);
@@ -165,8 +174,6 @@ namespace Azure.Messaging.ServiceBus
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> is <c>null</c>.</exception>
         public static string GetTransactionId(this ServiceBusReceivedMessage message)
         {
-            Guard.NotNull(message,nameof(message), "Requires an received Azure Service Bus message to retrieve the correlation transaction ID");
-
             return GetTransactionId(message, PropertyNames.TransactionId);
         }
 
@@ -186,8 +193,15 @@ namespace Azure.Messaging.ServiceBus
         /// <exception cref="ArgumentException">Thrown when the <paramref name="transactionIdPropertyName"/> is blank.</exception>
         public static string GetTransactionId(this ServiceBusReceivedMessage message, string transactionIdPropertyName)
         {
-            Guard.NotNull(message, nameof(message), "Requires an received Azure Service Bus message to retrieve the correlation transaction ID");
-            Guard.NotNullOrWhitespace(transactionIdPropertyName, nameof(transactionIdPropertyName), "Requires a non-blank property name to retrieve the correlation transaction ID from the received Azure Service Bus message");
+            if (message is null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            if (string.IsNullOrWhiteSpace(transactionIdPropertyName))
+            {
+                throw new ArgumentException("Requires a non-blank property name to retrieve the correlation transaction ID from the received Azure Service Bus message", nameof(transactionIdPropertyName));
+            }
 
             return GetOptionalUserProperty(message, transactionIdPropertyName);
         }

--- a/src/Arcus.Messaging.ServiceBus.Core/Extensions/ServiceBusSenderExtensions.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/Extensions/ServiceBusSenderExtensions.cs
@@ -188,6 +188,11 @@ namespace Azure.Messaging.ServiceBus
             Action<ServiceBusSenderMessageCorrelationOptions> configureOptions,
             CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (message is null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
             await SendMessagesAsync(sender, new[] { message }, correlationInfo, logger, configureOptions, cancellationToken);
         }
 

--- a/src/Arcus.Messaging.ServiceBus.Core/Extensions/ServiceBusSenderExtensions.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/Extensions/ServiceBusSenderExtensions.cs
@@ -3,11 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.ServiceBus.Core;
 using Arcus.Observability.Correlation;
 using Arcus.Observability.Telemetry.Core;
-using GuardNet;
 using Microsoft.Extensions.Logging;
 
 // ReSharper disable once CheckNamespace
@@ -40,11 +38,6 @@ namespace Azure.Messaging.ServiceBus
             ILogger logger,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(sender, nameof(sender), "Requires an Azure Service Bus sender to while sending a correlated message");
-            Guard.NotNull(messageBody, nameof(messageBody), "Requires a series of Azure Service Bus messages to send as correlated messages");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a message correlation instance to include the transaction ID in the send out messages");
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure Service Bus dependency while sending the correlated messages");
-
             await SendMessageAsync(sender, messageBody, correlationInfo, logger, configureOptions: null, cancellationToken);
         }
 
@@ -72,12 +65,7 @@ namespace Azure.Messaging.ServiceBus
             Action<ServiceBusSenderMessageCorrelationOptions> configureOptions,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(sender, nameof(sender), "Requires an Azure Service Bus sender to while sending a correlated message");
-            Guard.NotNull(messageBody, nameof(messageBody), "Requires a series of Azure Service Bus messages to send as correlated messages");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a message correlation instance to include the transaction ID in the send out messages");
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure Service Bus dependency while sending the correlated messages");
-
-            await SendMessagesAsync(sender, new [] { messageBody }, correlationInfo, logger, configureOptions, cancellationToken);
+            await SendMessagesAsync(sender, new[] { messageBody }, correlationInfo, logger, configureOptions, cancellationToken);
         }
 
         /// <summary>
@@ -107,13 +95,6 @@ namespace Azure.Messaging.ServiceBus
             ILogger logger,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(sender, nameof(sender), "Requires an Azure Service Bus sender to while sending a correlated message");
-            Guard.NotNull(messageBodies, nameof(messageBodies), "Requires a series of Azure Service Bus messages to send as correlated messages");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a message correlation instance to include the transaction ID in the send out messages");
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure Service Bus dependency while sending the correlated messages");
-            Guard.NotAny(messageBodies, nameof(messageBodies), "Requires at least a single message to send to Azure Service Bus");
-            Guard.For(() => messageBodies.Any(message => message is null), new ArgumentException("Requires non-null items in Azure Service Bus message sequence", nameof(messageBodies)));
-
             await SendMessagesAsync(sender, messageBodies, correlationInfo, logger, configureOptions: null, cancellationToken);
         }
 
@@ -146,12 +127,10 @@ namespace Azure.Messaging.ServiceBus
             Action<ServiceBusSenderMessageCorrelationOptions> configureOptions,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(sender, nameof(sender), "Requires an Azure Service Bus sender to while sending a correlated message");
-            Guard.NotNull(messageBodies, nameof(messageBodies), "Requires a series of Azure Service Bus messages to send as correlated messages");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a message correlation instance to include the transaction ID in the send out messages");
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure Service Bus dependency while sending the correlated messages");
-            Guard.NotAny(messageBodies, nameof(messageBodies), "Requires at least a single message to send to Azure Service Bus");
-            Guard.For(() => messageBodies.Any(message => message is null), new ArgumentException("Requires non-null items in Azure Service Bus message sequence", nameof(messageBodies)));
+            if (messageBodies is null)
+            {
+                throw new ArgumentNullException(nameof(messageBodies));
+            }
 
             ServiceBusMessage[] messages =
                 messageBodies.Select(messageBody => ServiceBusMessageBuilder.CreateForBody(messageBody).Build())
@@ -182,12 +161,7 @@ namespace Azure.Messaging.ServiceBus
             ILogger logger,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(sender, nameof(sender), "Requires an Azure Service Bus sender to while sending a correlated message");
-            Guard.NotNull(message, nameof(message), "Requires a Azure Service Bus message to send as a correlated message");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a message correlation instance to include the transaction ID in the send out messages");
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure Service Bus dependency while sending the correlated messages");
-
-            await SendMessageAsync(sender, message , correlationInfo, logger, configureOptions: null, cancellationToken);
+            await SendMessageAsync(sender, message, correlationInfo, logger, configureOptions: null, cancellationToken);
         }
 
         /// <summary>
@@ -214,11 +188,6 @@ namespace Azure.Messaging.ServiceBus
             Action<ServiceBusSenderMessageCorrelationOptions> configureOptions,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(sender, nameof(sender), "Requires an Azure Service Bus sender to while sending a correlated message");
-            Guard.NotNull(message, nameof(message), "Requires a Azure Service Bus message to send as a correlated message");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a message correlation instance to include the transaction ID in the send out messages");
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure Service Bus dependency while sending the correlated messages");
-
             await SendMessagesAsync(sender, new[] { message }, correlationInfo, logger, configureOptions, cancellationToken);
         }
 
@@ -249,13 +218,6 @@ namespace Azure.Messaging.ServiceBus
             ILogger logger,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(sender, nameof(sender), "Requires an Azure Service Bus sender to while sending a correlated message");
-            Guard.NotNull(messages, nameof(messages), "Requires a series of Azure Service Bus messages to send as correlated messages");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a message correlation instance to include the transaction ID in the send out messages");
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure Service Bus dependency while sending the correlated messages");
-            Guard.NotAny(messages, nameof(messages), "Requires at least a single message to send to Azure Service Bus");
-            Guard.For(() => messages.Any(message => message is null), new ArgumentException("Requires non-null items in Azure Service Bus message sequence", nameof(messages)));
-
             await SendMessagesAsync(sender, messages, correlationInfo, logger, configureOptions: null, cancellationToken);
         }
 
@@ -281,19 +243,32 @@ namespace Azure.Messaging.ServiceBus
         ///   <see href="https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas#messaging-quotas" />.
         /// </exception>
         public static async Task SendMessagesAsync(
-            this ServiceBusSender sender, 
-            IEnumerable<ServiceBusMessage> messages, 
+            this ServiceBusSender sender,
+            IEnumerable<ServiceBusMessage> messages,
             CorrelationInfo correlationInfo,
             ILogger logger,
             Action<ServiceBusSenderMessageCorrelationOptions> configureOptions,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            Guard.NotNull(sender, nameof(sender), "Requires an Azure Service Bus sender to send a correlated message");
-            Guard.NotNull(messages, nameof(messages), "Requires a series of Azure Service Bus messages to send as correlated messages");
-            Guard.NotNull(correlationInfo, nameof(correlationInfo), "Requires a message correlation instance to include the transaction ID in the send out messages");
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to track the Azure Service Bus dependency while sending the correlated messages");
-            Guard.NotAny(messages, nameof(messages), "Requires at least a single message to send to Azure Service Bus");
-            Guard.For(() => messages.Any(message => message is null), new ArgumentException("Requires non-null items in Azure Service Bus message sequence", nameof(messages)));
+            if (sender is null)
+            {
+                throw new ArgumentNullException(nameof(sender));
+            }
+
+            if (messages is null)
+            {
+                throw new ArgumentNullException(nameof(messages));
+            }
+
+            if (correlationInfo is null)
+            {
+                throw new ArgumentNullException(nameof(correlationInfo));
+            }
+
+            if (logger is null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
 
             var options = new ServiceBusSenderMessageCorrelationOptions();
             configureOptions?.Invoke(options);
@@ -308,7 +283,7 @@ namespace Azure.Messaging.ServiceBus
             }
 
             bool isSuccessful = false;
-            using (var measurement = DurationMeasurement.Start()) 
+            using (var measurement = DurationMeasurement.Start())
             {
                 try
                 {

--- a/src/Arcus.Messaging.ServiceBus.Core/ServiceBusMessageBuilder.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/ServiceBusMessageBuilder.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Text;
 using Arcus.Messaging.Abstractions;
-using GuardNet;
 using Newtonsoft.Json;
 
 // ReSharper disable once CheckNamespace
@@ -19,8 +18,8 @@ namespace Azure.Messaging.ServiceBus
 
         private ServiceBusMessageBuilder(object messageBody, Encoding encoding)
         {
-            _messageBody = messageBody;
-            _encoding = encoding;
+            _messageBody = messageBody ?? throw new ArgumentNullException(nameof(messageBody));
+            _encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
         }
 
         /// <summary>
@@ -30,7 +29,6 @@ namespace Azure.Messaging.ServiceBus
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="messageBody"/> is <c>null</c>.</exception>
         public static ServiceBusMessageBuilder CreateForBody(object messageBody)
         {
-            Guard.NotNull(messageBody, nameof(messageBody), "Requires a message body to include in the to-be-created Azure Service Bus message");
             return new ServiceBusMessageBuilder(messageBody, Encoding.UTF8);
         }
 
@@ -42,9 +40,6 @@ namespace Azure.Messaging.ServiceBus
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="messageBody"/> or the <paramref name="encoding"/> is <c>null</c>.</exception>
         public static ServiceBusMessageBuilder CreateForBody(object messageBody, Encoding encoding)
         {
-            Guard.NotNull(messageBody, nameof(messageBody), "Requires a message body to include in the to-be-created Azure Service Bus message");
-            Guard.NotNull(encoding, nameof(encoding), "Requires an encoding instance to encode the passed-in message body so it can be included in the Azure Service Bus message");
-
             return new ServiceBusMessageBuilder(messageBody, encoding);
         }
 
@@ -109,7 +104,7 @@ namespace Azure.Messaging.ServiceBus
             {
                 _transactionIdProperty = new KeyValuePair<string, object>(
                     transactionIdPropertyName ?? PropertyNames.TransactionId,
-                    transactionId); 
+                    transactionId);
             }
 
             return this;
@@ -144,7 +139,7 @@ namespace Azure.Messaging.ServiceBus
             {
                 _operationParentIdProperty = new KeyValuePair<string, object>(
                     operationParentIdPropertyName ?? PropertyNames.OperationParentId,
-                    operationParentId); 
+                    operationParentId);
             }
 
             return this;
@@ -169,7 +164,7 @@ namespace Azure.Messaging.ServiceBus
             if (_operationIdProperty.Key is null && _operationIdProperty.Value is not null)
             {
                 message.CorrelationId = _operationIdProperty.Value?.ToString();
-            } 
+            }
             else if (_operationIdProperty.Value is not null)
             {
                 message.ApplicationProperties.Add(_operationIdProperty);

--- a/src/Arcus.Messaging.ServiceBus.Core/ServiceBusSenderMessageCorrelationOptions.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/ServiceBusSenderMessageCorrelationOptions.cs
@@ -4,7 +4,6 @@ using System.Threading;
 using Arcus.Messaging.Abstractions;
 using Arcus.Observability.Correlation;
 using Azure.Messaging.ServiceBus;
-using GuardNet;
 using Microsoft.Extensions.Logging;
 
 namespace Arcus.Messaging.ServiceBus.Core
@@ -27,7 +26,11 @@ namespace Arcus.Messaging.ServiceBus.Core
             get => _transactionIdPropertyName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank value for the message correlation transaction ID Azure Service Bus application property name");
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentException("Requires a non-blank value for the message correlation transaction ID Azure Service Bus application property name", nameof(value));
+                }
+
                 _transactionIdPropertyName = value;
             }
         }
@@ -41,7 +44,11 @@ namespace Arcus.Messaging.ServiceBus.Core
             get => _upstreamServicePropertyName;
             set
             {
-                Guard.NotNullOrWhitespace(value, nameof(value), "Requires a non-blank value for the message correlation upstream service Azure Service Bus application property name");
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentException("Requires a non-blank value for the message correlation upstream service Azure Service Bus application property name", nameof(value));
+                }
+
                 _upstreamServicePropertyName = value;
             }
         }
@@ -57,11 +64,7 @@ namespace Arcus.Messaging.ServiceBus.Core
         public Func<string> GenerateDependencyId
         {
             get => _generateDependencyId;
-            set
-            {
-                Guard.NotNull(value, nameof(value), "Requires a function to generate the dependency ID used when tracking Azure Service Bus dependencies");
-                _generateDependencyId = value;
-            }
+            set => _generateDependencyId = value ?? throw new ArgumentNullException(nameof(value));
         }
 
         /// <summary>
@@ -76,7 +79,11 @@ namespace Arcus.Messaging.ServiceBus.Core
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="telemetryContext"/> is <c>null</c>.</exception>
         public void AddTelemetryContext(Dictionary<string, object> telemetryContext)
         {
-            Guard.NotNull(telemetryContext, nameof(telemetryContext), "Requires a telemetry context dictionary to add to the Azure Service Bus dependency tracking");
+            if (telemetryContext is null)
+            {
+                throw new ArgumentNullException(nameof(telemetryContext));
+            }
+
             foreach (KeyValuePair<string, object> item in telemetryContext)
             {
                 TelemetryContext[item.Key] = item.Value;


### PR DESCRIPTION
Remove any calls to the Guard.NET library in ServiceBus-related projects.

Relates to #449 