### PR TITLE
chore(deps): remove leftover & unused guard.net references

### DIFF
--- a/src/Arcus.Messaging.Abstractions/Extensions/IDictionaryExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions/Extensions/IDictionaryExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
-using GuardNet;
 
 // ReSharper disable once CheckNamespace
 namespace System

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/FallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/FallbackMessageHandler.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using GuardNet;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/src/Arcus.Messaging.Tests.Integration/Extensions/WorkerOptionsExtensions.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Extensions/WorkerOptionsExtensions.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 using Arcus.Messaging.Pumps.ServiceBus;
-using Azure.Messaging.ServiceBus;
-using GuardNet;
 using Microsoft.Extensions.DependencyInjection;
 
 // ReSharper disable once CheckNamespace
@@ -25,8 +23,8 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
         /// <exception cref="ArgumentException">Thrown when the <paramref name="connectionString"/> is blank.</exception>
         public static ServiceBusMessageHandlerCollection AddServiceBusTopicMessagePump(this WorkerOptions options, string connectionString)
         {
-            Guard.NotNull(options, nameof(options));
-            Guard.NotNullOrWhitespace(connectionString, nameof(connectionString));
+            ArgumentNullException.ThrowIfNull(options);
+            ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
 
             return options.Services.AddServiceBusTopicMessagePump(
                 subscriptionName: Guid.NewGuid().ToString(),

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/TemporaryManagedIdentityConnection.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/TemporaryManagedIdentityConnection.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Arcus.Testing;
-using GuardNet;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
@@ -20,8 +19,7 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
             ILogger logger,
             params TemporaryEnvironmentVariable[] environmentVariables)
         {
-            Guard.NotNull(environmentVariables, nameof(environmentVariables));
-            Guard.NotAny(environmentVariables, nameof(environmentVariables));
+            ArgumentNullException.ThrowIfNull(environmentVariables);
 
             _logger = logger ?? NullLogger.Instance;
             _environmentVariables = environmentVariables;
@@ -41,7 +39,7 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="configuration"/> is <c>null</c>.</exception>
         internal static TemporaryManagedIdentityConnection Create(TestConfig configuration, ILogger logger)
         {
-            Guard.NotNull(configuration, nameof(configuration));
+            ArgumentNullException.ThrowIfNull(configuration);
             logger ??= NullLogger.Instance;
 
             string tenantId = configuration.GetTenantId();

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/Worker.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/Worker.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
-using GuardNet;
 using Microsoft.Extensions.Hosting;
 
 namespace Arcus.Messaging.Tests.Integration.Fixture
@@ -34,8 +33,8 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="options"/> is <c>null</c>.</exception>
         public static async Task<Worker> StartNewAsync(WorkerOptions options, [CallerMemberName] string memberName = null)
         {
-            Guard.NotNull(options, nameof(options), "Requires a options instance that influence the test worker implementation");
-            
+            ArgumentNullException.ThrowIfNull(options);
+
             Console.WriteLine("Start '{0}' integration test", memberName);
 
             IHostBuilder hostBuilder = Host.CreateDefaultBuilder();

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/WorkerOptions.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/WorkerOptions.cs
@@ -2,7 +2,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using GuardNet;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -38,7 +37,7 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="additionalHostOption"/> is <c>null</c>.</exception>
         public WorkerOptions Configure(Action<IHostBuilder> additionalHostOption)
         {
-            Guard.NotNull(additionalHostOption, nameof(additionalHostOption), "Requires an custom action that will add the additional hosting option");
+            ArgumentNullException.ThrowIfNull(additionalHostOption);
             _additionalHostOptions.Add(additionalHostOption);
 
             return this;
@@ -51,7 +50,7 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="logger"/> is <c>null</c>.</exception>
         public WorkerOptions AddXunitTestLogging(ITestOutputHelper logger)
         {
-            Guard.NotNull(logger, nameof(logger), "Requires a logger instance to write diagnostic trace messages to the test output");
+            ArgumentNullException.ThrowIfNull(logger);
 
             _outputWriter = logger;
             return this;
@@ -64,8 +63,7 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="configure"/> is <c>null</c>.</exception>
         public WorkerOptions ConfigureSerilog(Action<LoggerConfiguration> configure)
         {
-            Guard.NotNull(configure, nameof(configure));
-
+            ArgumentNullException.ThrowIfNull(configure);
             _additionalSerilogConfigOptions.Add(configure);
 
             return this;
@@ -78,7 +76,7 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="hostBuilder"/> is <c>null</c>.</exception>
         internal void ApplyOptions(IHostBuilder hostBuilder)
         {
-            Guard.NotNull(hostBuilder, nameof(hostBuilder), "Requires a host builder instance to apply the worker options to");
+            ArgumentNullException.ThrowIfNull(hostBuilder);
 
             LoggerConfiguration config =
                 new LoggerConfiguration()

--- a/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthService.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Health/TcpHealthService.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
-using GuardNet;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -33,7 +32,7 @@ namespace Arcus.Messaging.Tests.Integration.Health
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="healthTcpPort"/> is not a valid TCP port number.</exception>
         public TcpHealthService(int healthTcpPort, ILogger logger)
         {
-            Guard.NotLessThan(healthTcpPort, 0, nameof(healthTcpPort), "Requires a TCP health port number that's above zero");
+            ArgumentOutOfRangeException.ThrowIfNegative(healthTcpPort);
             _healthTcpPort = healthTcpPort;
             _logger = logger ?? NullLogger.Instance;
         }

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBus/TestServiceBusMessageProducer.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBus/TestServiceBusMessageProducer.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Arcus.Messaging.Tests.Integration.Fixture;
 using Arcus.Testing;
 using Azure.Messaging.ServiceBus;
-using GuardNet;
 
 namespace Arcus.Messaging.Tests.Integration.MessagePump.ServiceBus
 {
@@ -38,8 +37,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump.ServiceBus
         /// </summary>
         public static TestServiceBusMessageProducer CreateFor(string entityName, TestConfig configuration)
         {
-            Guard.NotNull(configuration, nameof(configuration), "Requires a test configuration to retrieve the Azure Service Bus entity-scoped connection string");
-
+            ArgumentNullException.ThrowIfNull(configuration);
             return new TestServiceBusMessageProducer(entityName, configuration.GetServiceBus());
         }
 
@@ -50,7 +48,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump.ServiceBus
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="messages"/> is <c>null</c>.</exception>
         public async Task ProduceAsync(params ServiceBusMessage[] messages)
         {
-            Guard.NotNull(messages, nameof(messages), "Requires an Azure Service Bus message to send");
+            ArgumentNullException.ThrowIfNull(messages);
 
             await using var client = _connectionString is null
                 ? new ServiceBusClient(_config.HostName, _config.ServicePrincipal.GetCredential())

--- a/src/Arcus.Messaging.Tests.Unit/Extensions/ObjectExtensions.cs
+++ b/src/Arcus.Messaging.Tests.Unit/Extensions/ObjectExtensions.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using System.Text;
 using Azure.Core.Amqp;
 using Bogus;
-using GuardNet;
 using Newtonsoft.Json;
 
 // ReSharper disable once CheckNamespace
@@ -30,8 +29,8 @@ namespace Azure.Messaging.ServiceBus
             string operationId = null,
             IDictionary<string, object> applicationProperties = null)
         {
-            Guard.NotNull(messageBody, nameof(messageBody), "Requires a message body to wrap in an received Azure Service Bus message");
-            
+            ArgumentNullException.ThrowIfNull(messageBody);
+
             string serializedMessageBody = JsonConvert.SerializeObject(messageBody);
             byte[] rawMessage = Encoding.UTF8.GetBytes(serializedMessageBody);
 

--- a/src/Arcus.Messaging.Tests.Unit/Fixture/TestMessageBodySerializer.cs
+++ b/src/Arcus.Messaging.Tests.Unit/Fixture/TestMessageBodySerializer.cs
@@ -1,6 +1,5 @@
 ﻿using System.Threading.Tasks;
 using Arcus.Messaging.Abstractions.MessageHandling;
-using GuardNet;
 using Xunit;
 
 namespace Arcus.Messaging.Tests.Unit.Fixture
@@ -32,7 +31,7 @@ namespace Arcus.Messaging.Tests.Unit.Fixture
         /// </summary>
         public TestMessageBodySerializer(string expectedBody, object message)
         {
-            Guard.NotNull(message, nameof(message), "Requires a test message to be used as result of the message deserialization");
+            ArgumentNullException.ThrowIfNull(message);
 
             _expectedExpectedBody = expectedBody;
             _message = message;

--- a/src/Arcus.Messaging.Tests.Unit/Fixture/TestMessageBodySerializer.cs
+++ b/src/Arcus.Messaging.Tests.Unit/Fixture/TestMessageBodySerializer.cs
@@ -1,3 +1,4 @@
+﻿using System;
 ﻿using System.Threading.Tasks;
 using Arcus.Messaging.Abstractions.MessageHandling;
 using Xunit;


### PR DESCRIPTION
As described in #449 , the Guard.NET will no longer be something that is baked into the Messaging library. Since this dependency is also transient via the Arcus.Observability package, some `using`s and test infrastructure code still had references to Guard.NET. This PR removes those.