### PR TITLE
chore(general): deprecate general message context message handler

### DIFF
--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageBody.MessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageBody.MessageHandlerCollectionExtensions.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The collection of services to use in the application.</param>
         /// <param name="messageBodyFilter">The filter to restrict the message processing based on the incoming message body.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or <paramref name="messageBodyFilter"/> is <c>null</c>.</exception>
+
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage>(
             this MessageHandlerCollection services,
             Func<TMessage, bool> messageBodyFilter)

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageBody.MessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageBody.MessageHandlerCollectionExtensions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The collection of services to use in the application.</param>
         /// <param name="messageBodyFilter">The filter to restrict the message processing based on the incoming message body.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or <paramref name="messageBodyFilter"/> is <c>null</c>.</exception>
-
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage>(
             this MessageHandlerCollection services,
             Func<TMessage, bool> messageBodyFilter)
@@ -61,6 +61,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageBodyFilter">The filter to restrict the message processing based on the incoming message body.</param>
         /// <param name="implementationFactory">The function that creates the service.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/>, <paramref name="messageBodyFilter"/>, or <paramref name="implementationFactory"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage>(
             this MessageHandlerCollection services,
             Func<TMessage, bool> messageBodyFilter,

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageBody.IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageBody.IServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.MessageHandling;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.Extensions.DependencyInjection
@@ -23,6 +22,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageBodyFilter">The filter to restrict the message processing based on the incoming message body.</param>
         /// <param name="implementationFactory">The function that creates the service.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/>, <paramref name="messageContextFilter"/>, <paramref name="messageBodyFilter"/>, or <paramref name="implementationFactory"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage>(
             this MessageHandlerCollection services,
             Func<MessageContext, bool> messageContextFilter,
@@ -44,6 +44,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageContextFilter">The function that determines if the message handler should handle the message based on the context.</param>
         /// <param name="messageBodyFilter">The filter to restrict the message processing based on the incoming message body.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/>, <paramref name="messageContextFilter"/>, or <paramref name="messageBodyFilter"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage>(
             this MessageHandlerCollection services,
             Func<MessageContext, bool> messageContextFilter,

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageHandlerCollectionExtensions.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The collection of services to use in the application.</param>
         /// <param name="messageContextFilter">The function that determines if the message handler should handle the message based on the context.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or <paramref name="messageContextFilter"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage>(
             this MessageHandlerCollection services,
             Func<MessageContext, bool> messageContextFilter)
@@ -39,6 +40,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageContextFilter">The function that determines if the message handler should handle the message based on the context.</param>
         /// <param name="implementationFactory">The function that creates the service.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/>, <paramref name="messageContextFilter"/>, or <paramref name="implementationFactory"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage>(
             this MessageHandlerCollection services,
             Func<MessageContext, bool> messageContextFilter,
@@ -70,7 +72,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 services, messageContextFilter, serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
         }
 
-         /// <summary>
+        /// <summary>
         /// Adds a <see cref="IMessageHandler{TMessage, TMessageContext}" /> implementation to process the messages from an Azure Service Bus.
         /// resources.
         /// </summary>

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageSerializer.MessageBody.IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageSerializer.MessageBody.IServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageBodyFilter">The filter to restrict the message processing based on the incoming message body.</param>
         /// <param name="messageBodySerializer">The custom <see cref="IMessageBodySerializer"/> to deserialize the incoming message for the <typeparamref name="TMessageHandler"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or <paramref name="messageBodyFilter"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage>(
             this MessageHandlerCollection services,
             Func<MessageContext, bool> messageContextFilter,
@@ -44,6 +45,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageBodySerializerImplementationFactory">The function to create an custom <see cref="IMessageBodySerializer"/> to deserialize the incoming message for the <typeparamref name="TMessageHandler"/>.</param>
         /// <param name="messageBodyFilter">The filter to restrict the message processing based on the incoming message body.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or <paramref name="messageBodyFilter"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage>(
             this MessageHandlerCollection services,
             Func<MessageContext, bool> messageContextFilter,
@@ -117,6 +119,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageBodyFilter">The filter to restrict the message processing based on the incoming message body.</param>
         /// <param name="implementationFactory">The function that creates the service.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/>, <paramref name="messageBodyFilter"/>, or <paramref name="implementationFactory"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage>(
             this MessageHandlerCollection services,
             Func<MessageContext, bool> messageContextFilter,
@@ -142,6 +145,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageBodyFilter">The filter to restrict the message processing based on the incoming message body.</param>
         /// <param name="messageHandlerImplementationFactory">The function that creates the service.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/>, <paramref name="messageBodyFilter"/>, or <paramref name="messageHandlerImplementationFactory"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage>(
             this MessageHandlerCollection services,
             Func<MessageContext, bool> messageContextFilter,

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageSerializer.MessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageSerializer.MessageHandlerCollectionExtensions.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The collection of services to use in the application.</param>
         /// <param name="messageContextFilter">The function that determines if the message handler should handle the message based on the context.</param>
         /// <param name="messageBodySerializer">The custom <see cref="IMessageBodySerializer"/> that deserializes the incoming message for the <see cref="IMessageHandler{TMessage,TMessageContext}"/>.</param>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage>(
             this MessageHandlerCollection services,
             Func<MessageContext, bool> messageContextFilter,
