### PR TITLE
chore(deps): upgrade arcus.testing to v1.2 in unit tests

### DIFF
--- a/src/Arcus.Messaging.Tests.Unit/Arcus.Messaging.Tests.Unit.csproj
+++ b/src/Arcus.Messaging.Tests.Unit/Arcus.Messaging.Tests.Unit.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Arcus.Security.Core" Version="2.0.0" />
     <PackageReference Include="Arcus.Testing.Security.Providers.InMemory" Version="0.5.0" />
-    <PackageReference Include="Arcus.Testing.Logging" Version="0.5.0" />
+    <PackageReference Include="Arcus.Testing.Logging.Xunit" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />

--- a/src/Arcus.Messaging.Tests.Unit/EventHubs/EventHubProducerClientExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/EventHubs/EventHubProducerClientExtensionsTests.cs
@@ -7,7 +7,7 @@ using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Tests.Core.Generators;
 using Arcus.Messaging.Tests.Core.Messages.v1;
 using Arcus.Messaging.Tests.Unit.EventHubs.Fixture;
-using Arcus.Testing.Logging;
+using Arcus.Testing;
 using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Producer;
 using Azure.Messaging.ServiceBus;
@@ -34,12 +34,12 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             var logger = new InMemoryLogger();
 
             // Act
-           await spySender.SendAsync(expectedOrders, correlation, logger);
+            await spySender.SendAsync(expectedOrders, correlation, logger);
 
             // Assert
             AssertDependencyTelemetry(logger);
             Assert.All(
-                spySender.Messages.Zip(expectedOrders), 
+                spySender.Messages.Zip(expectedOrders),
                 item => AssertEnrichedEventData(item.First, item.Second, correlation));
         }
 
@@ -59,7 +59,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             // Assert
             AssertDependencyTelemetry(logger, dependencyId);
             Assert.All(
-                spySender.Messages.Zip(expectedOrders), 
+                spySender.Messages.Zip(expectedOrders),
                 item => AssertEnrichedEventDataWithDependencyId(item.First, item.Second, correlation, dependencyId));
         }
 
@@ -79,7 +79,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             // Assert
             AssertDependencyTelemetry(logger);
             Assert.All(
-                spySender.Messages.Zip(expectedOrders), 
+                spySender.Messages.Zip(expectedOrders),
                 item => AssertEnrichedEventData(item.First, item.Second, correlation, transactionIdPropertyName: transactionIdPropertyName));
         }
 
@@ -99,7 +99,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             // Assert
             AssertDependencyTelemetry(logger);
             Assert.All(
-                spySender.Messages.Zip(expectedOrders), 
+                spySender.Messages.Zip(expectedOrders),
                 item => AssertEnrichedEventData(item.First, item.Second, correlation, operationParentPropertyName: upstreamServicePropertyName));
         }
 
@@ -122,7 +122,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             Assert.Contains(key, logMessage);
             Assert.Contains(value, logMessage);
             Assert.All(
-                spySender.Messages.Zip(expectedOrders), 
+                spySender.Messages.Zip(expectedOrders),
                 item => AssertEnrichedEventData(item.First, item.Second, correlation));
         }
 
@@ -143,7 +143,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             // Assert
             AssertDependencyTelemetry(logger);
             Assert.All(
-                spySender.Messages.Zip(expectedOrders), 
+                spySender.Messages.Zip(expectedOrders),
                 item => AssertEnrichedEventData(item.First, item.Second, correlation));
         }
 
@@ -165,7 +165,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             // Assert
             AssertDependencyTelemetry(logger, dependencyId);
             Assert.All(
-                spySender.Messages.Zip(expectedOrders), 
+                spySender.Messages.Zip(expectedOrders),
                 item => AssertEnrichedEventDataWithDependencyId(item.First, item.Second, correlation, dependencyId));
         }
 
