### PR TITLE
fix(service-bus): remove invalid flags attribute on topic subscription

### DIFF
--- a/src/Arcus.Messaging.Pumps.ServiceBus/TopicSubscription.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/TopicSubscription.cs
@@ -1,11 +1,8 @@
-﻿using System;
-
-namespace Arcus.Messaging.Pumps.ServiceBus
+﻿namespace Arcus.Messaging.Pumps.ServiceBus
 {
     /// <summary>
     /// Represents the option to control the topic subscription existence during the lifecycle of the <see cref="AzureServiceBusMessagePump"/>.
     /// </summary>
-    [Flags]
     public enum TopicSubscription
     {
         /// <summary>


### PR DESCRIPTION
The `TopicSubscription` invalidly had the `[Flags]` attribute, which would indicate that the enumeration members could be used in combination with one another - which is not correct.

This PR removes the `[Flags]` attribute, making the intend of the enumeration more clear. 