@@ -39,6 +40,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The collection of services to use in the application.</param>
         /// <param name="messageContextFilter">The function that determines if the message handler should handle the message based on the context.</param>
         /// <param name="messageBodySerializerImplementationFactory">The custom <see cref="IMessageBodySerializer"/> that deserializes the incoming message for the <see cref="IMessageHandler{TMessage,TMessageContext}"/>.</param>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage>(
             this MessageHandlerCollection services,
             Func<MessageContext, bool> messageContextFilter,
@@ -59,6 +61,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageContextFilter">The function that determines if the message handler should handle the message based on the context.</param>
         /// <param name="messageBodySerializer">The custom <see cref="IMessageBodySerializer"/> that deserializes the incoming message for the <see cref="IMessageHandler{TMessage,TMessageContext}"/>.</param>
         /// <param name="messageHandlerImplementationFactory">The function that creates the service.</param>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage>(
             this MessageHandlerCollection services,
             Func<MessageContext, bool> messageContextFilter,
@@ -81,6 +84,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageContextFilter">The function that determines if the message handler should handle the message based on the context.</param>
         /// <param name="messageBodySerializerImplementationFactory">The custom <see cref="IMessageBodySerializer"/> that deserializes the incoming message for the <typeparamref name="TMessageHandler"/>.</param>
         /// <param name="messageHandlerImplementationFactory">The function that creates the service.</param>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage>(
             this MessageHandlerCollection services,
             Func<MessageContext, bool> messageContextFilter,
@@ -91,8 +95,8 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             return WithMessageHandler<TMessageHandler, TMessage, MessageContext>(
                 services,
-                messageContextFilter, 
-                messageBodySerializerImplementationFactory, 
+                messageContextFilter,
+                messageBodySerializerImplementationFactory,
                 messageHandlerImplementationFactory);
         }
 
@@ -210,10 +214,10 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             services.AddMessageHandler(
-                messageHandlerImplementationFactory, 
-                messageContextFilter: messageContextFilter, 
+                messageHandlerImplementationFactory,
+                messageContextFilter: messageContextFilter,
                 implementationFactoryMessageBodySerializer: messageBodySerializerImplementationFactory);
-            
+
             return services;
         }
     }

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageHandlerCollectionExtensions.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="TMessage">The type of the message that the message handler will process.</typeparam>
         /// <param name="collection">The collection of collection to use in the application.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="collection"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage>(this MessageHandlerCollection collection)
             where TMessageHandler : class, IMessageHandler<TMessage, MessageContext>
             where TMessage : class
@@ -36,6 +37,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="collection">The collection of collection to use in the application.</param>
         /// <param name="implementationFactory">The function that creates the service.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="collection"/> or <paramref name="implementationFactory"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage>(
             this MessageHandlerCollection collection,
             Func<IServiceProvider, TMessageHandler> implementationFactory)
@@ -55,7 +57,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="collection">The collection of collection to use in the application.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="collection"/> is <c>null</c>.</exception>
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(this MessageHandlerCollection collection)
-            where TMessageHandler : class, IMessageHandler<TMessage, TMessageContext> 
+            where TMessageHandler : class, IMessageHandler<TMessage, TMessageContext>
             where TMessage : class
             where TMessageContext : MessageContext
         {
@@ -76,7 +78,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             this MessageHandlerCollection collection,
             Func<IServiceProvider, TMessageHandler> implementationFactory)
