### PR TITLE
chore(observability): deprecate hierarchical content-type property name

### DIFF
--- a/src/Arcus.Messaging.Abstractions/PropertyNames.cs
+++ b/src/Arcus.Messaging.Abstractions/PropertyNames.cs
@@ -29,6 +29,7 @@ namespace Arcus.Messaging.Abstractions
         /// <summary>
         /// Gets the context property to get the content type of the message.
         /// </summary>
+        [Obsolete("Will be removed in v3.0 as the property name is only used in deprecated 'Hierarchical' correlation message construction")]
         public const string ContentType = "Content-Type";
     }
 }


### PR DESCRIPTION
As described in the #470 discussion, the 'Hierarchical' correlation format is being made deprecated in v2.2 and removed in v3. This was already partly done in previous PR's, like #485.
This PR deprecates the content-type property name that was solely used in the `ServiceBusMessageBuilder` - which in turn is also made deprecated as it was only used within 'Hierarcical' contexts.