@@ -187,7 +187,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             // Assert
             AssertDependencyTelemetry(logger);
             Assert.All(
-                spySender.Messages.Zip(expectedOrders), 
+                spySender.Messages.Zip(expectedOrders),
                 item => AssertEnrichedEventData(item.First, item.Second, correlation, transactionIdPropertyName: transactionIdPropertyName));
         }
 
@@ -209,7 +209,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             // Assert
             AssertDependencyTelemetry(logger);
             Assert.All(
-                spySender.Messages.Zip(expectedOrders), 
+                spySender.Messages.Zip(expectedOrders),
                 item => AssertEnrichedEventData(item.First, item.Second, correlation, operationParentPropertyName: upstreamServicePropertyName));
         }
 
@@ -234,7 +234,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             Assert.Contains(key, logMessage);
             Assert.Contains(value, logMessage);
             Assert.All(
-                spySender.Messages.Zip(expectedOrders), 
+                spySender.Messages.Zip(expectedOrders),
                 item => AssertEnrichedEventData(item.First, item.Second, correlation));
         }
 
@@ -291,7 +291,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             Assert.Equal(correlation.TransactionId, Assert.Contains(transactionIdPropertyName, message.Properties));
             Assert.Equal(dependencyId, Assert.Contains(operationParentIdPropertyName, message.Properties));
         }
-        
+
         [Fact]
         public async Task SendMessagesBodyWithoutOptions_WithoutMessageBody_Fails()
         {
@@ -299,7 +299,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             var sender = Mock.Of<EventHubProducerClient>();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendAsync(eventBatch: (IEnumerable<object>) null, correlation, logger));
@@ -312,7 +312,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             var sender = Mock.Of<EventHubProducerClient>();
             var order = OrderGenerator.Generate();
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendAsync(new[] { order }, correlationInfo: null, logger));
@@ -325,7 +325,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             var sender = Mock.Of<EventHubProducerClient>();
             var order = OrderGenerator.Generate();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendAsync(new[] { order }, correlation, logger: null));
@@ -338,7 +338,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             var sender = Mock.Of<EventHubProducerClient>();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendAsync(eventBatch: (IEnumerable<object>) null, correlation, logger, options => { }));
@@ -351,7 +351,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             var sender = Mock.Of<EventHubProducerClient>();
             var order = OrderGenerator.Generate();
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendAsync(new[] { order }, correlationInfo: null, logger, options => { }));
@@ -364,7 +364,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             var sender = Mock.Of<EventHubProducerClient>();
             var order = OrderGenerator.Generate();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendAsync(new[] { order }, correlation, logger: null, options => { }));
@@ -377,7 +377,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             var sender = Mock.Of<EventHubProducerClient>();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendAsync(eventBatch: null, correlation, logger));
@@ -390,7 +390,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             var sender = Mock.Of<EventHubProducerClient>();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendAsync(eventBatch: null, correlation, logger, options => { }));
@@ -403,7 +403,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             var sender = Mock.Of<EventHubProducerClient>();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendAsync(eventBatch: null, correlation, logger));
@@ -416,7 +416,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             var sender = Mock.Of<EventHubProducerClient>();
             var order = ServiceBusMessageBuilder.CreateForBody(OrderGenerator.Generate()).Build();
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendAsync(new[] { order }, correlationInfo: null, logger));
@@ -429,7 +429,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             var sender = Mock.Of<EventHubProducerClient>();
             var order = ServiceBusMessageBuilder.CreateForBody(OrderGenerator.Generate()).Build();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendAsync(new[] { order }, correlation, logger: null));
@@ -442,7 +442,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             var sender = Mock.Of<EventHubProducerClient>();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendAsync(eventBatch: null, correlation, logger, options => { }));
@@ -455,7 +455,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             var sender = Mock.Of<EventHubProducerClient>();
             var order = ServiceBusMessageBuilder.CreateForBody(OrderGenerator.Generate()).Build();
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendAsync(new[] { order }, correlationInfo: null, logger, options => { }));
@@ -468,7 +468,7 @@ namespace Arcus.Messaging.Tests.Unit.EventHubs
             var sender = Mock.Of<EventHubProducerClient>();
             var order = ServiceBusMessageBuilder.CreateForBody(OrderGenerator.Generate()).Build();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendAsync(new[] { order }, correlation, logger: null, options => { }));

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/MessageHandlerTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/MessageHandlerTests.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.MessageHandling;
 using Arcus.Messaging.Tests.Unit.Fixture;
