### PR TITLE
chore(docker): remove (now) unused/leftover test hosting types enums

### DIFF
--- a/src/Arcus.Messaging.Tests.Integration/Fixture/IntegrationTestHostingType.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/IntegrationTestHostingType.cs
@@ -1,8 +1,0 @@
-﻿namespace Arcus.Messaging.Tests.Integration.Fixture
-{
-    public enum IntegrationTestHostingType
-    {
-        Worker,
-        AzureFunctions
-    }
-}

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/IntegrationTestType.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/IntegrationTestType.cs
@@ -1,7 +1,0 @@
-﻿namespace Arcus.Messaging.Tests.Integration.Fixture
-{
-    public enum IntegrationTestType
-    {
-        SelfContained,
-    }
-}


### PR DESCRIPTION
In a previous PR #446 the Docker integration tests were removed as to both simplify and centralize the responsibility of the Arcus.Messaging library. During that exercise, there were some leftover enumerations that are now being unused throughout the integration test project.

This PR removes those enumerations.