### PR TITLE
chore(service-bus): deprecate automatic az service-bus topic subscriptions

### DIFF
--- a/docs/preview/02-Features/02-message-handling/01-service-bus.md
+++ b/docs/preview/02-Features/02-message-handling/01-service-bus.md
@@ -436,10 +436,6 @@ public class Program
                 // Indicate whether or not the default built-in JSON deserialization should ignore additional members 
                 // when deserializing the incoming message (default: AdditionalMemberHandling.Error).
                 options.Routing.Deserialization.AdditionalMembers = AdditionalMemberHandling.Ignore;
-
-                // Indicate whether or not a new Azure Service Bus Topic subscription should be created/deleted
-                // when the message pump starts/stops (default: None, so no subscription will be created or deleted).
-                options.TopicSubscription = TopicSubscription.Automatic;
             });
 
         services.AddServiceBusQueueMessagePump(...

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -136,12 +136,14 @@ namespace Arcus.Messaging.Pumps.ServiceBus
         /// <param name="cancellationToken">Indicates that the start process has been aborted.</param>
         public override async Task StartAsync(CancellationToken cancellationToken)
         {
+#pragma warning disable CS0618
             if (Settings.ServiceBusEntity == ServiceBusEntityType.Topic
                 && Settings.Options.TopicSubscription.HasValue
                 && Settings.Options.TopicSubscription.Value.HasFlag(TopicSubscription.Automatic))
             {
                 _ownsTopicSubscription = await CreateTopicSubscriptionAsync(cancellationToken);
             }
+#pragma warning restore
 
             await base.StartAsync(cancellationToken);
         }
@@ -391,6 +393,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
                 await _messageReceiver.CloseAsync();
             }
 
+#pragma warning disable CS0618
             if (Settings.ServiceBusEntity == ServiceBusEntityType.Topic
                 && Settings.Options.TopicSubscription.HasValue
                 && Settings.Options.TopicSubscription.Value.HasFlag(TopicSubscription.Automatic)
@@ -398,6 +401,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             {
                 await DeleteTopicSubscriptionAsync(cancellationToken);
             }
+#pragma warning restore
 
             await base.StopAsync(cancellationToken);
             _isHostShuttingDown = true;

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 
+#pragma warning disable CS0618
+
 namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
 {
     /// <summary>
@@ -29,6 +31,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// <remarks>
         ///     Provides capability to create and delete these subscriptions. This requires 'Manage' permissions on the Azure Service Bus Topic or namespace.
         /// </remarks>
+        [Obsolete("Will be removed in v3.0 as automatic Azure Service bus topic subscriptions will not be supported anymore")]
         public TopicSubscription? TopicSubscription { get; set; }
 
         /// <summary>

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
@@ -31,7 +31,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// <remarks>
         ///     Provides capability to create and delete these subscriptions. This requires 'Manage' permissions on the Azure Service Bus Topic or namespace.
         /// </remarks>
-        [Obsolete("Will be removed in v3.0 as automatic Azure Service bus topic subscriptions will not be supported anymore")]
+        [Obsolete("Will be removed in v3.0 as automatic Azure Service bus topic subscription creation and deletion will not be supported anymore")]
         public TopicSubscription? TopicSubscription { get; set; }
 
         /// <summary>

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusTopicMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusTopicMessagePumpOptions.cs
@@ -15,8 +15,9 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// <remarks>
         ///     Provides capability to create and delete these subscriptions. This requires 'Manage' permissions on the Azure Service Bus Topic or namespace.
         /// </remarks>
+        [Obsolete("Will be removed in v3.0 as automatic Azure Service bus topic subscriptions will not be supported anymore")]
         TopicSubscription? TopicSubscription { get; set; }
-        
+
         /// <summary>
         /// Gets or sets the maximum concurrent calls to process messages.
         /// </summary>
@@ -40,7 +41,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// Gets or sets the flag to indicate whether or not to emit security events during the lifetime of the message pump.
         /// </summary>
         bool EmitSecurityEvents { get; set; }
-        
+
         /// <summary>
         /// Gets or sets the unique identifier for this background job to distinguish this job instance in a multi-instance deployment.
         /// </summary>

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusTopicMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusTopicMessagePumpOptions.cs
@@ -15,7 +15,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// <remarks>
         ///     Provides capability to create and delete these subscriptions. This requires 'Manage' permissions on the Azure Service Bus Topic or namespace.
         /// </remarks>
-        [Obsolete("Will be removed in v3.0 as automatic Azure Service bus topic subscriptions will not be supported anymore")]
+        [Obsolete("Will be removed in v3.0 as automatic Azure Service bus topic subscription creation and deletion will not be supported anymore")]
         TopicSubscription? TopicSubscription { get; set; }
 
         /// <summary>

--- a/src/Arcus.Messaging.Pumps.ServiceBus/TopicSubscription.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/TopicSubscription.cs
@@ -1,8 +1,11 @@
-﻿namespace Arcus.Messaging.Pumps.ServiceBus
+﻿using System;
+
+namespace Arcus.Messaging.Pumps.ServiceBus
 {
     /// <summary>
     /// Represents the option to control the topic subscription existence during the lifecycle of the <see cref="AzureServiceBusMessagePump"/>.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 as automatic Azure Service bus topic subscriptions will not be supported anymore")]
     public enum TopicSubscription
     {
         /// <summary>

--- a/src/Arcus.Messaging.Pumps.ServiceBus/TopicSubscription.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/TopicSubscription.cs
@@ -5,7 +5,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
     /// <summary>
     /// Represents the option to control the topic subscription existence during the lifecycle of the <see cref="AzureServiceBusMessagePump"/>.
     /// </summary>
-    [Obsolete("Will be removed in v3.0 as automatic Azure Service bus topic subscriptions will not be supported anymore")]
+    [Obsolete("Will be removed in v3.0 as automatic Azure Service bus topic subscription creation and deletion will not be supported anymore")]
     public enum TopicSubscription
     {
         /// <summary>


### PR DESCRIPTION
> 👉 This is a follow-up PR for #471.

It came to our attention that we only require a `ServiceBusAdministrationClient` in case of automatic Azure Service bus topic subscriptions. Because this functionality is not used very often in production, and should be in a 'Infrastructure-as-Code' deployment anyway to follow best practices, it is better to deprecate this functionality.

This PR deprecates the option and removes it from the feature documentation.