-using Arcus.Testing.Logging;
+using Arcus.Testing;
 using Bogus;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -310,7 +310,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling
             // Assert
             MessageHandler messageHandler = Assert.Single(messageHandlers);
             Assert.NotNull(messageHandler);
-            
+
             var context = TestMessageContext.Generate();
             Assert.Equal(matchesContext, messageHandler.CanProcessMessageBasedOnContext(messageContext: context));
         }
@@ -337,7 +337,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling
             // Assert
             MessageHandler messageHandler = Assert.Single(messageHandlers);
             Assert.NotNull(messageHandler);
-            
+
             var context = TestMessageContext.Generate();
             Assert.Equal(matchesContext, messageHandler.CanProcessMessageBasedOnContext(messageContext: context));
             Assert.Equal(matchesBody, messageHandler.CanProcessMessageBasedOnMessage(new TestMessage()));
@@ -354,7 +354,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling
             collection.WithMessageHandler<StubTestMessageHandler<TestMessage, MessageContext>, TestMessage>();
 
             IServiceProvider serviceProvider = collection.Services.BuildServiceProvider();
-            
+
             // Act
             IEnumerable<MessageHandler> messageHandlers = MessageHandler.SubtractFrom(serviceProvider, _logger);
 
@@ -411,7 +411,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling
 
             var purchase = new Purchase
             {
-                CustomerName = _bogusGenerator.Name.FullName(), 
+                CustomerName = _bogusGenerator.Name.FullName(),
                 Price = _bogusGenerator.Commerce.Price()
             };
             string purchaseJson = JsonConvert.SerializeObject(purchase);
@@ -424,17 +424,17 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling
             // Assert
             Assert.True(spyHandler.IsProcessed);
         }
