### PR TITLE
chore(deprecate): hierarchical message correlation format

### DIFF
--- a/docs/preview/02-Features/02-message-handling/01-service-bus.md
+++ b/docs/preview/02-Features/02-message-handling/01-service-bus.md
@@ -435,10 +435,6 @@ public class Startup
                 // this job instance in a multi-instance deployment (default: guid).
                 options.JobId = Guid.NewGuid().ToString();
 
-                // The format of the message correlation used when receiving Azure Service Bus messages.
-                // (default: W3C).
-                options.Routing.Correlation.Format = MessageCorrelationFormat.Hierarchical;
-
                 // The name of the operation used when tracking the request telemetry.
                 // (default: Process)
                 options.Routing.Correlation.OperationName = "Order";
@@ -490,10 +486,6 @@ public class Startup
                 // The unique identifier for this background job to distinguish 
                 // this job instance in a multi-instance deployment (default: guid).
                 options.JobId = Guid.NewGuid().ToString();
-
-                // The format of the message correlation used when receiving Azure Service Bus messages.
-                // (default: W3C).
-                options.Routing.Correlation.Format = MessageCorrelationFormat.Hierarchical;
 
                 // The name of the operation used when tracking the request telemetry.
                 // (default: Process)

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageCorrelationFormat.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageCorrelationFormat.cs
@@ -1,4 +1,8 @@
-﻿namespace Arcus.Messaging.Abstractions.MessageHandling
+﻿using System;
+
+#pragma warning disable S1133 // Disable usage of deprecated functionality until v3.0 is released.
+
+namespace Arcus.Messaging.Abstractions.MessageHandling
 {
     /// <summary>
     /// Represents the message correlation format of the received message.
@@ -13,6 +17,7 @@
         /// <summary>
         /// Uses the hierarchical message correlation system with Root-Id and Request-Id to represent parent-child relationship.
         /// </summary>
+        [Obsolete("Hierarchical correlation will be removed in v3.0")]
         Hierarchical
     }
 }

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageCorrelationOptions.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageCorrelationOptions.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 
+#pragma warning disable S1133 // Disable usage of deprecated functionality until v3.0 is released.
+
 namespace Arcus.Messaging.Abstractions.MessageHandling
 {
     /// <summary>
@@ -22,6 +24,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         ///     Only used when the <see cref="Format"/> is set to <see cref="MessageCorrelationFormat.Hierarchical"/>.
         /// </remarks>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="value"/> is blank.</exception>
+        [Obsolete("Will be removed in v3.0 as the property name is only used in the deprecated 'Hierarchical' correlation format")]
         public string TransactionIdPropertyName
         {
             get => _transactionIdPropertyName;
@@ -43,6 +46,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         ///     Only used when the <see cref="Format"/> is set to <see cref="MessageCorrelationFormat.Hierarchical"/>.
         /// </remarks>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="value"/> is blank.</exception>
+        [Obsolete("Will be removed in v3.0 as the property name is only used in the deprecated 'Hierarchical' correlation format")]
         public string OperationParentIdPropertyName
         {
             get => _operationParentIdPropertyName;

--- a/src/Arcus.Messaging.AzureFunctions.EventHubs/Extensions/FunctionContextExtensions.cs
+++ b/src/Arcus.Messaging.AzureFunctions.EventHubs/Extensions/FunctionContextExtensions.cs
@@ -7,6 +7,8 @@ using Arcus.Messaging.Abstractions.MessageHandling;
 using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.DependencyInjection;
 
+#pragma warning disable CS0618 // Deprecated functionality will be removed in v3.0.
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Azure.Functions.Worker
 {

--- a/src/Arcus.Messaging.AzureFunctions.ServiceBus/Extensions/FunctionContextExtensions.cs
+++ b/src/Arcus.Messaging.AzureFunctions.ServiceBus/Extensions/FunctionContextExtensions.cs
@@ -6,6 +6,8 @@ using Arcus.Messaging.Abstractions.MessageHandling;
 using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.DependencyInjection;
 
+#pragma warning disable CS0618 // Deprecated functionality will be removed in v3.0.
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Azure.Functions.Worker
 {

--- a/src/Arcus.Messaging.Pumps.EventHubs/AzureEventHubsMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.EventHubs/AzureEventHubsMessagePump.cs
@@ -14,6 +14,8 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
+#pragma warning disable CS0618 // Deprecated functionality will be removed in v3.0.
+
 namespace Arcus.Messaging.Pumps.EventHubs
 {
     /// <summary>

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -486,9 +486,11 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             }
 
             MessageCorrelationInfo correlationInfo =
+#pragma warning disable CS0618 // Type or member is obsolete: will be removed in v3.0, once the 'Hierarchical' correlation format is removed.
                 message.GetCorrelationInfo(
                     Settings.Options.Routing.Correlation?.TransactionIdPropertyName ?? PropertyNames.TransactionId,
                     Settings.Options.Routing.Correlation?.OperationParentIdPropertyName ?? PropertyNames.OperationParentId);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             return MessageCorrelationResult.Create(correlationInfo);
         }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusCorrelationOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusCorrelationOptions.cs
@@ -2,13 +2,15 @@
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.MessageHandling;
 
+#pragma warning disable S1133 // Disable usage of deprecated functionality until v3.0 is released.
+
 namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
 {
     /// <summary>
     /// Represents the user-configurable options to control the correlation information tracking
     /// during the receiving of the Azure Service Bus messages in the <see cref="AzureServiceBusMessagePump"/>.
     /// </summary>
-    [Obsolete("Will use the " + nameof(MessageCorrelationOptions) + " in the future")]
+    [Obsolete("Will be removed in v3.0 as the options model is only used in the deprecated 'Hierarchical' correlation format")]
     public class AzureServiceBusCorrelationOptions
     {
         private readonly MessageCorrelationOptions _correlationOptions;

--- a/src/Arcus.Messaging.ServiceBus.Core/Extensions/MessageExtensions.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/Extensions/MessageExtensions.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using Arcus.Messaging.Abstractions;
 using Azure.Messaging.ServiceBus;
 
+#pragma warning disable S1133 // Disable usage of deprecated functionality until v3.0 is released.
+
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Azure.ServiceBus
 {
@@ -59,7 +61,7 @@ namespace Microsoft.Azure.ServiceBus
         ///     otherwise both will be generated GUID's.
         /// </returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> is <c>null</c>.</exception>
-        [Obsolete("Use the 'GetCorrelationInfo' extension in the 'Azure.Messaging.ServiceBus' namespace, remove the 'Microsoft.Azure.ServiceBus' namespace from your using statements")]
+        [Obsolete("Will be removed in v3.0 as the extension on the Azure Service bus message is only used for the deprecated 'Hierarchical' correlation format")]
         public static MessageCorrelationInfo GetCorrelationInfo(this ServiceBusReceivedMessage message)
         {
             return GetCorrelationInfo(message, PropertyNames.TransactionId);
@@ -77,7 +79,7 @@ namespace Microsoft.Azure.ServiceBus
         /// </returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="transactionIdPropertyName"/> is blank.</exception>
-        [Obsolete("Use the 'GetCorrelationInfo' extension in the 'Azure.Messaging.ServiceBus' namespace, remove the 'Microsoft.Azure.ServiceBus' namespace from your using statements")]
+        [Obsolete("Will be removed in v3.0 as the extension on the Azure Service bus message is only used for the deprecated 'Hierarchical' correlation format")]
         public static MessageCorrelationInfo GetCorrelationInfo(this ServiceBusReceivedMessage message, string transactionIdPropertyName)
         {
             MessageCorrelationInfo messageCorrelationInfo =
@@ -101,7 +103,7 @@ namespace Microsoft.Azure.ServiceBus
         /// <exception cref="ArgumentException">
         ///     Thrown when the <paramref name="transactionIdPropertyName"/> or the <paramref name="operationParentIdPropertyName"/> is blank.
         /// </exception>
-        [Obsolete("Use the 'GetCorrelationInfo' extension in the 'Azure.Messaging.ServiceBus' namespace, remove the 'Microsoft.Azure.ServiceBus' namespace from your using statements")]
+        [Obsolete("Will be removed in v3.0 as the extension on the Azure Service bus message is only used for the deprecated 'Hierarchical' correlation format")]
         public static MessageCorrelationInfo GetCorrelationInfo(
             this ServiceBusReceivedMessage message,
             string transactionIdPropertyName,
@@ -161,7 +163,7 @@ namespace Microsoft.Azure.ServiceBus
         ///     The correlation transaction ID for message if an application property could be found with the key <see cref="PropertyNames.TransactionId"/>; <c>null</c> otherwise.
         /// </returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> is <c>null</c>.</exception>
-        [Obsolete("Use the 'GetTransactionId' extension in the 'Azure.Messaging.ServiceBus' namespace, remove the 'Microsoft.Azure.ServiceBus' namespace from your using statements")]
+        [Obsolete("Will be removed in v3.0 as the extension on the Azure Service bus message is only used for the deprecated 'Hierarchical' correlation format")]
         public static string GetTransactionId(this ServiceBusReceivedMessage message)
         {
             return GetTransactionId(message, PropertyNames.TransactionId);
@@ -177,7 +179,7 @@ namespace Microsoft.Azure.ServiceBus
         /// </returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="transactionIdPropertyName"/> is blank.</exception>
-        [Obsolete("Use the 'GetTransactionId' extension in the 'Azure.Messaging.ServiceBus' namespace, remove the 'Microsoft.Azure.ServiceBus' namespace from your using statements")]
+        [Obsolete("Will be removed in v3.0 as the extension on the Azure Service bus message is only used for the deprecated 'Hierarchical' correlation format")]
         public static string GetTransactionId(this ServiceBusReceivedMessage message, string transactionIdPropertyName)
         {
             if (message is null)

--- a/src/Arcus.Messaging.ServiceBus.Core/Extensions/ServiceBusReceivedMessageExtensions.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/Extensions/ServiceBusReceivedMessageExtensions.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using Arcus.Messaging.Abstractions;
 
+#pragma warning disable S1133 // Disable usage of deprecated functionality until v3.0 is released.
+
 // ReSharper disable once CheckNamespace
 namespace Azure.Messaging.ServiceBus
 {
@@ -61,6 +63,7 @@ namespace Azure.Messaging.ServiceBus
         ///     otherwise both will be generated GUID's.
         /// </returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as the extension on the Azure Service bus message is only used for the deprecated 'Hierarchical' correlation format")]
         public static MessageCorrelationInfo GetCorrelationInfo(this ServiceBusReceivedMessage message)
         {
             return GetCorrelationInfo(message, PropertyNames.TransactionId);
@@ -82,6 +85,7 @@ namespace Azure.Messaging.ServiceBus
         /// </returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="transactionIdPropertyName"/> is blank.</exception>
+        [Obsolete("Will be removed in v3.0 as the extension on the Azure Service bus message is only used for the deprecated 'Hierarchical' correlation format")]
         public static MessageCorrelationInfo GetCorrelationInfo(this ServiceBusReceivedMessage message, string transactionIdPropertyName)
         {
             MessageCorrelationInfo messageCorrelationInfo =
@@ -109,6 +113,7 @@ namespace Azure.Messaging.ServiceBus
         /// <exception cref="ArgumentException">
         ///     Thrown when the <paramref name="transactionIdPropertyName"/> or the <paramref name="operationParentIdPropertyName"/> is blank.
         /// </exception>
+        [Obsolete("Will be removed in v3.0 as the extension on the Azure Service bus message is only used for the deprecated 'Hierarchical' correlation format")]
         public static MessageCorrelationInfo GetCorrelationInfo(
             this ServiceBusReceivedMessage message,
             string transactionIdPropertyName,
@@ -137,6 +142,7 @@ namespace Azure.Messaging.ServiceBus
             return messageCorrelationInfo;
         }
 
+        [Obsolete("Will be removed in v3.0")]
         private static string DetermineTransactionId(ServiceBusReceivedMessage message, string transactionIdPropertyName)
         {
             string transactionId = GetTransactionId(message, transactionIdPropertyName);
@@ -172,6 +178,7 @@ namespace Azure.Messaging.ServiceBus
         ///     The correlation transaction ID for message if an application property could be found with the key <see cref="PropertyNames.TransactionId"/>; <c>null</c> otherwise.
         /// </returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as the extension on the Azure Service bus message is only used for the deprecated 'Hierarchical' correlation format")]
         public static string GetTransactionId(this ServiceBusReceivedMessage message)
         {
             return GetTransactionId(message, PropertyNames.TransactionId);
@@ -191,6 +198,7 @@ namespace Azure.Messaging.ServiceBus
         /// </returns>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="message"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="transactionIdPropertyName"/> is blank.</exception>
+        [Obsolete("Will be removed in v3.0 as the extension on the Azure Service bus message is only used for the deprecated 'Hierarchical' correlation format")]
         public static string GetTransactionId(this ServiceBusReceivedMessage message, string transactionIdPropertyName)
         {
             if (message is null)

--- a/src/Arcus.Messaging.ServiceBus.Core/Extensions/ServiceBusSenderExtensions.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/Extensions/ServiceBusSenderExtensions.cs
@@ -8,6 +8,8 @@ using Arcus.Observability.Correlation;
 using Arcus.Observability.Telemetry.Core;
 using Microsoft.Extensions.Logging;
 
+#pragma warning disable S1133 // Disable usage of deprecated functionality until v3.0 is released.
+
 // ReSharper disable once CheckNamespace
 namespace Azure.Messaging.ServiceBus
 {
@@ -31,6 +33,7 @@ namespace Azure.Messaging.ServiceBus
         ///   For more information on service limits, see
         ///   <see href="https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas#messaging-quotas" />.
         /// </exception>
+        [Obsolete("Will be removed in v3.0 as this extension on the Azure Service bus sender is only used in the deprecated 'Hierarchical' correlation format")]
         public static async Task SendMessageAsync(
             this ServiceBusSender sender,
             object messageBody,
@@ -57,6 +60,7 @@ namespace Azure.Messaging.ServiceBus
         ///   For more information on service limits, see
         ///   <see href="https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas#messaging-quotas" />.
         /// </exception>
+        [Obsolete("Will be removed in v3.0 as this extension on the Azure Service bus sender is only used in the deprecated 'Hierarchical' correlation format")]
         public static async Task SendMessageAsync(
             this ServiceBusSender sender,
             object messageBody,
@@ -66,6 +70,65 @@ namespace Azure.Messaging.ServiceBus
             CancellationToken cancellationToken = default(CancellationToken))
         {
             await SendMessagesAsync(sender, new[] { messageBody }, correlationInfo, logger, configureOptions, cancellationToken);
+        }
+
+        /// <summary>
+        ///   Sends a message to the associated entity of Service Bus.
+        /// </summary>
+        /// <param name="sender">The Azure Service Bus sender when sending the <paramref name="message"/></param>
+        /// <param name="message">The message to send.</param>
+        /// <param name="correlationInfo">The message correlation instance to enrich the <paramref name="message"/> with.</param>
+        /// <param name="logger">The logger instance to track the Azure Service Bus dependency.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        /// <exception cref="ServiceBusException">
+        ///   The message exceeds the maximum size allowed, as determined by the Service Bus service.
+        ///   The <see cref="ServiceBusException.Reason" /> will be set to <see cref="ServiceBusFailureReason.MessageSizeExceeded" /> in this case.
+        ///   For more information on service limits, see
+        ///   <see href="https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas#messaging-quotas" />.
+        /// </exception>
+        [Obsolete("Will be removed in v3.0 as this extension on the Azure Service bus sender is only used in the deprecated 'Hierarchical' correlation format")]
+        public static async Task SendMessageAsync(
+            this ServiceBusSender sender,
+            ServiceBusMessage message,
+            CorrelationInfo correlationInfo,
+            ILogger logger,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            await SendMessageAsync(sender, message, correlationInfo, logger, configureOptions: null, cancellationToken);
+        }
+
+        /// <summary>
+        ///   Sends a message to the associated entity of Service Bus.
+        /// </summary>
+        /// <param name="sender">The Azure Service Bus sender when sending the <paramref name="message"/></param>
+        /// <param name="message">The message to send.</param>
+        /// <param name="correlationInfo">The message correlation instance to enrich the <paramref name="message"/> with.</param>
+        /// <param name="logger">The logger instance to track the Azure Service Bus dependency.</param>
+        /// <param name="configureOptions">The function to configure additional options to the correlated <paramref name="message"/>.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        /// <exception cref="ServiceBusException">
+        ///   The message exceeds the maximum size allowed, as determined by the Service Bus service.
+        ///   The <see cref="ServiceBusException.Reason" /> will be set to <see cref="ServiceBusFailureReason.MessageSizeExceeded" /> in this case.
+        ///   For more information on service limits, see
+        ///   <see href="https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas#messaging-quotas" />.
+        /// </exception>
+        [Obsolete("Will be removed in v3.0 as this extension on the Azure Service bus sender is only used in the deprecated 'Hierarchical' correlation format")]
+        public static async Task SendMessageAsync(
+            this ServiceBusSender sender,
+            ServiceBusMessage message,
+            CorrelationInfo correlationInfo,
+            ILogger logger,
+            Action<ServiceBusSenderMessageCorrelationOptions> configureOptions,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (message is null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            await SendMessagesAsync(sender, new[] { message }, correlationInfo, logger, configureOptions, cancellationToken);
         }
 
         /// <summary>
@@ -88,6 +151,7 @@ namespace Azure.Messaging.ServiceBus
         ///   For more information on service limits, see
         ///   <see href="https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas#messaging-quotas" />.
         /// </exception>
+        [Obsolete("Will be removed in v3.0 as this extension on the Azure Service bus sender is only used in the deprecated 'Hierarchical' correlation format")]
         public static async Task SendMessagesAsync(
             this ServiceBusSender sender,
             IEnumerable<object> messageBodies,
@@ -119,6 +183,7 @@ namespace Azure.Messaging.ServiceBus
         ///   For more information on service limits, see
         ///   <see href="https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas#messaging-quotas" />.
         /// </exception>
+        [Obsolete("Will be removed in v3.0 as this extension on the Azure Service bus sender is only used in the deprecated 'Hierarchical' correlation format")]
         public static async Task SendMessagesAsync(
             this ServiceBusSender sender,
             IEnumerable<object> messageBodies,
@@ -137,63 +202,6 @@ namespace Azure.Messaging.ServiceBus
                              .ToArray();
 
             await SendMessagesAsync(sender, messages, correlationInfo, logger, configureOptions, cancellationToken);
-        }
-
-        /// <summary>
-        ///   Sends a message to the associated entity of Service Bus.
-        /// </summary>
-        /// <param name="sender">The Azure Service Bus sender when sending the <paramref name="message"/></param>
-        /// <param name="message">The message to send.</param>
-        /// <param name="correlationInfo">The message correlation instance to enrich the <paramref name="message"/> with.</param>
-        /// <param name="logger">The logger instance to track the Azure Service Bus dependency.</param>
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
-        /// <returns>A task to be resolved on when the operation has completed.</returns>
-        /// <exception cref="ServiceBusException">
-        ///   The message exceeds the maximum size allowed, as determined by the Service Bus service.
-        ///   The <see cref="ServiceBusException.Reason" /> will be set to <see cref="ServiceBusFailureReason.MessageSizeExceeded" /> in this case.
-        ///   For more information on service limits, see
-        ///   <see href="https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas#messaging-quotas" />.
-        /// </exception>
-        public static async Task SendMessageAsync(
-            this ServiceBusSender sender,
-            ServiceBusMessage message,
-            CorrelationInfo correlationInfo,
-            ILogger logger,
-            CancellationToken cancellationToken = default(CancellationToken))
-        {
-            await SendMessageAsync(sender, message, correlationInfo, logger, configureOptions: null, cancellationToken);
-        }
-
-        /// <summary>
-        ///   Sends a message to the associated entity of Service Bus.
-        /// </summary>
-        /// <param name="sender">The Azure Service Bus sender when sending the <paramref name="message"/></param>
-        /// <param name="message">The message to send.</param>
-        /// <param name="correlationInfo">The message correlation instance to enrich the <paramref name="message"/> with.</param>
-        /// <param name="logger">The logger instance to track the Azure Service Bus dependency.</param>
-        /// <param name="configureOptions">The function to configure additional options to the correlated <paramref name="message"/>.</param>
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
-        /// <returns>A task to be resolved on when the operation has completed.</returns>
-        /// <exception cref="ServiceBusException">
-        ///   The message exceeds the maximum size allowed, as determined by the Service Bus service.
-        ///   The <see cref="ServiceBusException.Reason" /> will be set to <see cref="ServiceBusFailureReason.MessageSizeExceeded" /> in this case.
-        ///   For more information on service limits, see
-        ///   <see href="https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas#messaging-quotas" />.
-        /// </exception>
-        public static async Task SendMessageAsync(
-            this ServiceBusSender sender,
-            ServiceBusMessage message,
-            CorrelationInfo correlationInfo,
-            ILogger logger,
-            Action<ServiceBusSenderMessageCorrelationOptions> configureOptions,
-            CancellationToken cancellationToken = default(CancellationToken))
-        {
-            if (message is null)
-            {
-                throw new ArgumentNullException(nameof(message));
-            }
-
-            await SendMessagesAsync(sender, new[] { message }, correlationInfo, logger, configureOptions, cancellationToken);
         }
 
         /// <summary>
@@ -216,6 +224,7 @@ namespace Azure.Messaging.ServiceBus
         ///   For more information on service limits, see
         ///   <see href="https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas#messaging-quotas" />.
         /// </exception>
+        [Obsolete("Will be removed in v3.0 as this extension on the Azure Service bus sender is only used in the deprecated 'Hierarchical' correlation format")]
         public static async Task SendMessagesAsync(
             this ServiceBusSender sender,
             IEnumerable<ServiceBusMessage> messages,
@@ -247,6 +256,7 @@ namespace Azure.Messaging.ServiceBus
         ///   For more information on service limits, see
         ///   <see href="https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas#messaging-quotas" />.
         /// </exception>
+        [Obsolete("Will be removed in v3.0 as this extension on the Azure Service bus sender is only used in the deprecated 'Hierarchical' correlation format")]
         public static async Task SendMessagesAsync(
             this ServiceBusSender sender,
             IEnumerable<ServiceBusMessage> messages,

--- a/src/Arcus.Messaging.ServiceBus.Core/ServiceBusMessageBuilder.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/ServiceBusMessageBuilder.cs
@@ -2,7 +2,10 @@
 using System.Collections.Generic;
 using System.Text;
 using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Abstractions.MessageHandling;
 using Newtonsoft.Json;
+
+#pragma warning disable S1133 // Disable usage of deprecated functionality until v3.0 is released.
 
 // ReSharper disable once CheckNamespace
 namespace Azure.Messaging.ServiceBus
@@ -10,6 +13,7 @@ namespace Azure.Messaging.ServiceBus
     /// <summary>
     /// Represents a builder instance to create <see cref="ServiceBusMessage"/> instances in different ways.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 as this builder is only used when Azure Service bus messages are send with the deprecated " + nameof(MessageCorrelationFormat.Hierarchical) + " correlation format")]
     public class ServiceBusMessageBuilder
     {
         private readonly object _messageBody;

--- a/src/Arcus.Messaging.ServiceBus.Core/ServiceBusSenderMessageCorrelationOptions.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/ServiceBusSenderMessageCorrelationOptions.cs
@@ -2,15 +2,19 @@
 using System.Collections.Generic;
 using System.Threading;
 using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Abstractions.MessageHandling;
 using Arcus.Observability.Correlation;
 using Azure.Messaging.ServiceBus;
 using Microsoft.Extensions.Logging;
+
+#pragma warning disable S1133 // Disable usage of deprecated functionality until v3.0 is released.
 
 namespace Arcus.Messaging.ServiceBus.Core
 {
     /// <summary>
     /// Represents the user-configurable options to influence the message correlation tracking behavior of the <see cref="ServiceBusSenderExtensions.SendMessageAsync(ServiceBusSender,ServiceBusMessage,CorrelationInfo,ILogger,Action{ServiceBusSenderMessageCorrelationOptions},CancellationToken)"/> extensions.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 as this options model is only used in the deprecated " + nameof(MessageCorrelationFormat.Hierarchical) + " correlation format")]
     public class ServiceBusSenderMessageCorrelationOptions
     {
         private string _transactionIdPropertyName = PropertyNames.TransactionId;


### PR DESCRIPTION
The old `Hierarchical` format was already made officially deprecated as a tracking system during the time that we implemented it. Since we're planning on moving to the new OpenTelemetry format, we can start deprecating his format in favor of W3C and OpenTelemetry. This will lower maintainence cost and guide people to newer correlation formats.

This PR deprecates all usage of the `Hierarchical` format in the repository.