### PR TITLE
chore(general): deprecate general message routing

### DIFF
--- a/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.EventHubs/Extensions/IServiceCollectionExtensions.cs
@@ -90,7 +90,9 @@ namespace Microsoft.Extensions.DependencyInjection
 
                 return implementationFactory(serviceProvider, options);
             });
+#pragma warning disable CS0618 // Type or member is obsolete: EventHubs-related projects will be removed anyway.
             services.AddMessageRouting(serviceProvider => serviceProvider.GetRequiredService<IAzureEventHubsMessageRouter>());
+#pragma warning restore CS0618 // Type or member is obsolete
 
             return new EventHubsMessageHandlerCollection(services);
         }

--- a/src/Arcus.Messaging.Abstractions.EventHubs/MessageHandling/AzureEventHubsMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.EventHubs/MessageHandling/AzureEventHubsMessageRouter.cs
@@ -11,6 +11,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Serilog.Context;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
 
+#pragma warning disable CS0618 // Type or member is obsolete: EventHubs-related projects will be removed anyway.
+
 namespace Arcus.Messaging.Abstractions.EventHubs.MessageHandling
 {
     /// <summary>
@@ -125,7 +127,9 @@ namespace Arcus.Messaging.Abstractions.EventHubs.MessageHandling
         ///     Thrown when the <paramref name="message"/>, <paramref name="messageContext"/>, or <paramref name="correlationInfo"/> is <c>null</c>.
         /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when no message handlers or none matching message handlers are found to process the message.</exception>
+#pragma warning disable CS0672 // Member overrides obsolete member: ventHubs-related projects will be removed anyway.
         public override async Task RouteMessageAsync<TMessageContext>(
+#pragma warning restore CS0672 // Member overrides obsolete member
             string message,
             TMessageContext messageContext,
             MessageCorrelationInfo correlationInfo,

--- a/src/Arcus.Messaging.Abstractions.EventHubs/MessageHandling/IAzureEventHubsMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.EventHubs/MessageHandling/IAzureEventHubsMessageRouter.cs
@@ -9,7 +9,9 @@ namespace Arcus.Messaging.Abstractions.EventHubs.MessageHandling
     /// <summary>
     /// Represents an <see cref="IMessageRouter"/> that can route Azure EventHubs <see cref="EventData"/>s.
     /// </summary>
+#pragma warning disable CS0618 // Type or member is obsolete: EventHubs-related projects will be removed anyway.
     public interface IAzureEventHubsMessageRouter : IMessageRouter
+#pragma warning restore CS0618 // Type or member is obsolete
     {
         /// <summary>
         /// Handle a new <paramref name="message"/> that was received by routing them through registered <see cref="IAzureEventHubsMessageHandler{TMessage}"/>s

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/IServiceCollectionExtensions.cs
@@ -97,7 +97,9 @@ namespace Microsoft.Extensions.DependencyInjection
 
                 return implementationFactory(serviceProvider, options);
             });
+#pragma warning disable CS0618 // Type or member is obsolete: message router will be registered directly in v3.0.
             services.AddMessageRouting(serviceProvider => serviceProvider.GetRequiredService<IAzureServiceBusMessageRouter>());
+#pragma warning restore CS0618 // Type or member is obsolete
 
             return new ServiceBusMessageHandlerCollection(services);
         }

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
@@ -29,8 +29,9 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         /// <param name="logger">The logger instance to write diagnostic trace messages during the routing of the message.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
         public AzureServiceBusMessageRouter(IServiceProvider serviceProvider, AzureServiceBusMessageRouterOptions options, ILogger<AzureServiceBusMessageRouter> logger)
-            : this(serviceProvider, options, (ILogger) logger)
+            : base(serviceProvider, options, (ILogger) logger)
         {
+            ServiceBusOptions = options;
         }
 
         /// <summary>