-        
+
         [Fact]
         public void WithMultipleMessageHandlers_WithSameMessageType_RegistersBoth()
         {
             // Arrange
             var services = new MessageHandlerCollection(new ServiceCollection());
             services.WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(message => message.TestProperty == "Some value");
-            
+
             // Act
             services.WithMessageHandler<TestMessageHandler, TestMessage, TestMessageContext>(message => message.TestProperty == "Some other value");
-            
+
             // Assert
             IServiceProvider provider = services.Services.BuildServiceProvider();
             IEnumerable<MessageHandler> handlers = MessageHandler.SubtractFrom(provider, NullLogger.Instance);

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/AzureServiceBusMessageRouterTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/AzureServiceBusMessageRouterTests.cs
@@ -14,7 +14,7 @@ using Arcus.Messaging.Tests.Core.Messages.v2;
 using Arcus.Messaging.Tests.Unit.Fixture;
 using Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus.Stubs;
 using Arcus.Messaging.Tests.Workers.MessageHandlers;
-using Arcus.Testing.Logging;
+using Arcus.Testing;
 using Azure.Messaging.ServiceBus;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -125,7 +125,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
             var spyHandler = new StubServiceBusMessageHandler<Order>();
             collection.WithServiceBusMessageHandler<StubServiceBusMessageHandler<Order>, Order>(serviceProvider => spyHandler)
                       .WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(serviceProvider => ignoredHandler);
-            
+
             // Act
             services.AddServiceBusMessageRouting();
 
@@ -339,7 +339,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
             var expectedMessage = new TestMessage { TestProperty = "Some value" };
             string expectedBody = JsonConvert.SerializeObject(expectedMessage);
             var serializer = new TestMessageBodySerializer(expectedBody, OrderGenerator.Generate());
-            
+
             collection.WithServiceBusMessageHandler<StubServiceBusMessageHandler<Order>, Order>(
                           messageContextFilter: ctx => ctx != null,
                           messageBodyFilter: body => body != null,
@@ -349,7 +349,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
                           messageBodyFilter: body => body is null,
                           implementationFactory: serviceProvider => ignoredHandler2)
                       .WithServiceBusMessageHandler<StubServiceBusMessageHandler<Order>, Order>(
-                          messageBodySerializer: serializer, 
+                          messageBodySerializer: serializer,
                           messageBodyFilter: body => body.Customer != null,
                           messageContextFilter: ctx => ctx.MessageId.StartsWith("message-id"),
                           implementationFactory: serviceProvider => spyHandler)
@@ -381,11 +381,11 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
             var services = new ServiceCollection();
             var collection = new ServiceBusMessageHandlerCollection(services);
             collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>();
-            
+
             // Act
             services.AddServiceBusMessageRouting(serviceProvider =>
                 new TestAzureServiceBusMessageRouter(serviceProvider, NullLogger.Instance));
-            
+
             // Assert
             IServiceProvider provider = services.BuildServiceProvider();
             Assert.IsType<TestAzureServiceBusMessageRouter>(provider.GetRequiredService<IAzureServiceBusMessageRouter>());
@@ -404,10 +404,10 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
             var messageHandlerV2 = new OrderV2AzureServiceBusMessageHandler();
             collection.WithServiceBusMessageHandler<OrderV1AzureServiceBusMessageHandler, Order>(provider => messageHandlerV1)
                       .WithServiceBusMessageHandler<OrderV2AzureServiceBusMessageHandler, OrderV2>(provider => messageHandlerV2);
-            
+
             // Act
             services.AddServiceBusMessageRouting(options => options.Deserialization.AdditionalMembers = additionalMemberHandling);
-            
+
             // Assert
             IServiceProvider serviceProvider = services.BuildServiceProvider();
             var router = serviceProvider.GetRequiredService<IAzureServiceBusMessageRouter>();
@@ -417,7 +417,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
             AzureServiceBusMessageContext context = AzureServiceBusMessageContextFactory.Generate();
             var correlationInfo = new MessageCorrelationInfo("operation-id", "transaction-id");
             await router.RouteMessageAsync(message, context, correlationInfo, CancellationToken.None);
-            
+
             Assert.Equal(additionalMemberHandling is AdditionalMemberHandling.Error, messageHandlerV2.IsProcessed);
             Assert.Equal(additionalMemberHandling is AdditionalMemberHandling.Ignore, messageHandlerV1.IsProcessed);
         }
@@ -431,7 +431,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
 
             var spyOrderV1MessageHandler = new OrderV1AzureServiceBusMessageHandler();
             var spyOrderV2MessageHandler = new OrderV2AzureServiceBusMessageHandler();
-            
+
             collection.WithServiceBusMessageHandler<OrderV1AzureServiceBusMessageHandler, Order>(messageBodyFilter: order => order.ArticleNumber == "NotExisting")
                       .WithServiceBusMessageHandler<OrderV2AzureServiceBusMessageHandler, OrderV2>(implementationFactory: provider => spyOrderV2MessageHandler)
                       .WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>()
@@ -440,7 +440,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
                       .WithServiceBusMessageHandler<OrderV1AzureServiceBusMessageHandler, Order>();
 
             services.AddServiceBusMessageRouting();
-            
+
             // Assert
             IServiceProvider serviceProvider = services.BuildServiceProvider();
             var router = serviceProvider.GetRequiredService<IAzureServiceBusMessageRouter>();
@@ -452,7 +452,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
                           {
                               var orderV1 = OrderGenerator.Generate().AsServiceBusReceivedMessage();
                               var orderV2 = OrderV2Generator.Generate().AsServiceBusReceivedMessage();
-                              return new[] {orderV1, orderV2};
+                              return new[] { orderV1, orderV2 };
                           });
 
             foreach (ServiceBusReceivedMessage message in messages)
