### PR TITLE
chore(telemetry): deprecate telemetry-specific correlation result constructor

### DIFF
--- a/src/Arcus.Messaging.Abstractions/MessageCorrelationResult.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageCorrelationResult.cs
@@ -52,9 +52,10 @@ namespace Arcus.Messaging.Abstractions
         /// <param name="transactionId">The cross-operation transaction ID of the message correlation.</param>
         /// <param name="operationParentId">The parent ID of the message correlation.</param>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="transactionId"/> or the <paramref name="operationParentId"/> is blank.</exception>
+        [Obsolete("Will be moved in v3.0 outside the 'Abstractions' library in a separate Telemetry-specific library, see the v3.0 migration guide for more information")]
         public static MessageCorrelationResult Create(
             TelemetryClient client,
-            string transactionId, 
+            string transactionId,
             string operationParentId)
         {
             if (string.IsNullOrWhiteSpace(transactionId))

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -10,7 +10,6 @@ using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 using Arcus.Messaging.Pumps.Abstractions;
 using Arcus.Messaging.Pumps.ServiceBus.Configuration;
 using Azure.Messaging.ServiceBus;
-using Azure.Messaging.ServiceBus.Administration;
 using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -486,7 +485,10 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             {
                 (string transactionId, string operationParentId) = message.ApplicationProperties.GetTraceParent();
                 var client = ServiceProvider.GetRequiredService<TelemetryClient>();
+
+#pragma warning disable CS0618 // Type or member is obsolete: will be moved to a Telemetry-specific library in v3.0
                 return MessageCorrelationResult.Create(client, transactionId, operationParentId);
+#pragma warning restore
             }
 
             MessageCorrelationInfo correlationInfo =

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -10,6 +10,7 @@ using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 using Arcus.Messaging.Pumps.Abstractions;
 using Arcus.Messaging.Pumps.ServiceBus.Configuration;
 using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
 using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
As described in the #470 discussion, the telemetry-specific concrete implementations will be removed from the core message routing functionality, making it possible to 'inject' certain telmetry solutions. As preperation of that exercise, all telemetry-specific functionality should be made deprecated.

This PR deprecates the specific constructor with the Application Insights `TelemetryClient` for the message correlation result.  