### PR TITLE
chore(service-bus): deprecate key rotation timeout option

### DIFF
--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
@@ -108,6 +108,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// Gets or sets the timeout when the message pump tries to restart and re-authenticate during key rotation.
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="value"/> is less than <see cref="TimeSpan.Zero"/>.</exception>
+        [Obsolete("Will be removed in v3.0 as the key rotation functionality will be removed as well")]
         public TimeSpan KeyRotationTimeout
         {
             get => _keyRotationTimeout;

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusQueueMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusQueueMessagePumpOptions.cs
@@ -43,6 +43,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// Gets or sets the timeout when the message pump tries to restart and re-authenticate during key rotation.
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="value"/> is less than <see cref="TimeSpan.Zero"/>.</exception>
+        [Obsolete("Will be removed in v3.0 as the key rotation functionality will be removed as well")]
         TimeSpan KeyRotationTimeout { get; set; }
 
         /// <summary>

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusTopicMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/IAzureServiceBusTopicMessagePumpOptions.cs
@@ -53,6 +53,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// Gets or sets the timeout when the message pump tries to restart and re-authenticate during key rotation.
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="value"/> is less than <see cref="TimeSpan.Zero"/>.</exception>
+        [Obsolete("Will be removed in v3.0 as the key rotation functionality will be removed as well")]
         TimeSpan KeyRotationTimeout { get; set; }
 
         /// <summary>


### PR DESCRIPTION
During the slimed-down exercise described in #470 , the focus will be on pure message routing/handling. Key rotation functionality will not be part of this core functionality.
The other key rotation functionality is already being made deprecated in another PR: #495, this PR deprecates the now unused option.