@@ -466,7 +466,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
                     new MessageCorrelationInfo($"operation-{Guid.NewGuid()}", $"transaction-{Guid.NewGuid()}"),
                     CancellationToken.None);
             }
-            
+
             Assert.Equal(messageCount, spyOrderV1MessageHandler.ProcessedMessages.Length);
             Assert.Equal(messageCount, spyOrderV2MessageHandler.ProcessedMessages.Length);
         }

--- a/src/Arcus.Messaging.Tests.Unit/MessagePump/DefaultMessagePumpCircuitBreakerTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessagePump/DefaultMessagePumpCircuitBreakerTests.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 using Arcus.Messaging.Pumps.Abstractions.Resiliency;
 using Arcus.Messaging.Tests.Unit.MessagePump.Fixture;
-using Arcus.Testing.Logging;
+using Arcus.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -44,7 +44,7 @@ namespace Arcus.Messaging.Tests.Unit.MessagePump
         {
             // Arrange
             var services = new ServiceCollection();
-            services.AddMessagePump(p => (Pumps.Abstractions.MessagePump)new TestMessagePump("same-job-id", Mock.Of<IConfiguration>(), p, _logger));
+            services.AddMessagePump(p => (Pumps.Abstractions.MessagePump) new TestMessagePump("same-job-id", Mock.Of<IConfiguration>(), p, _logger));
             services.AddMessagePump(p => new TestMessagePump("same-job-id", Mock.Of<IConfiguration>(), p, _logger));
             IServiceProvider provider = services.BuildServiceProvider();
 

--- a/src/Arcus.Messaging.Tests.Unit/MessagePump/DefaultMessagePumpLifetimeTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessagePump/DefaultMessagePumpLifetimeTests.cs
@@ -3,7 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Arcus.Messaging.Pumps.Abstractions;
 using Arcus.Messaging.Tests.Unit.MessagePump.Fixture;
-using Arcus.Testing.Logging;
+using Arcus.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;

--- a/src/Arcus.Messaging.Tests.Unit/ServiceBus/ServiceBusSenderExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/ServiceBus/ServiceBusSenderExtensionsTests.cs
@@ -6,7 +6,7 @@ using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Tests.Core.Generators;
 using Arcus.Messaging.Tests.Core.Messages.v1;
 using Arcus.Messaging.Tests.Unit.ServiceBus.Fixture;
-using Arcus.Testing.Logging;
+using Arcus.Testing;
 using Azure.Messaging.ServiceBus;
 using Bogus;
 using Moq;
@@ -114,7 +114,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             // Assert
             AssertDependencyTelemetry(logger);
             Assert.All(
-                spySender.Messages.Zip(expectedOrders), 
+                spySender.Messages.Zip(expectedOrders),
                 item => AssertEnrichedServiceBusMessage(item.First, item.Second, correlation));
         }
 
@@ -134,7 +134,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             // Assert
             AssertDependencyTelemetry(logger, dependencyId);
             Assert.All(
-                spySender.Messages.Zip(expectedOrders), 
+                spySender.Messages.Zip(expectedOrders),
                 item => AssertEnrichedServiceBusMessageWithDependencyId(item.First, item.Second, correlation, dependencyId));
         }
 
@@ -154,7 +154,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             // Assert
             AssertDependencyTelemetry(logger);
             Assert.All(
-                spySender.Messages.Zip(expectedOrders), 
+                spySender.Messages.Zip(expectedOrders),
                 item => AssertEnrichedServiceBusMessage(item.First, item.Second, correlation, transactionIdPropertyName: transactionIdPropertyName));
         }
 
@@ -174,11 +174,11 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             // Assert
             AssertDependencyTelemetry(logger);
             Assert.All(
-                spySender.Messages.Zip(expectedOrders), 
+                spySender.Messages.Zip(expectedOrders),
                 item => AssertEnrichedServiceBusMessage(item.First, item.Second, correlation, operationParentPropertyName: upstreamServicePropertyName));
         }
 