-            where TMessageHandler : class, IMessageHandler<TMessage, TMessageContext> 
+            where TMessageHandler : class, IMessageHandler<TMessage, TMessageContext>
             where TMessage : class
             where TMessageContext : MessageContext
         {
@@ -157,7 +159,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static MessageHandlerCollection WithFallbackMessageHandler<TMessageHandler, TMessageContext>(
             this MessageHandlerCollection collection,
             Func<IServiceProvider, TMessageHandler> createImplementation)
-            where TMessageHandler : IFallbackMessageHandler<string, TMessageContext> 
+            where TMessageHandler : IFallbackMessageHandler<string, TMessageContext>
             where TMessageContext : MessageContext
         {
             if (collection is null)

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageSerializer.MessageBody.IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageSerializer.MessageBody.IServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageBodyFilter">The filter to restrict the message processing based on the incoming message body.</param>
         /// <param name="messageBodySerializer">The custom <see cref="IMessageBodySerializer"/> to deserialize the incoming message for the <typeparamref name="TMessageHandler"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or <paramref name="messageBodyFilter"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage>(
             this MessageHandlerCollection services,
             IMessageBodySerializer messageBodySerializer,
@@ -41,6 +42,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageBodyFilter">The filter to restrict the message processing based on the incoming message body.</param>
         /// <param name="messageBodySerializerImplementationFactory">The function to create an custom <see cref="IMessageBodySerializer"/> to deserialize the incoming message for the <typeparamref name="TMessageHandler"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or <paramref name="messageBodyFilter"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage>(
             this MessageHandlerCollection services,
             Func<IServiceProvider, IMessageBodySerializer> messageBodySerializerImplementationFactory,
@@ -108,6 +110,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="implementationFactory">The function that creates the service.</param>
         /// <param name="messageBodySerializer">The custom <see cref="IMessageBodySerializer"/> to deserialize the incoming message for the <typeparamref name="TMessageHandler"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/>, <paramref name="messageBodyFilter"/>, or <paramref name="implementationFactory"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage>(
             this MessageHandlerCollection services,
             IMessageBodySerializer messageBodySerializer,
@@ -131,6 +134,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageHandlerImplementationFactory">The function that creates the service.</param>
         /// <param name="messageBodySerializerImplementationFactory">The function to create an custom <see cref="IMessageBodySerializer"/> to deserialize the incoming message for the <typeparamref name="TMessageHandler"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/>, <paramref name="messageBodyFilter"/>, or <paramref name="messageHandlerImplementationFactory"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage>(
             this MessageHandlerCollection services,
             Func<IServiceProvider, IMessageBodySerializer> messageBodySerializerImplementationFactory,
@@ -218,10 +222,10 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             services.AddMessageHandler(
-                messageHandlerImplementationFactory, 
-                messageBodyFilter, 
+                messageHandlerImplementationFactory,
+                messageBodyFilter,
                 implementationFactoryMessageBodySerializer: messageBodySerializerImplementationFactory);
-            
+
             return services;
         }
     }

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageSerializer.MessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageSerializer.MessageHandlerCollectionExtensions.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="TMessage">The type of the message that the message handler will process.</typeparam>
         /// <param name="services">The collection of services to use in the application.</param>
         /// <param name="messageBodySerializer">The custom <see cref="IMessageBodySerializer"/> to deserialize the incoming message for the <typeparamref name="TMessageHandler"/>.</param>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage>(
             this MessageHandlerCollection services,
             IMessageBodySerializer messageBodySerializer)
@@ -56,6 +57,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The collection of services to use in the application.</param>
         /// <param name="messageBodySerializer">The function to create the custom <see cref="IMessageBodySerializer"/> that deserializes the incoming message for the <see cref="IMessageHandler{TMessage,TMessageContext}"/>.</param>
         /// <param name="implementationFactory">The function that creates the service.</param>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage>(
             this MessageHandlerCollection services,
             IMessageBodySerializer messageBodySerializer,
@@ -91,7 +93,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
                 services,
-                messageBodySerializerImplementationFactory: _ => messageBodySerializer, 
+                messageBodySerializerImplementationFactory: _ => messageBodySerializer,
                 messageHandlerImplementationFactory: implementationFactory);
         }
 
@@ -103,6 +105,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="TMessage">The type of the message that the message handler will process.</typeparam>
         /// <param name="services">The collection of services to use in the application.</param>
         /// <param name="messageBodySerializerImplementationFactory">The function to create an custom <see cref="IMessageBodySerializer"/> to deserialize the incoming message for the <typeparamref name="TMessageHandler"/>.</param>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage>(
             this MessageHandlerCollection services,
             Func<IServiceProvider, IMessageBodySerializer> messageBodySerializerImplementationFactory)
@@ -130,7 +133,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             return WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
                 services,
-                messageBodySerializerImplementationFactory, 
+                messageBodySerializerImplementationFactory,
                 serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
         }
 
@@ -142,6 +145,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The collection of services to use in the application.</param>
         /// <param name="messageBodySerializerImplementationFactory">The function to create the custom <see cref="IMessageBodySerializer"/> that deserializes the incoming message for the <see cref="IMessageHandler{TMessage,TMessageContext}"/>.</param>
         /// <param name="messageHandlerImplementationFactory">The function that creates the service.</param>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage>(
             this MessageHandlerCollection services,
             Func<IServiceProvider, IMessageBodySerializer> messageBodySerializerImplementationFactory,

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/IMessageHandler.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/IMessageHandler.cs
@@ -31,6 +31,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
     /// Represents a handler for a specific <typeparamref name="TMessage"/> in a <see cref="MessageContext"/>
     /// during the processing of the message pump or router.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
     public interface IMessageHandler<in TMessage> : IMessageHandler<TMessage, MessageContext>
     {
     }


### PR DESCRIPTION
Only concrete implementations of the message pump and message router will be available in the v3.0 space. This PR deprecates the message handler interface and registration with the general `MessageContext` so that it can be removed later on.

General message routing includes routing messages based on string instead of concrete types like ServiceBusReceivedMessage. The general message routing was required before when using it directly in Azure Functions, but since we removed the specific Azure Funcions support, we should remove this general message routing as well.

Relates to lightweight exercise described in https://github.com/arcus-azure/arcus.messaging/discussions/470