### PR TITLE
chore(sb): deprecate older rotate connection strings functionality

### DIFF
--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusClient.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusClient.cs
@@ -9,6 +9,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
     /// <summary>
     /// Represents a client to interact with a Azure Service Bus.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 as the pump project will solely focus on providing message routing functionality")]
     public class AzureServiceBusClient
     {
         private readonly IAzureServiceBusManagementAuthentication _authentication;

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusNamespace.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusNamespace.cs
@@ -6,6 +6,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
     /// <summary>
     /// Represents the namespace of a Azure Service Bus resource; where the Azure Service Bus is located.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 as the pump project will solely focus on providing message routing functionality")]
     public class AzureServiceBusNamespace
     {
         /// <summary>

--- a/src/Arcus.Messaging.Pumps.ServiceBus/DefaultAzureServiceBusManagementAuthentication.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/DefaultAzureServiceBusManagementAuthentication.cs
@@ -11,6 +11,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
     /// <summary>
     /// Represents the authentication with the Azure Service Bus.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 as the pump project will solely focus on providing message routing functionality")]
     public class DefaultAzureServiceBusManagementAuthentication : IAzureServiceBusManagementAuthentication
     {
         private readonly string _clientId, _clientSecretKey, _subscriptionId, _tenantId;

--- a/src/Arcus.Messaging.Pumps.ServiceBus/IAzureServiceBusManagementAuthentication.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/IAzureServiceBusManagementAuthentication.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Microsoft.Azure.Management.ServiceBus;
 
 namespace Arcus.Messaging.Pumps.ServiceBus
@@ -6,6 +7,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
     /// <summary>
     /// Represents the contract on how to authenticate with the Azure Service Bus.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 as the pump project will solely focus on providing message routing functionality")]
     public interface IAzureServiceBusManagementAuthentication
     {
         /// <summary>


### PR DESCRIPTION
Deprecates the functionality in the Service bus pump project that allows for rotation of conection strings. This used an older version of authentication, and is somewhat conflicting with the 'pump' project as it has little to do with message routing.

This PR deprecates all rotation-related functionality.