### PR TITLE
chore(general): deprecate remaining message handler registrations

### DIFF
--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageBody.MessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageBody.MessageHandlerCollectionExtensions.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The collection of services to use in the application.</param>
         /// <param name="messageBodyFilter">The filter to restrict the message processing based on the incoming message body.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or <paramref name="messageBodyFilter"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             this MessageHandlerCollection services,
             Func<TMessage, bool> messageBodyFilter)
@@ -83,6 +84,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageBodyFilter">The filter to restrict the message processing based on the incoming message body.</param>
         /// <param name="implementationFactory">The function that creates the message handler.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/>, <paramref name="messageBodyFilter"/>, or <paramref name="implementationFactory"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             this MessageHandlerCollection services,
             Func<TMessage, bool> messageBodyFilter,

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageBody.IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageBody.IServiceCollectionExtensions.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageContextFilter">The function that determines if the message handler should handle the message based on the context.</param>
         /// <param name="messageBodyFilter">The filter to restrict the message processing based on the incoming message body.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/>, <paramref name="messageContextFilter"/>, or <paramref name="messageBodyFilter"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             this MessageHandlerCollection services,
             Func<TMessageContext, bool> messageContextFilter,
@@ -90,6 +91,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageBodyFilter">The filter to restrict the message processing based on the incoming message body.</param>
         /// <param name="implementationFactory">The function that creates the message handler.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/>, <paramref name="messageContextFilter"/>, <paramref name="messageBodyFilter"/>, or <paramref name="implementationFactory"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             this MessageHandlerCollection services,
             Func<TMessageContext, bool> messageContextFilter,

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageHandlerCollectionExtensions.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The collection of services to use in the application.</param>
         /// <param name="messageContextFilter">The function that determines if the message handler should handle the message based on the context.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or <paramref name="messageContextFilter"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             this MessageHandlerCollection services,
             Func<TMessageContext, bool> messageContextFilter)
@@ -83,6 +84,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageContextFilter">The function that determines if the message handler should handle the message based on the context.</param>
         /// <param name="implementationFactory">The function that creates the message handler.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/>, <paramref name="messageContextFilter"/>, or <paramref name="implementationFactory"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             this MessageHandlerCollection services,
             Func<TMessageContext, bool> messageContextFilter,

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageSerializer.MessageBody.IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageSerializer.MessageBody.IServiceCollectionExtensions.cs
@@ -69,6 +69,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageBodySerializer">The custom <see cref="IMessageBodySerializer"/> to deserialize the incoming message for the <typeparamref name="TMessageHandler"/>.</param>
         /// <param name="messageBodyFilter">The filter to restrict the message processing based on the incoming message body.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or <paramref name="messageBodyFilter"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             this MessageHandlerCollection services,
             Func<TMessageContext, bool> messageContextFilter,
@@ -94,6 +95,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageBodySerializerImplementationFactory">The function to create an custom <see cref="IMessageBodySerializer"/> to deserialize the incoming message for the <typeparamref name="TMessageHandler"/>.</param>
         /// <param name="messageBodyFilter">The filter to restrict the message processing based on the incoming message body.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or <paramref name="messageBodyFilter"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             this MessageHandlerCollection services,
             Func<TMessageContext, bool> messageContextFilter,
@@ -172,6 +174,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageBodyFilter">The filter to restrict the message processing based on the incoming message body.</param>
         /// <param name="implementationFactory">The function that creates the message handler.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/>, <paramref name="messageBodyFilter"/>, or <paramref name="implementationFactory"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             this MessageHandlerCollection services,
             Func<TMessageContext, bool> messageContextFilter,
@@ -203,6 +206,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageBodyFilter">The filter to restrict the message processing based on the incoming message body.</param>
         /// <param name="messageHandlerImplementationFactory">The function that creates the message handler.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/>, <paramref name="messageBodyFilter"/>, or <paramref name="messageHandlerImplementationFactory"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             this MessageHandlerCollection services,
             Func<TMessageContext, bool> messageContextFilter,

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageSerializer.MessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageContext.MessageSerializer.MessageHandlerCollectionExtensions.cs
@@ -110,6 +110,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The collection of services to use in the application.</param>
         /// <param name="messageContextFilter">The function that determines if the message handler should handle the message based on the context.</param>
         /// <param name="messageBodySerializer">The function that creates the <see cref="IMessageBodySerializer"/> implementation.</param>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             this MessageHandlerCollection services,
             Func<TMessageContext, bool> messageContextFilter,
@@ -133,6 +134,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageContextFilter">The function that determines if the message handler should handle the message based on the context.</param>
         /// <param name="messageHandlerImplementationFactory">The function that creates the message handler.</param>
         /// <param name="messageBodySerializer">The <see cref="IMessageBodySerializer"/> that custom deserializes the incoming message for the <see cref="IMessageHandler{TMessage,TMessageContext}"/>.</param>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             this MessageHandlerCollection services,
             Func<TMessageContext, bool> messageContextFilter,
@@ -161,6 +163,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The collection of services to use in the application.</param>
         /// <param name="messageContextFilter">The function that determines if the message handler should handle the message based on the context.</param>
         /// <param name="messageBodySerializerImplementationFactory">The function that creates the <see cref="IMessageBodySerializer"/> implementation.</param>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             this MessageHandlerCollection services,
             Func<TMessageContext, bool> messageContextFilter,
