### PR TITLE
chore(general): deprecate leftover general message router/handling registrations

### DIFF
--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
@@ -19,7 +19,9 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
     /// <summary>
     /// Represents an <see cref="IMessageRouter"/> that can route Azure Service Bus <see cref="ServiceBusReceivedMessage"/>s.
     /// </summary>
+#pragma warning disable CS0618 // Type or member is obsolete: general message router will be removed in v3.0 in favor of concrete implementations.
     public class AzureServiceBusMessageRouter : MessageRouter, IAzureServiceBusMessageRouter
+#pragma warning restore CS0618 // Type or member is obsolete
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureServiceBusMessageRouter"/> class.

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/ServiceBusMessageHandlerCollection.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/ServiceBusMessageHandlerCollection.cs
@@ -8,7 +8,9 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
     /// Represents the model that exposes the available <see cref="IAzureServiceBusMessageHandler{TMessage}"/>s, <see cref="IAzureServiceBusFallbackMessageHandler"/>s,
     /// and possible additional configurations that can be configured with the current state of the Azure Service Bus instance.
     /// </summary>
+#pragma warning disable CS0618 // Type or member is obsolete: general message handler collection will be removed in favor of concrete implementations.
     public class ServiceBusMessageHandlerCollection : MessageHandlerCollection
+#pragma warning restore CS0618 // Type or member is obsolete
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ServiceBusMessageHandlerCollection" /> class.

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageHandlerCollection.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageHandlerCollection.cs
@@ -8,6 +8,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
     /// Represents the model that exposes the available <see cref="IMessageHandler{TMessage}"/>s, <see cref="IFallbackMessageHandler"/>s,
     /// and possible additional configurations that can be configured with the current state.
     /// </summary>
+    [Obsolete("Will be removed in favor of concrete message handler collection implementations")]
     public class MessageHandlerCollection
     {
         /// <summary>
@@ -52,7 +53,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             {
                 throw new ArgumentNullException(nameof(implementationFactory));
             }
-            
+
             Services.AddTransient(
                 serviceProvider => MessageHandler.Create(
                     implementationFactory(serviceProvider),

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
@@ -16,9 +16,8 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
     /// <summary>
     /// Represents how incoming messages gets routed through registered <see cref="IMessageHandler{TMessage,TMessageContext}"/> instances.
     /// </summary>
-#pragma warning disable CS0618 // Type or member is obsolete: deprecated interface will be removed in v3.0.
+    [Obsolete("Will be removed in v3.0 in favor of concrete message router implementations")]
     public class MessageRouter : IMessageRouter
-#pragma warning restore CS0618 // Type or member is obsolete
     {
         private readonly JsonSerializerOptions _jsonOptions;
 


### PR DESCRIPTION
As described in the #470 discussion, the general message routing will be removed in v3.0. Previous PR's already deprecated the message handler registrations itself, like #498, this PR deprecates the actual general message router and message handler collection (used during registration). This functionlity is made available in 'concrete' implementations (like Service bus) via inheritance. Which means that in next versions, this functionlity should be exposed in a another way. 