### PR TITLE
chore(observability): deprecate hierarchical message correlation result constructor

### DIFF
--- a/src/Arcus.Messaging.Abstractions/MessageCorrelationResult.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageCorrelationResult.cs
@@ -40,6 +40,7 @@ namespace Arcus.Messaging.Abstractions
         /// </summary>
         /// <param name="correlationInfo">The correlation information based on custom application properties.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="correlationInfo"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as the Hierarchical correlation format is deprecated")]
         public static MessageCorrelationResult Create(MessageCorrelationInfo correlationInfo)
         {
             return new MessageCorrelationResult(correlationInfo ?? throw new ArgumentNullException(nameof(correlationInfo)));

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -497,9 +497,10 @@ namespace Arcus.Messaging.Pumps.ServiceBus
                 message.GetCorrelationInfo(
                     Settings.Options.Routing.Correlation?.TransactionIdPropertyName ?? PropertyNames.TransactionId,
                     Settings.Options.Routing.Correlation?.OperationParentIdPropertyName ?? PropertyNames.OperationParentId);
-#pragma warning restore CS0618 // Type or member is obsolete
 
             return MessageCorrelationResult.Create(correlationInfo);
+#pragma warning restore CS0618 // Type or member is obsolete
+
         }
 
         private static async Task UntilCancelledAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
As partly described in #470, the Hierarchical format will be made deprecated in v2.2 and removed in v3.0. Previous PR's already made parts of it usage obsolete, like #485.

This PR deprecates the constructor for the `MessageCorrelationResult` that's only used for hierarhical purposes. 