### PR TITLE
chore(service-bus): deprecate service-bus encoding message-context extension

### DIFF
--- a/src/Arcus.Messaging.ServiceBus.Core/Extensions/MessageContextExtensions.cs
+++ b/src/Arcus.Messaging.ServiceBus.Core/Extensions/MessageContextExtensions.cs
@@ -17,6 +17,7 @@ namespace Arcus.Messaging.Abstractions
         /// Gets the encoding property value in the messaging context, using UTF-8 as default if no such encoding value can be retrieved.
         /// </summary>
         /// <param name="messageContext">The context of the message.</param>
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(PropertyNames.Encoding) + " to extract the encoding yourself from the message context")]
         public static Encoding GetMessageEncodingProperty(this MessageContext messageContext)
         {
             Encoding encoding = GetMessageEncodingProperty(messageContext, NullLogger.Instance);
@@ -28,6 +29,7 @@ namespace Arcus.Messaging.Abstractions
         /// </summary>
         /// <param name="messageContext">The context of the message.</param>
         /// <param name="logger"></param>
+        [Obsolete("Will be removed in v3.0, please use the " + nameof(PropertyNames.Encoding) + " to extract the encoding yourself from the message context")]
         public static Encoding GetMessageEncodingProperty(this MessageContext messageContext, ILogger logger)
         {
             if (messageContext is null)


### PR DESCRIPTION
The `Arcus.Messaging.ServiceBus.Core` project will eventually be removed completely, as it only contains deprecated/old functionality. One of the extensions that is still used, is retrieving the encoding from the message context.

This PR inlines this functionality into the Azure Service bus message router so that we don't need the extension anymore, and deprecates the extension in the `.Core` library, so that anyone using this directly is aware of this.