@@ -184,6 +187,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageContextFilter">The function that determines if the message handler should handle the message based on the context.</param>
         /// <param name="messageHandlerImplementationFactory">The function that creates the message handler.</param>
         /// <param name="messageBodySerializerImplementationFactory">The function that creates the <see cref="IMessageBodySerializer"/>.</param>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             this MessageHandlerCollection services,
             Func<TMessageContext, bool> messageContextFilter,

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageHandlerCollectionExtensions.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="TMessageContext">The type of the context in which the message handler will process the message.</typeparam>
         /// <param name="collection">The collection of collection to use in the application.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="collection"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(this MessageHandlerCollection collection)
             where TMessageHandler : class, IMessageHandler<TMessage, TMessageContext>
             where TMessage : class
@@ -75,6 +76,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="collection">The collection of collection to use in the application.</param>
         /// <param name="implementationFactory">The function that creates the message handler.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="collection"/> or <paramref name="implementationFactory"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             this MessageHandlerCollection collection,
             Func<IServiceProvider, TMessageHandler> implementationFactory)

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageSerializer.MessageBody.IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageSerializer.MessageBody.IServiceCollectionExtensions.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageBodyFilter">The filter to restrict the message processing based on the incoming message body.</param>
         /// <param name="messageBodySerializer">The custom <see cref="IMessageBodySerializer"/> to deserialize the incoming message for the <typeparamref name="TMessageHandler"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or <paramref name="messageBodyFilter"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             this MessageHandlerCollection services,
             IMessageBodySerializer messageBodySerializer,
@@ -87,6 +88,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageBodyFilter">The filter to restrict the message processing based on the incoming message body.</param>
         /// <param name="messageBodySerializerImplementationFactory">The function to create an custom <see cref="IMessageBodySerializer"/> to deserialize the incoming message for the <typeparamref name="TMessageHandler"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or <paramref name="messageBodyFilter"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             this MessageHandlerCollection services,
             Func<IServiceProvider, IMessageBodySerializer> messageBodySerializerImplementationFactory,
@@ -159,6 +161,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="implementationFactory">The function that creates the message handler.</param>
         /// <param name="messageBodySerializer">The custom <see cref="IMessageBodySerializer"/> to deserialize the incoming message for the <typeparamref name="TMessageHandler"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/>, <paramref name="messageBodyFilter"/>, or <paramref name="implementationFactory"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             this MessageHandlerCollection services,
             IMessageBodySerializer messageBodySerializer,
@@ -192,6 +195,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="messageHandlerImplementationFactory">The function that creates the message handler.</param>
         /// <param name="messageBodySerializerImplementationFactory">The function to create an custom <see cref="IMessageBodySerializer"/> to deserialize the incoming message for the <typeparamref name="TMessageHandler"/>.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/>, <paramref name="messageBodyFilter"/>, or <paramref name="messageHandlerImplementationFactory"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             this MessageHandlerCollection services,
             Func<IServiceProvider, IMessageBodySerializer> messageBodySerializerImplementationFactory,

--- a/src/Arcus.Messaging.Abstractions/Extensions/MessageSerializer.MessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/MessageSerializer.MessageHandlerCollectionExtensions.cs
@@ -38,6 +38,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="TMessageContext">The type of the context in which the message handler will process the message.</typeparam>
         /// <param name="services">The collection of services to use in the application.</param>
         /// <param name="messageBodySerializer">The custom <see cref="IMessageBodySerializer"/> to deserialize the incoming message for the <typeparamref name="TMessageHandler"/>.</param>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             this MessageHandlerCollection services,
             IMessageBodySerializer messageBodySerializer)
@@ -78,6 +79,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The collection of services to use in the application.</param>
         /// <param name="implementationFactory">The function that creates the message handler.</param>
         /// <param name="messageBodySerializer">The <see cref="IMessageBodySerializer"/> that custom deserializes the incoming message for the <see cref="IMessageHandler{TMessage,TMessageContext}"/>.</param>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             this MessageHandlerCollection services,
             IMessageBodySerializer messageBodySerializer,
@@ -124,6 +126,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="TMessageContext">The type of the context in which the message handler will process the message.</typeparam>
         /// <param name="services">The collection of services to use in the application.</param>
         /// <param name="messageBodySerializerImplementationFactory">The function to create an custom <see cref="IMessageBodySerializer"/> to deserialize the incoming message for the <typeparamref name="TMessageHandler"/>.</param>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             this MessageHandlerCollection services,
             Func<IServiceProvider, IMessageBodySerializer> messageBodySerializerImplementationFactory)
@@ -169,6 +172,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The collection of services to use in the application.</param>
         /// <param name="messageHandlerImplementationFactory">The function that creates the message handler.</param>
         /// <param name="messageBodySerializerImplementationFactory">The function to create an custom <see cref="IMessageBodySerializer"/> to deserialize the incoming message for the <typeparamref name="TMessageHandler"/>.</param>
+        [Obsolete("Will be removed in v3.0 as only concrete implementations of message handling will be supported from now on")]
         public static MessageHandlerCollection WithMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             this MessageHandlerCollection services,
             Func<IServiceProvider, IMessageBodySerializer> messageBodySerializerImplementationFactory,


### PR DESCRIPTION
As described in the #470 discussion, the 'general messaging' will be deprecated in favor of concrete implementations. A previous PR #516 made sure that the references made to these general message handler registrations are minimized, which makes deprecating them in this PR more easy.

This PR deprecates all remaining 'general message handler' registrations in the solution, so they can be deleted in v3.0.