### PR TITLE
feat(circuit-breaker): add job ID + old/new state change to circuit-breaker transition

### DIFF
--- a/docs/preview/02-Features/06-general-messaging.md
+++ b/docs/preview/02-Features/06-general-messaging.md
@@ -96,9 +96,16 @@ The instances should implement the `ICircuitBreakerEventHandler`, which allows y
 ```csharp
 public class MyFirstCircuitBreakerEventHandler : ICircuitBreakerEventHandler
 {
-    public Task OnTransitionAsync(MessagePumpCircuitState newState)
+    public Task OnTransitionAsync(MessagePumpCircuitStateChang change)
     {
-        // ...
+        // The job ID of the message pump that was transitioned.
+        string jobId = change.JobId;
+
+        // The circuit breaker state transitions.
+        MessagePumpCircuitState oldState = change.OldState;
+        MessagePumpCircuitState newState = change.NewState;
+
+        // Process the state change event...
     }
 }
 ```

--- a/src/Arcus.Messaging.Pumps.Abstractions/MessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/MessagePump.cs
@@ -211,7 +211,7 @@ namespace Arcus.Messaging.Pumps.Abstractions
 
             foreach (var handler in eventHandlers)
             {
-                Task.Run(() => handler.OnTransition(new MessagePumpCircuitStateChangeEventArgs(JobId, oldState, newState)));
+                Task.Run(() => handler.OnTransition(new MessagePumpCircuitStateChangedEventArgs(JobId, oldState, newState)));
             }
         }
 

--- a/src/Arcus.Messaging.Pumps.Abstractions/MessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/MessagePump.cs
@@ -211,7 +211,7 @@ namespace Arcus.Messaging.Pumps.Abstractions
 
             foreach (var handler in eventHandlers)
             {
-                Task.Run(() => handler.OnTransition(new MessagePumpCircuitStateChange(JobId, oldState, newState)));
+                Task.Run(() => handler.OnTransition(new MessagePumpCircuitStateChangeEventArgs(JobId, oldState, newState)));
             }
         }
 

--- a/src/Arcus.Messaging.Pumps.Abstractions/MessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/MessagePump.cs
@@ -145,9 +145,12 @@ namespace Arcus.Messaging.Pumps.Abstractions
 
             if (!CircuitState.IsHalfOpen)
             {
-                CircuitState = CircuitState.TransitionTo(CircuitBreakerState.HalfOpen);
+                MessagePumpCircuitState
+                    oldState = CircuitState,
+                    newState = CircuitState.TransitionTo(CircuitBreakerState.HalfOpen);
 
-                NotifyCircuitBreakerStateChangedSubscribers();
+                CircuitState = newState;
+                NotifyCircuitBreakerStateChangedSubscribers(oldState, newState);
             }
         }
 
@@ -162,9 +165,12 @@ namespace Arcus.Messaging.Pumps.Abstractions
 
             if (!CircuitState.IsHalfOpen)
             {
-                CircuitState = CircuitState.TransitionTo(CircuitBreakerState.HalfOpen);
+                MessagePumpCircuitState
+                    oldState = CircuitState,
+                    newState = CircuitState.TransitionTo(CircuitBreakerState.HalfOpen);
 
-                NotifyCircuitBreakerStateChangedSubscribers();
+                CircuitState = newState;
+                NotifyCircuitBreakerStateChangedSubscribers(oldState, newState);
             }
         }
 
@@ -176,9 +182,12 @@ namespace Arcus.Messaging.Pumps.Abstractions
         {
             Logger.LogDebug("Circuit breaker caused message pump '{JobId}' to transition from a '{CurrentState}' an 'Open' state", JobId, CircuitState);
 
-            CircuitState = CircuitState.TransitionTo(CircuitBreakerState.Open, options);
+            MessagePumpCircuitState
+                oldState = CircuitState,
+                newState = CircuitState.TransitionTo(CircuitBreakerState.Open, options);
 
-            NotifyCircuitBreakerStateChangedSubscribers();
+            CircuitState = newState;
+            NotifyCircuitBreakerStateChangedSubscribers(oldState, newState);
         }
 
         /// <summary>
@@ -188,18 +197,21 @@ namespace Arcus.Messaging.Pumps.Abstractions
         {
             Logger.LogDebug("Circuit breaker caused message pump '{JobId}' to transition back from '{CurrentState}' to a 'Closed' state, retrieving messages is resumed", JobId, CircuitState);
 
-            CircuitState = MessagePumpCircuitState.Closed;
+            MessagePumpCircuitState
+                oldState = CircuitState,
+                newState = MessagePumpCircuitState.Closed;
 
-            NotifyCircuitBreakerStateChangedSubscribers();
+            CircuitState = newState;
+            NotifyCircuitBreakerStateChangedSubscribers(oldState, newState);
         }
 
