### PR TITLE
chore(general): deprecate general fallback message handler

### DIFF
--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageHandlerCollectionExtensions.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="collection">The collection of collection to use in the application.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="collection"/> is <c>null</c>.</exception>
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(this MessageHandlerCollection collection)
-            where TMessageHandler : class, IMessageHandler<TMessage, TMessageContext> 
+            where TMessageHandler : class, IMessageHandler<TMessage, TMessageContext>
             where TMessage : class
             where TMessageContext : MessageContext
         {
@@ -76,7 +76,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             this MessageHandlerCollection collection,
             Func<IServiceProvider, TMessageHandler> implementationFactory)
-            where TMessageHandler : class, IMessageHandler<TMessage, TMessageContext> 
+            where TMessageHandler : class, IMessageHandler<TMessage, TMessageContext>
             where TMessage : class
             where TMessageContext : MessageContext
         {
@@ -100,6 +100,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="TMessageHandler">The type of the fallback message handler.</typeparam>
         /// <param name="collection">The collection to add the fallback message handler to.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="collection"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithFallbackMessageHandler<TMessageHandler>(this MessageHandlerCollection collection)
             where TMessageHandler : IFallbackMessageHandler<string, MessageContext>
         {
@@ -113,6 +114,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="TMessageContext">The type of the message context.</typeparam>
         /// <param name="collection">The collection to add the fallback message handler to.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="collection"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithFallbackMessageHandler<TMessageHandler, TMessageContext>(this MessageHandlerCollection collection)
             where TMessageHandler : IFallbackMessageHandler<string, TMessageContext>
             where TMessageContext : MessageContext
@@ -127,6 +129,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="collection">The collection to add the fallback message handler to.</param>
         /// <param name="createImplementation">The function to create the fallback message handler.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="collection"/> or the <paramref name="createImplementation"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithFallbackMessageHandler<TMessageHandler>(
             this MessageHandlerCollection collection,
             Func<IServiceProvider, TMessageHandler> createImplementation)
@@ -154,10 +157,11 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="collection">The collection to add the fallback message handler to.</param>
         /// <param name="createImplementation">The function to create the fallback message handler.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="collection"/> or the <paramref name="createImplementation"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithFallbackMessageHandler<TMessageHandler, TMessageContext>(
             this MessageHandlerCollection collection,
             Func<IServiceProvider, TMessageHandler> createImplementation)
-            where TMessageHandler : IFallbackMessageHandler<string, TMessageContext> 
+            where TMessageHandler : IFallbackMessageHandler<string, TMessageContext>
             where TMessageContext : MessageContext
         {
             if (collection is null)

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/IFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/IFallbackMessageHandler.cs
@@ -33,6 +33,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
     /// <summary>
     /// Fallback version of the <see cref="IMessageHandler{TMessage,TMessageContext}"/> to have a safety net when no message handlers able to process the message.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
     public interface IFallbackMessageHandler<in TMessage> : IMessageHandler<TMessage, MessageContext>
     {
     }
@@ -40,6 +41,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
     /// <summary>
     /// Fallback version of the <see cref="IMessageHandler{TMessage,TMessageContext}"/> to have a safety net when no message handlers able to process the message.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
     public interface IFallbackMessageHandler : IFallbackMessageHandler<string, MessageContext>
     {
     }


### PR DESCRIPTION
Only concrete implementations of the message pump and message router will be available in the v3.0 space. This PR deprecates the general fallback message handler interface and registration so that it can be removed later on.

General message routing includes routing messages based on string instead of concrete types like ServiceBusReceivedMessage. The general message routing was required before when using it directly in Azure Functions, but since we removed the specific Azure Funcions support, we should remove this general message routing as well.

Relates to lightweight exercise described in https://github.com/arcus-azure/arcus.messaging/discussions/470