@@ -39,6 +40,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         /// <param name="serviceProvider">The service provider instance to retrieve all the <see cref="IAzureServiceBusMessageHandler{TMessage}"/> instances.</param>
         /// <param name="options">The consumer-configurable options to change the behavior of the router.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 for simplified message router initialization")]
         public AzureServiceBusMessageRouter(IServiceProvider serviceProvider, AzureServiceBusMessageRouterOptions options)
             : this(serviceProvider, options, NullLogger.Instance)
         {
@@ -50,6 +52,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         /// <param name="serviceProvider">The service provider instance to retrieve all the <see cref="IAzureServiceBusMessageHandler{TMessage}"/> instances.</param>
         /// <param name="logger">The logger instance to write diagnostic trace messages during the routing of the message.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 for simplified message router initialization")]
         public AzureServiceBusMessageRouter(IServiceProvider serviceProvider, ILogger<AzureServiceBusMessageRouter> logger)
             : this(serviceProvider, new AzureServiceBusMessageRouterOptions(), (ILogger) logger)
         {
@@ -60,6 +63,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         /// </summary>
         /// <param name="serviceProvider">The service provider instance to retrieve all the <see cref="IAzureServiceBusMessageHandler{TMessage}"/> instances.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 for simplified message router initialization")]
         public AzureServiceBusMessageRouter(IServiceProvider serviceProvider)
             : this(serviceProvider, new AzureServiceBusMessageRouterOptions(), NullLogger.Instance)
         {
@@ -71,6 +75,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         /// <param name="serviceProvider">The service provider instance to retrieve all the <see cref="IAzureServiceBusMessageHandler{TMessage}"/> instances.</param>
         /// <param name="logger">The logger instance to write diagnostic trace messages during the routing of the message.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 for simplified message router initialization")]
         protected AzureServiceBusMessageRouter(IServiceProvider serviceProvider, ILogger logger)
             : this(serviceProvider, new AzureServiceBusMessageRouterOptions(), logger)
         {
@@ -83,6 +88,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         /// <param name="options">The consumer-configurable options to change the behavior of the router.</param>
         /// <param name="logger">The logger instance to write diagnostic trace messages during the routing of the message.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 for simplified message router initialization")]
         protected AzureServiceBusMessageRouter(IServiceProvider serviceProvider, AzureServiceBusMessageRouterOptions options, ILogger logger)
             : base(serviceProvider, options, logger ?? NullLogger<AzureServiceBusMessageRouter>.Instance)
         {
@@ -106,6 +112,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         ///     Thrown when the <paramref name="message"/>, <paramref name="messageContext"/>, or <paramref name="correlationInfo"/> is <c>null</c>.
         /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when no message handlers or none matching message handlers are found to process the message.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message routing will be supported from now on")]
         public override async Task RouteMessageAsync<TMessageContext>(
             string message,
             TMessageContext messageContext,
@@ -313,7 +320,9 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
                     return MessageProcessingResult.Failure(message.MessageId, CannotFindMatchedHandler, "Failed to process message in pump as no message handler was matched against the message and no fallback message handlers were configured");
                 }
 
+#pragma warning disable CS0618 // Type or member is obsolete: general message routing will be removed in v3.0.
                 bool isProcessedByGeneralFallback = await TryFallbackProcessMessageAsync(messageBody, messageContext, correlationInfo, cancellationToken);
+#pragma warning restore CS0618 // Type or member is obsolete
                 if (isProcessedByGeneralFallback)
                 {
                     return MessageProcessingResult.Success(message.MessageId);

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/IAzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/IAzureServiceBusMessageRouter.cs
@@ -9,7 +9,9 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
     /// <summary>
     /// Represents an <see cref="IMessageRouter"/> that can route Azure Service Bus <see cref="ServiceBusReceivedMessage"/>s.
     /// </summary>
+#pragma warning disable CS0618 // Type or member is obsolete: general message router interface will be removed in v3.0.
     public interface IAzureServiceBusMessageRouter : IMessageRouter
+#pragma warning restore CS0618 // Type or member is obsolete
     {
         /// <summary>
         /// Handle a new <paramref name="message"/> that was received by routing them through registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/>s

--- a/src/Arcus.Messaging.Abstractions/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/IServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <param name="services">The collection of services to add the router to.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message routing will be supported from now on")]
         public static MessageHandlerCollection AddMessageRouting(this IServiceCollection services)
         {
             MessageHandlerCollection collection = AddMessageRouting(services, configureOptions: null);
@@ -30,6 +31,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The collection of services to add the router to.</param>
         /// <param name="configureOptions">The consumer-configurable options to change the behavior of the router.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message routing will be supported from now on")]
         public static MessageHandlerCollection AddMessageRouting(this IServiceCollection services, Action<MessageRouterOptions> configureOptions)
         {
             MessageHandlerCollection collection = AddMessageRouting(services, serviceProvider =>
@@ -51,6 +53,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The collection of services to add the router to.</param>
         /// <param name="implementationFactory">The function to create the <see cref="MessageRouter"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or <paramref name="implementationFactory"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message routing will be supported from now on")]
         public static MessageHandlerCollection AddMessageRouting<TMessageRouter>(
             this IServiceCollection services,
             Func<IServiceProvider, TMessageRouter> implementationFactory)

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/IMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/IMessageRouter.cs
@@ -7,11 +7,12 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
     /// <summary>
     /// Represents how incoming messages can be routed through registered <see cref="IMessageHandler{TMessage}"/> instances.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 as only concrete implementations of message routing will be supported from now on")]
     public interface IMessageRouter
     {
         /// <summary>
         /// Handle a new <paramref name="message"/> that was received by routing them through registered <see cref="IMessageHandler{TMessage,TMessageContext}"/>s
-        /// and optionally through an registered <see cref="IFallbackMessageHandler"/> if none of the message handlers were able to process the <paramref name="message"/>.
+        /// and optionally through a registered <see cref="IFallbackMessageHandler"/> if none of the message handlers were able to process the <paramref name="message"/>.
         /// </summary>
         /// <param name="message">The message that was received.</param>
         /// <param name="messageContext">The context providing more information concerning the processing.</param>
@@ -21,6 +22,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         ///     Thrown when the <paramref name="message"/>, <paramref name="messageContext"/>, or <paramref name="correlationInfo"/> is <c>null</c>.
         /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when no message handlers or none matching message handlers are found to process the message.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message routing will be supported from now on")]
         Task RouteMessageAsync<TMessageContext>(
             string message,
             TMessageContext messageContext,

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
@@ -17,7 +17,9 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
     /// <summary>
     /// Represents how incoming messages gets routed through registered <see cref="IMessageHandler{TMessage,TMessageContext}"/> instances.
     /// </summary>
+#pragma warning disable CS0618 // Type or member is obsolete: deprecated interface will be removed in v3.0.
     public class MessageRouter : IMessageRouter
+#pragma warning restore CS0618 // Type or member is obsolete
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MessageRouter"/> class.
@@ -26,17 +28,19 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// <param name="options">The consumer-configurable options to change the behavior of the router.</param>
         /// <param name="logger">The logger instance to write diagnostic trace messages during the routing of the message.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 for simplified message router initialization")]
         public MessageRouter(IServiceProvider serviceProvider, MessageRouterOptions options, ILogger<MessageRouter> logger)
             : this(serviceProvider, options, (ILogger) logger)
         {
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MessageRouter"/> class.
         /// </summary>
         /// <param name="serviceProvider">The service provider instance to retrieve all the <see cref="IMessageHandler{TMessage,TMessageContext}"/> instances.</param>
         /// <param name="options">The consumer-configurable options to change the behavior of the router.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 for simplified message router initialization")]
         public MessageRouter(IServiceProvider serviceProvider, MessageRouterOptions options)
             : this(serviceProvider, options, NullLogger.Instance)
         {
@@ -48,6 +52,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// <param name="serviceProvider">The service provider instance to retrieve all the <see cref="IMessageHandler{TMessage,TMessageContext}"/> instances.</param>
         /// <param name="logger">The logger instance to write diagnostic trace messages during the routing of the message.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 for simplified message router initialization")]
         public MessageRouter(IServiceProvider serviceProvider, ILogger<MessageRouter> logger)
             : this(serviceProvider, new MessageRouterOptions(), (ILogger) logger)
         {
@@ -58,17 +63,19 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// </summary>
         /// <param name="serviceProvider">The service provider instance to retrieve all the <see cref="IMessageHandler{TMessage,TMessageContext}"/> instances.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 for simplified message router initialization")]
         public MessageRouter(IServiceProvider serviceProvider)
             : this(serviceProvider, new MessageRouterOptions(), NullLogger.Instance)
         {
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MessageRouter"/> class.
         /// </summary>
         /// <param name="serviceProvider">The service provider instance to retrieve all the <see cref="IMessageHandler{TMessage,TMessageContext}"/> instances.</param>
         /// <param name="logger">The logger instance to write diagnostic trace messages during the routing of the message.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 for simplified message router initialization")]
         protected MessageRouter(IServiceProvider serviceProvider, ILogger logger)
             : this(serviceProvider, new MessageRouterOptions(), logger)
         {
@@ -92,12 +99,12 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// Gets the instance that provides all the registered services in the current application.
         /// </summary>
         protected IServiceProvider ServiceProvider { get; }
-        
+
         /// <summary>
         /// Gets the consumer-configurable options to change the behavior of the router.
         /// </summary>
         protected MessageRouterOptions Options { get; }
-        
+
         /// <summary>
         /// Gets the logger instance that writes diagnostic trace messages during the routing of the messages.
         /// </summary>
@@ -118,6 +125,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// <returns>
         ///     [true] if the router was able to process the message through one of the registered <see cref="IMessageHandler{TMessage,TMessageContext}"/>s; [false] otherwise.
         /// </returns>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message routing will be supported from now on")]
         protected async Task<bool> RouteMessageWithoutFallbackAsync<TMessageContext>(
             string message,
             TMessageContext messageContext,
@@ -147,7 +155,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
                 accessor?.SetCorrelationInfo(correlationInfo);
 
                 bool isProcessed = await TryProcessMessageAsync(serviceScope.ServiceProvider, message, messageContext, correlationInfo, cancellationToken);
-                return isProcessed; 
+                return isProcessed;
             }
         }
 
@@ -163,6 +171,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         ///     Thrown when the <paramref name="message"/>, <paramref name="messageContext"/>, or <paramref name="correlationInfo"/> is <c>null</c>.
         /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when no message handlers or none matching message handlers are found to process the message.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message routing will be supported from now on")]
         public virtual async Task RouteMessageAsync<TMessageContext>(
             string message,
             TMessageContext messageContext,
@@ -208,6 +217,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         ///     Thrown when the <paramref name="message"/>, <paramref name="messageContext"/>, or <paramref name="correlationInfo"/> is <c>null</c>.
         /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when no message handlers or none matching message handlers are found to process the message.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message routing will be supported from now on")]
         protected async Task RouteMessageAsync<TMessageContext>(
             IServiceProvider serviceProvider,
             string message,
@@ -226,7 +236,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             if (!isFallbackProcessed)
             {
                 Logger.LogDebug("Message router cannot correctly process the message in the '{MessageContextType}' because none of the registered '{MessageHandlerType}' implementations in the dependency container matches the incoming message type and context. Make sure you call the correct '.With...' extension on the '{ServiceCollectionType}' during the registration of the message pump/router to register a message handler", typeof(TMessageContext).Name, typeof(IMessageHandler<,>).Name, nameof(IServiceCollection));
-            } 
+            }
         }
 
         private async Task<bool> TryProcessMessageAsync<TMessageContext>(
@@ -238,7 +248,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             where TMessageContext : MessageContext
         {
             MessageHandler[] handlers = GetRegisteredMessageHandlers(serviceProvider).ToArray();
-            FallbackMessageHandler<string, TMessageContext>[] fallbackHandlers = 
+            FallbackMessageHandler<string, TMessageContext>[] fallbackHandlers =
                 GetAvailableFallbackMessageHandlersByContext<string, TMessageContext>(messageContext);
 
             if (handlers.Length <= 0 && fallbackHandlers.Length <= 0)
@@ -361,6 +371,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// <returns>
         ///     [true] if the received <paramref name="message"/> was handled by the registered <see cref="IFallbackMessageHandler"/>; [false] otherwise.
         /// </returns>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message routing will be supported from now on")]
         protected async Task<bool> TryFallbackProcessMessageAsync<TMessageContext>(
             string message,
             TMessageContext messageContext,
@@ -486,7 +497,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
                 args.ErrorContext.Handled = true;
             };
             jsonSerializer.Error += eventHandler;
-            
+
             try
             {
                 var value = JToken.Parse(message).ToObject(messageType, jsonSerializer);
@@ -506,7 +517,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             {
                 jsonSerializer.Error -= eventHandler;
             }
-            
+
             result = null;
             return false;
         }
@@ -514,7 +525,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         private JsonSerializer CreateJsonSerializer()
         {
             var jsonSerializer = new JsonSerializer();
-            
+
             if (Options.Deserialization is null)
             {
                 jsonSerializer.MissingMemberHandling = MissingMemberHandling.Error;


### PR DESCRIPTION
Only concrete implementations of the message pump and message router will be available in the v3.0 space. This PR deprecates the general message routing implementation and registration so that it can be removed later on.

General message routing includes routing messages based on `string` instead of concrete types like `ServiceBusReceivedMessage`. The general message routing was required before when using it directly in Azure Functions, but since we removed the specific Azure Funcions support, we should remove this general message routing as well.

Relates to lightweight exercise described in #470 