-        private void NotifyCircuitBreakerStateChangedSubscribers()
+        private void NotifyCircuitBreakerStateChangedSubscribers(MessagePumpCircuitState oldState, MessagePumpCircuitState newState)
         {
             ICircuitBreakerEventHandler[] eventHandlers = GetEventHandlersForPump();
 
             foreach (var handler in eventHandlers)
             {
-                Task.Run(() => handler.OnTransition(CircuitState));
+                Task.Run(() => handler.OnTransition(new MessagePumpCircuitStateChange(JobId, oldState, newState)));
             }
         }
 

--- a/src/Arcus.Messaging.Pumps.Abstractions/Resiliency/IMessagePumpCircuitBreaker.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/Resiliency/IMessagePumpCircuitBreaker.cs
@@ -34,18 +34,18 @@ namespace Arcus.Messaging.Pumps.Abstractions.Resiliency
         /// Notifies the application on a change in the message pump's circuit breaker state.
         /// </summary>
         /// <param name="args">The change in the circuit breaker state for a message pump.</param>
-        void OnTransition(MessagePumpCircuitStateChangeEventArgs args);
+        void OnTransition(MessagePumpCircuitStateChangedEventArgs args);
     }
 
     /// <summary>
     /// Represents a change event of the <see cref="MessagePumpCircuitState"/> in a <see cref="MessagePump"/>.
     /// </summary>
-    public class MessagePumpCircuitStateChangeEventArgs
+    public class MessagePumpCircuitStateChangedEventArgs
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="MessagePumpCircuitStateChangeEventArgs" /> class.
+        /// Initializes a new instance of the <see cref="MessagePumpCircuitStateChangedEventArgs" /> class.
         /// </summary>
-        internal MessagePumpCircuitStateChangeEventArgs(
+        internal MessagePumpCircuitStateChangedEventArgs(
             string jobId,
             MessagePumpCircuitState oldState,
             MessagePumpCircuitState newState)

--- a/src/Arcus.Messaging.Pumps.Abstractions/Resiliency/IMessagePumpCircuitBreaker.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/Resiliency/IMessagePumpCircuitBreaker.cs
@@ -33,8 +33,47 @@ namespace Arcus.Messaging.Pumps.Abstractions.Resiliency
         /// <summary>
         /// Notifies the application on a change in the message pump's circuit breaker state.
         /// </summary>
-        /// <param name="newState">The new circuit breaker state in which the message pump is currently running on.</param>
-        void OnTransition(MessagePumpCircuitState newState);
+        /// <param name="change">The change in the circuit breaker state for a message pump.</param>
+        void OnTransition(MessagePumpCircuitStateChange change);
+    }
+
+    /// <summary>
+    /// Represents a change event of the <see cref="MessagePumpCircuitState"/> in a <see cref="MessagePump"/>.
+    /// </summary>
+    public class MessagePumpCircuitStateChange
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessagePumpCircuitStateChange" /> class.
+        /// </summary>
+        internal MessagePumpCircuitStateChange(
+            string jobId,
+            MessagePumpCircuitState oldState,
+            MessagePumpCircuitState newState)
+        {
+            if (string.IsNullOrWhiteSpace(jobId))
+            {
+                throw new ArgumentException("Requires a non-blank job ID for the circuit breaker event state change registration", nameof(jobId));
+            }
+
+            JobId = jobId;
+            OldState = oldState;
+            NewState = newState;
+        }
+
+        /// <summary>
+        /// Gets the unique ID to distinguish the linked message pump that had it circuit breaker state changed.
+        /// </summary>
+        public string JobId { get; }
+
+        /// <summary>
+        /// Gets the original circuit breaker state the linked message pump was in.
+        /// </summary>
+        public MessagePumpCircuitState OldState { get; }
+
+        /// <summary>
+        /// Gets the current circuit breaker state the linked message pump is in.
+        /// </summary>
+        public MessagePumpCircuitState NewState { get; }
     }
 
     /// <summary>

--- a/src/Arcus.Messaging.Pumps.Abstractions/Resiliency/IMessagePumpCircuitBreaker.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/Resiliency/IMessagePumpCircuitBreaker.cs
@@ -33,19 +33,19 @@ namespace Arcus.Messaging.Pumps.Abstractions.Resiliency
         /// <summary>
         /// Notifies the application on a change in the message pump's circuit breaker state.
         /// </summary>
