### PR TITLE
chore(service-bus): deprecat emit security-events in service-bus

### DIFF
--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
@@ -80,6 +80,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// <summary>
         /// Gets or sets the flag to indicate whether or not to emit security events during the lifetime of the message pump.
         /// </summary>
+        [Obsolete("Will be removed in v3.0 as the direct link to Arcus.Observability will be removed as well")]
         public bool EmitSecurityEvents { get; set; } = false;
 
         /// <summary>

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpSettings.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpSettings.cs
@@ -12,6 +12,8 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
+#pragma warning disable CS0618
+
 namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
 {
     /// <summary>

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusQueueMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusQueueMessagePumpOptions.cs
@@ -30,6 +30,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// <summary>
         /// Gets or sets the flag to indicate whether or not to emit security events during the lifetime of the message pump.
         /// </summary>
+        [Obsolete("Will be removed in v3.0 as the direct link to Arcus.Observability will be removed as well")]
         bool EmitSecurityEvents { get; set; }
 
         /// <summary>

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusTopicMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusTopicMessagePumpOptions.cs
@@ -16,7 +16,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         ///     Provides capability to create and delete these subscriptions. This requires 'Manage' permissions on the Azure Service Bus Topic or namespace.
         /// </remarks>
         TopicSubscription? TopicSubscription { get; set; }
-        
+
         /// <summary>
         /// Gets or sets the maximum concurrent calls to process messages.
         /// </summary>
@@ -39,8 +39,9 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// <summary>
         /// Gets or sets the flag to indicate whether or not to emit security events during the lifetime of the message pump.
         /// </summary>
+        [Obsolete("Will be removed in v3.0 as the direct link to Arcus.Observability will be removed as well")]
         bool EmitSecurityEvents { get; set; }
-        
+
         /// <summary>
         /// Gets or sets the unique identifier for this background job to distinguish this job instance in a multi-instance deployment.
         /// </summary>


### PR DESCRIPTION
The `EmitSecurityEvents` option for the Azure Service bus message pump was a flag to send a custom event via a direct link with Arcus.Observability. During the slimed-down exercise described in #470 , the direct links to Arcus.Observbility is reviewed, which makes this option obsolete.

This PR deprectes this option in the exposed option interfaces