-         [Fact]
+        [Fact]
         public async Task SendMessageWithoutOptions_WithMessageCorrelation_Succeeds()
         {
             // Arrange
@@ -250,7 +250,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var spySender = new InMemoryServiceBusSender();
             var expectedOrder = OrderGenerator.Generate();
             var expected = ServiceBusMessageBuilder.CreateForBody(expectedOrder).Build();
-            
+
             var upstreamServicePropertyName = "My-UpstreamService-Id";
             MessageCorrelationInfo correlation = GenerateMessageCorrelationInfo();
             var logger = new InMemoryLogger();
@@ -282,7 +282,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             // Assert
             AssertDependencyTelemetry(logger);
             Assert.All(
-                spySender.Messages.Zip(expectedOrders), 
+                spySender.Messages.Zip(expectedOrders),
                 item => AssertEnrichedServiceBusMessage(item.First, item.Second, correlation));
         }
 
@@ -304,7 +304,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             // Assert
             AssertDependencyTelemetry(logger, dependencyId);
             Assert.All(
-                spySender.Messages.Zip(expectedOrders), 
+                spySender.Messages.Zip(expectedOrders),
                 item => AssertEnrichedServiceBusMessageWithDependencyId(item.First, item.Second, correlation, dependencyId));
         }
 
@@ -326,7 +326,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             // Assert
             AssertDependencyTelemetry(logger);
             Assert.All(
-                spySender.Messages.Zip(expectedOrders), 
+                spySender.Messages.Zip(expectedOrders),
                 item => AssertEnrichedServiceBusMessage(item.First, item.Second, correlation, transactionIdPropertyName: transactionIdPropertyName));
         }
 
@@ -348,7 +348,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             // Assert
             AssertDependencyTelemetry(logger);
             Assert.All(
-                spySender.Messages.Zip(expectedOrders), 
+                spySender.Messages.Zip(expectedOrders),
                 item => AssertEnrichedServiceBusMessage(item.First, item.Second, correlation, operationParentPropertyName: upstreamServicePropertyName));
         }
 
@@ -379,7 +379,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             Assert.Contains(key2, logMessage);
             Assert.Contains(value2, logMessage);
             Assert.All(
-                spySender.Messages.Zip(expectedOrders), 
+                spySender.Messages.Zip(expectedOrders),
                 item => AssertEnrichedServiceBusMessage(item.First, item.Second, correlation));
         }
 
@@ -444,7 +444,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var sender = Mock.Of<ServiceBusSender>();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendMessageAsync(messageBody: null, correlation, logger));
@@ -457,7 +457,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var sender = Mock.Of<ServiceBusSender>();
             var order = OrderGenerator.Generate();
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendMessageAsync(order, correlationInfo: null, logger));
@@ -470,7 +470,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var sender = Mock.Of<ServiceBusSender>();
             var order = OrderGenerator.Generate();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendMessageAsync(order, correlation, logger: null));
@@ -483,7 +483,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var sender = Mock.Of<ServiceBusSender>();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendMessageAsync(messageBody: null, correlation, logger, options => { }));
@@ -496,7 +496,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var sender = Mock.Of<ServiceBusSender>();
             var order = OrderGenerator.Generate();
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendMessageAsync(order, correlationInfo: null, logger, options => { }));
@@ -509,7 +509,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var sender = Mock.Of<ServiceBusSender>();
             var order = OrderGenerator.Generate();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendMessageAsync(order, correlation, logger: null, options => { }));
@@ -522,7 +522,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var sender = Mock.Of<ServiceBusSender>();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendMessagesAsync(messageBodies: null, correlation, logger));
@@ -535,7 +535,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var sender = Mock.Of<ServiceBusSender>();
             var order = OrderGenerator.Generate();
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendMessagesAsync(new[] { order }, correlationInfo: null, logger));
@@ -548,7 +548,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var sender = Mock.Of<ServiceBusSender>();
             var order = OrderGenerator.Generate();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendMessagesAsync(new[] { order }, correlation, logger: null));
