### PR TITLE
chore(observability): deprecate message correlation accessor

### DIFF
--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
@@ -249,7 +249,9 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
 
             try
             {
+#pragma warning disable CS0618 // Type or member is obsolete: will be refactored when moving towards v3.0.
                 var accessor = serviceScope.ServiceProvider.GetService<IMessageCorrelationInfoAccessor>();
+#pragma warning restore CS0618 // Type or member is obsolete
                 accessor?.SetCorrelationInfo(correlationInfo);
 
                 MessageProcessingResult routingResult = await TryRouteMessageWithPotentialFallbackAsync(serviceScope.ServiceProvider, messageReceiver, message, messageContext, correlationInfo, cancellationToken);

--- a/src/Arcus.Messaging.Abstractions/IMessageCorrelationInfoAccessor.cs
+++ b/src/Arcus.Messaging.Abstractions/IMessageCorrelationInfoAccessor.cs
@@ -1,4 +1,5 @@
-﻿using Arcus.Observability.Correlation;
+﻿using System;
+using Arcus.Observability.Correlation;
 
 namespace Arcus.Messaging.Abstractions
 {
@@ -6,6 +7,7 @@ namespace Arcus.Messaging.Abstractions
     /// Represents a marker interface for an <see cref="ICorrelationInfoAccessor{TCorrelationInfo}"/> implementation using the messaging <see cref="MessageCorrelationInfo"/>.
     /// </summary>
     /// <seealso cref="ICorrelationInfoAccessor{TCorrelationInfo}"/>
+    [Obsolete("Will be moved in v3.0 outside the 'Abstractions' library in a separate Serilog-specific library, see the v3.0 migration guide for more information")]
     public interface IMessageCorrelationInfoAccessor : ICorrelationInfoAccessor<MessageCorrelationInfo>
     {
     }

--- a/src/Arcus.Messaging.Abstractions/MessageCorrelationInfoAccessor.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageCorrelationInfoAccessor.cs
@@ -7,6 +7,7 @@ namespace Arcus.Messaging.Abstractions
     /// Represents an <see cref="ICorrelationInfoAccessor{TCorrelationInfo}"/> implementation that's using the marker <see cref="IMessageCorrelationInfoAccessor"/> interface
     /// for accessing the messaging <see cref="MessageCorrelationInfo"/>.
     /// </summary>
+    [Obsolete("Will be moved in v3.0 outside the 'Abstractions' library in a separate Serilog-specific library, see the v3.0 migration guide for more information")]
     public class MessageCorrelationInfoAccessor : IMessageCorrelationInfoAccessor
     {
         private readonly ICorrelationInfoAccessor<MessageCorrelationInfo> _implementation;


### PR DESCRIPTION
As discussed in #470, the core messaging will solely focus on message handling/routing, which makes the hard-linked dependencies to Arcus.Security, Arcus.Observability, Serilog and Application Insights deprecated in the abstractions library. Previous PR's already deprecated Serilog and Arcus.Security functionality, like #491.

This PR deprecates the Arcus.Observability correlation accessor implementation, as this is a rather unnecessary implementation, since the correlation will already be provided via the message routing.