-        /// <param name="change">The change in the circuit breaker state for a message pump.</param>
-        void OnTransition(MessagePumpCircuitStateChange change);
+        /// <param name="args">The change in the circuit breaker state for a message pump.</param>
+        void OnTransition(MessagePumpCircuitStateChangeEventArgs args);
     }
 
     /// <summary>
     /// Represents a change event of the <see cref="MessagePumpCircuitState"/> in a <see cref="MessagePump"/>.
     /// </summary>
-    public class MessagePumpCircuitStateChange
+    public class MessagePumpCircuitStateChangeEventArgs
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="MessagePumpCircuitStateChange" /> class.
+        /// Initializes a new instance of the <see cref="MessagePumpCircuitStateChangeEventArgs" /> class.
         /// </summary>
-        internal MessagePumpCircuitStateChange(
+        internal MessagePumpCircuitStateChangeEventArgs(
             string jobId,
             MessagePumpCircuitState oldState,
             MessagePumpCircuitState newState)

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/Fixture/MockCircuitBreakerEventHandler.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/Fixture/MockCircuitBreakerEventHandler.cs
@@ -13,13 +13,13 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump.Fixture
     /// </summary>
     internal class MockCircuitBreakerEventHandler : ICircuitBreakerEventHandler
     {
-        private readonly Collection<MessagePumpCircuitStateChangeEventArgs> _states = new();
+        private readonly Collection<MessagePumpCircuitStateChangedEventArgs> _states = new();
 
         /// <summary>
         /// Notifies the application on a change in the message pump's circuit breaker state.
         /// </summary>
         /// <param name="args">The change in the circuit breaker state for a message pump.</param>
-        public void OnTransition(MessagePumpCircuitStateChangeEventArgs args)
+        public void OnTransition(MessagePumpCircuitStateChangedEventArgs args)
         {
             _states.Add(args);
         }

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/Fixture/MockCircuitBreakerEventHandler.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/Fixture/MockCircuitBreakerEventHandler.cs
@@ -13,15 +13,15 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump.Fixture
     /// </summary>
     internal class MockCircuitBreakerEventHandler : ICircuitBreakerEventHandler
     {
-        private readonly Collection<MessagePumpCircuitStateChange> _states = new();
+        private readonly Collection<MessagePumpCircuitStateChangeEventArgs> _states = new();
 
         /// <summary>
         /// Notifies the application on a change in the message pump's circuit breaker state.
         /// </summary>
-        /// <param name="change">The change in the circuit breaker state for a message pump.</param>
-        public void OnTransition(MessagePumpCircuitStateChange change)
+        /// <param name="args">The change in the circuit breaker state for a message pump.</param>
+        public void OnTransition(MessagePumpCircuitStateChangeEventArgs args)
         {
-            _states.Add(change);
+            _states.Add(args);
         }
 
         /// <summary>

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePump.ResiliencyTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePump.ResiliencyTests.cs
@@ -62,8 +62,8 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             await producer.ProduceAsync(messageAfterBreak);
             await messageSink.ShouldReceiveOrdersAfterBreakAsync(messageAfterBreak.MessageId);
 
-            mockEventHandler1.ShouldTransitionCorrectly();
-            mockEventHandler2.ShouldTransitionCorrectly();
+            await mockEventHandler1.ShouldTransitionedCorrectlyAsync();
+            await mockEventHandler2.ShouldTransitionedCorrectlyAsync();
         }
 
         [Fact]
@@ -99,8 +99,8 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             await producer.ProduceAsync(messageAfterBreak);
             await messageSink.ShouldReceiveOrdersAfterBreakAsync(messageAfterBreak.MessageId);
 
-            mockEventHandler1.ShouldTransitionCorrectly();
-            mockEventHandler2.ShouldTransitionCorrectly();
+            await mockEventHandler1.ShouldTransitionedCorrectlyAsync();
+            await mockEventHandler2.ShouldTransitionedCorrectlyAsync();
         }
 
         private async Task<TemporaryTopicSubscription> CreateTopicSubscriptionForMessageAsync(params ServiceBusMessage[] messages)


### PR DESCRIPTION
Because the `ICircuitBreakerEventHandler` implementations only took `MessagePumpCircuitState` during the transition of circuit breaker states, there was no easy way to know 1) for which message pump the state was changed and 2) what the original state was.

This PR wraps this information in an additional type.