### PR TITLE
chore(testing): remove unused polly dependency in tests

### DIFF
--- a/src/Arcus.Messaging.Tests.Core/Arcus.Messaging.Tests.Core.csproj
+++ b/src/Arcus.Messaging.Tests.Core/Arcus.Messaging.Tests.Core.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.7.1" />
     <PackageReference Include="Bogus" Version="29.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Polly" Version="7.2.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/Fixture/AssertX.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/Fixture/AssertX.cs
@@ -3,9 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.ApplicationInsights.Channel;
 using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.Extensions.Logging;
-using Polly;
-using Polly.Retry;
 using Xunit;
 
 namespace Arcus.Messaging.Tests.Integration.MessagePump.Fixture
@@ -15,21 +12,6 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump.Fixture
     /// </summary>
     public static class AssertX
     {
-        public static void RetryAssertUntil(Action assertion, TimeSpan timeout, ILogger logger)
-        {
-            RetryPolicy retryPolicy =
-                Policy.Handle<Exception>(exception =>
-                      {
-                          logger.LogError(exception, "Failed assertion. Reason: {Message}", exception.Message);
-                          return true;
-                      })
-                      .WaitAndRetryForever(index => TimeSpan.FromSeconds(5));
-
-            Policy.Timeout(timeout)
-                  .Wrap(retryPolicy)
-                  .Execute(assertion);
-        }
-
         public static RequestTelemetry GetRequestFrom(
             IEnumerable<ITelemetry> telemetries,
             Predicate<RequestTelemetry> filter)


### PR DESCRIPTION
In previous versions, the integration tests used a custom way of polling for results in Application Insights during the test assertion of telemetry. These test polling operations are now being handled by Arcus.Testing, which means that we can remove any direct Polly reference.

This PR removes the Polly dependency and any remaining functionality that was using this in the integration test infrastructure.