### PR TITLE
chore(cd): remove eventhubs-related resources from `deploy-test-resources.yml`

### DIFF
--- a/build/deploy-test-resources.yml
+++ b/build/deploy-test-resources.yml
@@ -53,16 +53,8 @@ stages:
                   --resource-group $env:ARCUS_MESSAGING_RESOURCEGROUP_NAME `
                   --template-file ./build/templates/test-resources.bicep `
                   --parameters serviceBusNamespace=$env:ARCUS_MESSAGING_SERVICEBUS_NAMESPACE `
-                  --parameters eventHubsNamespace=$env:ARCUS_MESSAGING_EVENTHUBS_NAMESPACE `
-                  --parameters storageAccountName=$env:ARCUS_MESSAGING_STORAGEACCOUNT_NAME `
                   --parameters keyVaultName=$env:ARCUS_MESSAGING_KEYVAULT_NAME `
                   --parameters servicePrincipal_objectId=$objectId
-
-                $accountKey = (az storage account keys list --account-name $env:ARCUS_MESSAGING_STORAGEACCOUNT_NAME | ConvertFrom-Json)[0].value
-                az keyvault secret set `
-                  --name $env:ARCUS_MESSAGING_STORAGEACCOUNT_KEY_SECRETNAME `
-                  --value $accountKey `
-                  --vault-name ${{ parameters.keyVaultName }}
 
                 $serviceBusKeys = az servicebus namespace authorization-rule keys list `
                   --resource-group $env:ARCUS_MESSAGING_RESOURCEGROUP_NAME `
@@ -72,14 +64,4 @@ stages:
                 az keyvault secret set `
                   --name $env:ARCUS_MESSAGING_SERVICEBUS_CONNECTIONSTRING_SECRETNAME `
                   --value $serviceBusKeys.primaryConnectionString `
-                  --vault-name ${{ parameters.keyVaultName }}
-
-                $eventHubsKeys = az eventhubs namespace authorization-rule keys list `
-                  --resource-group $env:ARCUS_MESSAGING_RESOURCEGROUP_NAME `
-                  --namespace-name $env:ARCUS_MESSAGING_EVENTHUBS_NAMESPACE `
-                  --authorization-rule-name 'RootManageSharedAccessKey' `
-                  | ConvertFrom-Json
-                az keyvault secret set `
-                  --name $env:ARCUS_MESSAGING_EVENTHUBS_CONNECTIONSTRING_SECRETNAME `
-                  --value $eventHubsKeys.primaryConnectionString `
                   --vault-name ${{ parameters.keyVaultName }}

--- a/build/templates/test-resources.bicep
+++ b/build/templates/test-resources.bicep
@@ -4,12 +4,6 @@ param location string = resourceGroup().location
 // Define the name of the single Azure Service bus namespace.
 param serviceBusNamespace string
 
-// Define the name of the single Azure EventHubs namespace.
-param eventHubsNamespace string
-
-// Define the name of the storage account that will be created.
-param storageAccountName string
-
 // Define the name of the Key Vault.
 param keyVaultName string
 
@@ -29,44 +23,6 @@ module serviceBus 'br/public:avm/res/service-bus/namespace:0.8.0' = {
       {
         principalId: servicePrincipal_objectId
         roleDefinitionIdOrName: 'Azure Service Bus Data Owner'
-      }
-    ]
-  }
-}
-
-module hubs 'br/public:avm/res/event-hub/namespace:0.7.0' = {
-  name: 'eventHubsDeployment'
-  params: {
-    name: eventHubsNamespace
-    location: location
-    skuName: 'Basic'
-    disableLocalAuth: false
-    roleAssignments: [
-      {
-        principalId: servicePrincipal_objectId
-        roleDefinitionIdOrName: 'Azure Event Hubs Data Owner'
-      }
-    ]
-  }
-}
-
-module storageAccount 'br/public:avm/res/storage/storage-account:0.9.1' = {
-  name: 'storageAccountDeployment'
-  params: {
-    name: storageAccountName
-    location: location
-    allowBlobPublicAccess: true
-    publicNetworkAccess: 'Enabled'
-    networkAcls: {
-      bypass: 'AzureServices'
-      defaultAction: 'Allow'
-      ipRules: []
-      virtualNetworkRules: []
-    }
-    roleAssignments: [
-      {
-        principalId: servicePrincipal_objectId
-        roleDefinitionIdOrName: 'Storage Blob Data Contributor'
       }
     ]
   }


### PR DESCRIPTION
During the lightweight exercise described in #470 , the EventHubs-related projects are becoming deprecated, which means that we do not need to include them anymore in our continuous delivery pipeline (`deploy-test-resources.yml`).

This PR removes both the EventHubs-related references in the Bicep files, as well as the parameters passed along with it via the pipeline.