@@ -561,7 +561,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var sender = Mock.Of<ServiceBusSender>();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendMessagesAsync(messageBodies: null, correlation, logger, options => { }));
@@ -574,7 +574,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var sender = Mock.Of<ServiceBusSender>();
             var order = OrderGenerator.Generate();
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendMessagesAsync(new[] { order }, correlationInfo: null, logger, options => { }));
@@ -587,7 +587,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var sender = Mock.Of<ServiceBusSender>();
             var order = OrderGenerator.Generate();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendMessagesAsync(new[] { order }, correlation, logger: null, options => { }));
@@ -600,7 +600,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var sender = Mock.Of<ServiceBusSender>();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendMessageAsync(message: null, correlation, logger));
@@ -613,7 +613,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var sender = Mock.Of<ServiceBusSender>();
             var order = ServiceBusMessageBuilder.CreateForBody(OrderGenerator.Generate()).Build();
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendMessageAsync(order, correlationInfo: null, logger));
@@ -626,7 +626,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var sender = Mock.Of<ServiceBusSender>();
             var order = ServiceBusMessageBuilder.CreateForBody(OrderGenerator.Generate()).Build();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendMessageAsync(order, correlation, logger: null));
@@ -639,7 +639,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var sender = Mock.Of<ServiceBusSender>();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendMessageAsync(message: null, correlation, logger, options => { }));
@@ -652,7 +652,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var sender = Mock.Of<ServiceBusSender>();
             var order = ServiceBusMessageBuilder.CreateForBody(OrderGenerator.Generate()).Build();
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendMessageAsync(order, correlationInfo: null, logger, options => { }));
@@ -665,7 +665,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var sender = Mock.Of<ServiceBusSender>();
             var order = ServiceBusMessageBuilder.CreateForBody(OrderGenerator.Generate()).Build();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendMessageAsync(order, correlation, logger: null, options => { }));
@@ -678,7 +678,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var sender = Mock.Of<ServiceBusSender>();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendMessagesAsync(messages: null, correlation, logger));
@@ -691,7 +691,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var sender = Mock.Of<ServiceBusSender>();
             var order = ServiceBusMessageBuilder.CreateForBody(OrderGenerator.Generate()).Build();
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendMessagesAsync(new[] { order }, correlationInfo: null, logger));
@@ -704,7 +704,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var sender = Mock.Of<ServiceBusSender>();
             var order = ServiceBusMessageBuilder.CreateForBody(OrderGenerator.Generate()).Build();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendMessagesAsync(new[] { order }, correlation, logger: null));
@@ -717,7 +717,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var sender = Mock.Of<ServiceBusSender>();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendMessagesAsync(messages: null, correlation, logger, options => { }));
@@ -730,7 +730,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var sender = Mock.Of<ServiceBusSender>();
             var order = ServiceBusMessageBuilder.CreateForBody(OrderGenerator.Generate()).Build();
             var logger = new InMemoryLogger();
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendMessagesAsync(new[] { order }, correlationInfo: null, logger, options => { }));
@@ -743,7 +743,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             var sender = Mock.Of<ServiceBusSender>();
             var order = ServiceBusMessageBuilder.CreateForBody(OrderGenerator.Generate()).Build();
             var correlation = new MessageCorrelationInfo("operation ID", "transaction ID", "parent ID");
-            
+
             // Act
             await Assert.ThrowsAnyAsync<ArgumentException>(
                 () => sender.SendMessagesAsync(new[] { order }, correlation, logger: null, options => { }));


### PR DESCRIPTION
The unit test project was still using the older `Arcus.Testing` library to tracking logs in the test output.

This PR upgrades the unit test project to the new xUnit-specific logging package: `Arcus.Testing.Logging.Xunit`.