### PR TITLE
chore(message-router): deprecate az func-only az service-bus message-router registrations

### DIFF
--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/IServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <param name="services">The collection of services to add the router to.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as the message pump will be the main point of interaction, instead of these registration - which were only used in Azure Functions applications")]
         public static ServiceBusMessageHandlerCollection AddServiceBusMessageRouting(this IServiceCollection services)
         {
             return AddServiceBusMessageRouting(services, configureOptions: null);
@@ -30,6 +31,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The collection of services to add the router to.</param>
         /// <param name="configureOptions">The function to configure the options that change the behavior of the router.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as the message pump will be the main point of interaction, instead of these registration - which were only used in Azure Functions applications")]
         public static ServiceBusMessageHandlerCollection AddServiceBusMessageRouting(
             this IServiceCollection services,
             Action<AzureServiceBusMessageRouterOptions> configureOptions)
@@ -52,6 +54,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="implementationFactory">The function to create the <typeparamref name="TMessageRouter"/> implementation.</param>
         /// <typeparam name="TMessageRouter">The type of the <see cref="IAzureServiceBusMessageRouter"/> implementation.</typeparam>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or <paramref name="implementationFactory"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as the message pump will be the main point of interaction, instead of these registration - which were only used in Azure Functions applications")]
         public static ServiceBusMessageHandlerCollection AddServiceBusMessageRouting<TMessageRouter>(
             this IServiceCollection services,
             Func<IServiceProvider, TMessageRouter> implementationFactory)
@@ -74,6 +77,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="configureOptions">The function to configure the options that change the behavior of the router.</param>
         /// <typeparam name="TMessageRouter">The type of the <see cref="IAzureServiceBusMessageRouter"/> implementation.</typeparam>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or <paramref name="implementationFactory"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0 as the message pump will be the main point of interaction, instead of these registration - which were only used in Azure Functions applications")]
         public static ServiceBusMessageHandlerCollection AddServiceBusMessageRouting<TMessageRouter>(
             this IServiceCollection services,
             Func<IServiceProvider, AzureServiceBusMessageRouterOptions, TMessageRouter> implementationFactory,

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
@@ -1127,11 +1127,13 @@ namespace Microsoft.Extensions.DependencyInjection
             AzureServiceBusMessagePumpOptions options =
                 DetermineMessagePumpOptions(configureQueueMessagePump, configureTopicMessagePump);
 
+#pragma warning disable CS0618 // Type or member is obsolete: message router will be initiated directly in v3.0.
             ServiceBusMessageHandlerCollection collection = services.AddServiceBusMessageRouting(provider =>
             {
                 var logger = provider.GetService<ILogger<AzureServiceBusMessageRouter>>();
                 return new AzureServiceBusMessageRouter(provider, options.Routing, logger);
             });
+#pragma warning restore CS0618 // Type or member is obsolete
             collection.JobId = options.JobId;
 
             services.TryAddSingleton<IMessagePumpLifetime, DefaultMessagePumpLifetime>();


### PR DESCRIPTION
As described in the discussion #470, the Azure Functions-support will be removed in v3.0. This means that message router-only functionality/regisrataions are now unnecessary.

This PR deprecates the registrations of the Azure Service bus message router, in favor of using the constructor, in v3.0.  