### PR TITLE
chore(deps): remove guard.net references from the pumps abstractions project

### DIFF
--- a/src/Arcus.Messaging.Pumps.Abstractions/Extensions/IMessagePumpCircuitBreakerExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/Extensions/IMessagePumpCircuitBreakerExtensions.cs
@@ -27,7 +27,7 @@ namespace Arcus.Messaging.Pumps.Abstractions.Resiliency
 
             if (string.IsNullOrWhiteSpace(jobId))
             {
-                throw new ArgumentException("Requires a non-blank unique job ID to identify he message pump", nameof(jobId))
+                throw new ArgumentException("Requires a non-blank unique job ID to identify he message pump", nameof(jobId));
             }
 
             await circuitBreaker.PauseMessageProcessingAsync(jobId, _ => { });

--- a/src/Arcus.Messaging.Pumps.Abstractions/Extensions/IMessagePumpCircuitBreakerExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/Extensions/IMessagePumpCircuitBreakerExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading.Tasks;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Arcus.Messaging.Pumps.Abstractions.Resiliency
@@ -21,8 +20,15 @@ namespace Arcus.Messaging.Pumps.Abstractions.Resiliency
             this IMessagePumpCircuitBreaker circuitBreaker,
             string jobId)
         {
-            Guard.NotNull(circuitBreaker, nameof(circuitBreaker));
-            Guard.NotNullOrWhitespace(jobId, nameof(jobId));
+            if (circuitBreaker is null)
+            {
+                throw new ArgumentNullException(nameof(circuitBreaker));
+            }
+
+            if (string.IsNullOrWhiteSpace(jobId))
+            {
+                throw new ArgumentException("Requires a non-blank unique job ID to identify he message pump", nameof(jobId))
+            }
 
             await circuitBreaker.PauseMessageProcessingAsync(jobId, _ => { });
         }

--- a/src/Arcus.Messaging.Pumps.Abstractions/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/Extensions/IServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Pumps.Abstractions;
 using Arcus.Messaging.Pumps.Abstractions.Resiliency;
-using GuardNet;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 
@@ -26,8 +25,15 @@ namespace Microsoft.Extensions.DependencyInjection
             Func<IServiceProvider, TMessagePump> implementationFactory)
             where TMessagePump : MessagePump
         {
-            Guard.NotNull(services, nameof(services), "Requires an application services instance to register the custom message pump instance");
-            Guard.NotNull(implementationFactory, nameof(implementationFactory), "Requires a factory implementation function to create the custom message pump instance");
+            if (services is null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
+            if (implementationFactory is null)
+            {
+                throw new ArgumentNullException(nameof(implementationFactory));
+            }
 
             services.TryAddSingleton<IMessagePumpLifetime, DefaultMessagePumpLifetime>();
             services.TryAddSingleton<IMessagePumpCircuitBreaker>(

--- a/src/Arcus.Messaging.Pumps.Abstractions/Resiliency/DefaultMessagePumpCircuitBreaker.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/Resiliency/DefaultMessagePumpCircuitBreaker.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
-using GuardNet;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -26,9 +25,7 @@ namespace Arcus.Messaging.Pumps.Abstractions.Resiliency
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
         public DefaultMessagePumpCircuitBreaker(IServiceProvider serviceProvider, ILogger<DefaultMessagePumpCircuitBreaker> logger)
         {
-            Guard.NotNull(serviceProvider, nameof(serviceProvider));
-
-            _serviceProvider = serviceProvider;
+            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
             _logger = logger ?? NullLogger<DefaultMessagePumpCircuitBreaker>.Instance;
         }
 
@@ -40,7 +37,10 @@ namespace Arcus.Messaging.Pumps.Abstractions.Resiliency
         /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
         public virtual Task PauseMessageProcessingAsync(string jobId, Action<MessagePumpCircuitBreakerOptions> configureOptions)
         {
-            Guard.NotNullOrWhitespace(jobId, nameof(jobId));
+            if (string.IsNullOrWhiteSpace(jobId))
+            {
+                throw new ArgumentException("Requires a non-blank unique job ID to identify he message pump", nameof(jobId))
+            }
 
             MessagePump messagePump = GetRegisteredMessagePump(jobId);
 
@@ -69,7 +69,10 @@ namespace Arcus.Messaging.Pumps.Abstractions.Resiliency
         /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
         public MessagePumpCircuitState GetCircuitBreakerState(string jobId)
         {
-            Guard.NotNullOrWhitespace(jobId, nameof(jobId));
+            if (string.IsNullOrWhiteSpace(jobId))
+            {
+                throw new ArgumentException("Requires a non-blank unique job ID to identify he message pump", nameof(jobId))
+            }
 
             MessagePump messagePump = GetRegisteredMessagePump(jobId);
             return messagePump.CircuitState;
@@ -82,7 +85,10 @@ namespace Arcus.Messaging.Pumps.Abstractions.Resiliency
         /// <exception cref="InvalidOperationException">Thrown when not a single or more than one message pump could be found by the configured job ID.</exception>
         protected MessagePump GetRegisteredMessagePump(string jobId)
         {
-            Guard.NotNullOrWhitespace(jobId, nameof(jobId));
+            if (string.IsNullOrWhiteSpace(jobId))
+            {
+                throw new ArgumentException("Requires a non-blank unique job ID to identify he message pump", nameof(jobId))
+            }
 
             MessagePump[] messagePumps =
                 _serviceProvider.GetServices<IHostedService>()

--- a/src/Arcus.Messaging.Pumps.Abstractions/Resiliency/DefaultMessagePumpCircuitBreaker.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/Resiliency/DefaultMessagePumpCircuitBreaker.cs
@@ -39,7 +39,7 @@ namespace Arcus.Messaging.Pumps.Abstractions.Resiliency
         {
             if (string.IsNullOrWhiteSpace(jobId))
             {
-                throw new ArgumentException("Requires a non-blank unique job ID to identify he message pump", nameof(jobId))
+                throw new ArgumentException("Requires a non-blank unique job ID to identify he message pump", nameof(jobId));
             }
 
             MessagePump messagePump = GetRegisteredMessagePump(jobId);
@@ -71,7 +71,7 @@ namespace Arcus.Messaging.Pumps.Abstractions.Resiliency
         {
             if (string.IsNullOrWhiteSpace(jobId))
             {
-                throw new ArgumentException("Requires a non-blank unique job ID to identify he message pump", nameof(jobId))
+                throw new ArgumentException("Requires a non-blank unique job ID to identify he message pump", nameof(jobId));
             }
 
             MessagePump messagePump = GetRegisteredMessagePump(jobId);
@@ -87,7 +87,7 @@ namespace Arcus.Messaging.Pumps.Abstractions.Resiliency
         {
             if (string.IsNullOrWhiteSpace(jobId))
             {
-                throw new ArgumentException("Requires a non-blank unique job ID to identify he message pump", nameof(jobId))
+                throw new ArgumentException("Requires a non-blank unique job ID to identify he message pump", nameof(jobId));
             }
 
             MessagePump[] messagePumps =


### PR DESCRIPTION
The pumps abstractions still had some references to the Guard.NET library. This PR removes those references in favor of built-in functionlity - not using the .NET 8 functionlity just yet as this is not availble in .NET Standard 2.1.