### PR TITLE
chore(message-routing): deprecate custom type-not-found exception

### DIFF
--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageHandler.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageHandler.cs
@@ -322,7 +322,6 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// <exception cref="ArgumentNullException">
         ///     Thrown when the <paramref name="message"/>, <paramref name="messageContext"/>, or <paramref name="correlationInfo"/> is <c>null</c>.
         /// </exception>
-        /// <exception cref="TypeNotFoundException">Thrown when no processing method was found on the message handler.</exception>
         /// <exception cref="InvalidOperationException">Thrown when the message handler cannot process the message correctly.</exception>
         /// <exception cref="AmbiguousMatchException">Thrown when more than a single processing method was found on the message handler.</exception>
         public async Task<bool> ProcessMessageAsync<TMessageContext>(

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/TypeNotFoundException.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/TypeNotFoundException.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 
-namespace Arcus.Messaging.Abstractions.MessageHandling 
+namespace Arcus.Messaging.Abstractions.MessageHandling
 {
     /// <summary>
     /// Exception thrown when a specific type cannot be found during reflected selection.
     /// </summary>
     [Serializable]
+    [Obsolete("Will be removed in v3.0 as no reflection is included anymore in message routing, which means no need for this custom exception")]
     public class TypeNotFoundException : Exception
     {
         /// <summary>


### PR DESCRIPTION
A long time ago, code reflection was the only way to do message routing. The custom `TypeNotFoundException` exception class was introduced for a more user-friendly way of reporting not-found members.
Since we have stepped away from code reflection a long time ago, we can deprecate this exception and eventually remove it in v3.0.