### PR TITLE
chore(general): deprecate unnecessary general message pump information

### DIFF
--- a/src/Arcus.Messaging.Pumps.Abstractions/MessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/MessagePump.cs
@@ -9,7 +9,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using ArgumentException = System.ArgumentException;
+
+#pragma warning disable CS0618 // Type or member is obsolete: lots of deprecated functionality will be removed in v3.0.
 
 namespace Arcus.Messaging.Pumps.Abstractions
 {
@@ -27,21 +28,33 @@ namespace Arcus.Messaging.Pumps.Abstractions
         /// <exception cref="ArgumentNullException">
         ///     Thrown when the <paramref name="configuration"/>, the <paramref name="serviceProvider"/>, or <paramref name="logger"/> is <c>null</c>.
         /// </exception>
+        [Obsolete("Will be removed in v3.0 as the application configuration is not needed anymore by the message pump")]
         protected MessagePump(IConfiguration configuration, IServiceProvider serviceProvider, ILogger logger)
+            : this(serviceProvider, logger)
         {
             if (configuration is null)
             {
                 throw new ArgumentNullException(nameof(configuration));
             }
 
+            Configuration = configuration;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessagePump"/> class.
+        /// </summary>
+        /// <param name="serviceProvider">The collection of services that are configured.</param>
+        /// <param name="logger">The logger to write telemetry to.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
+        protected MessagePump(IServiceProvider serviceProvider, ILogger logger)
+        {
             if (serviceProvider is null)
             {
                 throw new ArgumentNullException(nameof(serviceProvider));
             }
 
-            Logger = logger ?? NullLogger.Instance;
-            Configuration = configuration;
             ServiceProvider = serviceProvider;
+            Logger = logger ?? NullLogger.Instance;
         }
 
         /// <summary>
@@ -62,16 +75,19 @@ namespace Arcus.Messaging.Pumps.Abstractions
         /// <summary>
         /// Gets hte ID of the client being used to connect to the messaging service.
         /// </summary>
+        [Obsolete("Will be removed in v3.0 in favor of using the " + nameof(JobId) + " to identifying a message pump")]
         protected string ClientId { get; private set; }
 
         /// <summary>
         /// Gets entity path that is being processed.
         /// </summary>
+        [Obsolete("Will be moved down to the Azure Service bus message pump in v3.0, as it is related to Azure Service bus")]
         public string EntityPath { get; private set; }
 
         /// <summary>
         /// Gets the configuration of the application.
         /// </summary>
+        [Obsolete("Will be removed in v3.0 as it is not used in the messaging system with the removal of using the application configuration directly to retrieve connection strings")]
         protected IConfiguration Configuration { get; }
 
         /// <summary>
@@ -82,6 +98,7 @@ namespace Arcus.Messaging.Pumps.Abstractions
         /// <summary>
         /// Gets the default encoding used during the message processing through the message pump.
         /// </summary>
+        [Obsolete("Will be removed in v3.0 as it is not used by the messaging system")]
         protected Encoding DefaultEncoding { get; } = Encoding.UTF8;
 
         /// <summary>
@@ -228,6 +245,7 @@ namespace Arcus.Messaging.Pumps.Abstractions
         /// </summary>
         /// <param name="clientId">Id of the client being used to connect to the messaging service</param>
         /// <param name="entityPath">Entity path that is being processed</param>
+        [Obsolete("Will be removed in v3.0 as it is not used in the messaging system")]
         protected void RegisterClientInformation(string clientId, string entityPath)
         {
             if (string.IsNullOrWhiteSpace(clientId))

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
@@ -1139,12 +1139,11 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.AddHostedService(provider =>
             {
-                var config = provider.GetRequiredService<IConfiguration>();
                 var router = provider.GetService<IAzureServiceBusMessageRouter>();
                 var logger = provider.GetService<ILogger<AzureServiceBusMessagePump>>();
 
                 AzureServiceBusMessagePumpSettings settings = createSettings(provider, options);
-                return new AzureServiceBusMessagePump(settings, config, provider, router, logger);
+                return new AzureServiceBusMessagePump(settings, provider, router, logger);
             });
 
             return collection;


### PR DESCRIPTION
As described in the #470 discussion, the core messaging functionality is being reviewed. A part of that exercise is to review the 'general' messaging. Previous PR's already deprecated sevaral parts of this, like #498.

This PR deprecates additional, old, message pump information that was added in one of the first versions of the message pump, that still leaked concrete information to the general abstraction, like an `EntityPath` property.