### PR TITLE
fix(warnings): in unit test project

### DIFF
--- a/src/Arcus.Messaging.Tests.Unit/Arcus.Messaging.Tests.Unit.csproj
+++ b/src/Arcus.Messaging.Tests.Unit/Arcus.Messaging.Tests.Unit.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Arcus.Security.Core" Version="2.0.0" />
-    <PackageReference Include="Arcus.Testing.Security.Providers.InMemory" Version="0.5.0" />
+    <PackageReference Include="Arcus.Testing.Security.Providers.InMemory" Version="1.2.0" />
     <PackageReference Include="Arcus.Testing.Logging.Xunit" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Moq" Version="4.13.1" />

--- a/src/Arcus.Messaging.Tests.Unit/ServiceBus/ProcessMessageEventArgsExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/ServiceBus/ProcessMessageEventArgsExtensionsTests.cs
@@ -5,6 +5,8 @@ using Azure.Messaging.ServiceBus;
 using Moq;
 using Xunit;
 
+#pragma warning disable CS0618 // Disable warning for usage of deprecated functionality that will be removed in v3.0.
+
 namespace Arcus.Messaging.Tests.Unit.ServiceBus
 {
     public class ProcessMessageEventArgsExtensionsTests
@@ -19,7 +21,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
 
             // Act
             var eventArgs = new ProcessMessageEventArgs(message, expectedReceiver, CancellationToken.None);
-            
+
             // Assert
             ServiceBusReceiver actualReceiver = eventArgs.GetServiceBusReceiver();
             Assert.Equal(expectedReceiver, actualReceiver);


### PR DESCRIPTION
The unit test project had some compilation warnings related to the use of deprecated functionality and package range conflicts.

This PR resolves these warnings.