### PR TITLE
chore(message-router): deprecate az func-only az service-bus message-router overloads

### DIFF
--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
@@ -142,7 +142,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
 
         /// <summary>
         /// Handle a new <paramref name="message"/> that was received by routing them through registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/>s
-        /// and optionally through an registered <see cref="IFallbackMessageHandler"/> or <see cref="IAzureServiceBusFallbackMessageHandler"/>
+        /// and optionally through <see cref="IAzureServiceBusFallbackMessageHandler"/>
         /// if none of the message handlers were able to process the <paramref name="message"/>.
         /// </summary>
         /// <param name="message">The incoming message that needs to be routed through registered message handlers.</param>
@@ -158,6 +158,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         ///     Thrown when the <paramref name="message"/>, <paramref name="messageContext"/>, or <paramref name="correlationInfo"/> is <c>null</c>.
         /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when no message handlers or none matching message handlers are found to process the message.</exception>
+        [Obsolete("Will be removed in v3.0 as the message pump will be the sole point of contact for message processing instead of this overload that was used in message pump-free scenarios like Azure Functions, use the other overload instead with the " + nameof(ServiceBusReceiver))]
         public async Task<MessageProcessingResult> RouteMessageAsync(
             ServiceBusReceivedMessage message,
             AzureServiceBusMessageContext messageContext,
@@ -174,7 +175,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
 
         /// <summary>
         /// Handle a new <paramref name="message"/> that was received by routing them through registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/>s
-        /// and optionally through a registered <see cref="IFallbackMessageHandler"/> or <see cref="IAzureServiceBusFallbackMessageHandler"/>
+        /// and optionally through a <see cref="IAzureServiceBusFallbackMessageHandler"/>
         /// if none of the message handlers were able to process the <paramref name="message"/>.
         /// </summary>
         /// <param name="messageReceiver">
@@ -201,7 +202,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
 
         /// <summary>
         /// Handle a new <paramref name="message"/> that was received by routing them through registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/>s
-        /// and optionally through a registered <see cref="IFallbackMessageHandler"/> or <see cref="IAzureServiceBusFallbackMessageHandler"/>
+        /// and optionally through a registered <see cref="IAzureServiceBusFallbackMessageHandler"/>
         /// if none of the message handlers were able to process the <paramref name="message"/>.
         /// </summary>
         /// <param name="messageReceiver">

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/IAzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/IAzureServiceBusMessageRouter.cs
@@ -7,7 +7,7 @@ using Azure.Messaging.ServiceBus;
 namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
 {
     /// <summary>
-    /// Represents an <see cref="IMessageRouter"/> that can route Azure Service Bus <see cref="ServiceBusReceivedMessage"/>s.
+    /// Represents an instance that can route Azure Service Bus <see cref="ServiceBusReceivedMessage"/>s through registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/>s.
     /// </summary>
 #pragma warning disable CS0618 // Type or member is obsolete: general message router interface will be removed in v3.0.
     public interface IAzureServiceBusMessageRouter : IMessageRouter
@@ -15,7 +15,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
     {
         /// <summary>
         /// Handle a new <paramref name="message"/> that was received by routing them through registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/>s
-        /// and optionally through a registered <see cref="IFallbackMessageHandler"/> or <see cref="IAzureServiceBusFallbackMessageHandler"/>
+        /// and optionally through <see cref="IAzureServiceBusFallbackMessageHandler"/>
         /// if none of the message handlers were able to process the <paramref name="message"/>.
         /// </summary>
         /// <param name="message">The incoming message that needs to be routed through registered message handlers.</param>
@@ -31,6 +31,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         ///     Thrown when the <paramref name="message"/>, <paramref name="messageContext"/>, or <paramref name="correlationInfo"/> is <c>null</c>.
         /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when no message handlers or none matching message handlers are found to process the message.</exception>
+        [Obsolete("Will be removed in v3.0 as the message pump will be the sole point of contact for message processing instead of this overload that was used in message pump-free scenarios like Azure Functions, use the other overload instead with the " + nameof(ServiceBusReceiver))]
         Task<MessageProcessingResult> RouteMessageAsync(
             ServiceBusReceivedMessage message,
             AzureServiceBusMessageContext messageContext,
@@ -39,7 +40,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
 
         /// <summary>
         /// Handle a new <paramref name="message"/> that was received by routing them through registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/>s
-        /// and optionally through a registered <see cref="IFallbackMessageHandler"/> or <see cref="IAzureServiceBusFallbackMessageHandler"/>
+        /// and optionally through a registered <see cref="IAzureServiceBusFallbackMessageHandler"/>
         /// if none of the message handlers were able to process the <paramref name="message"/>.
         /// </summary>
         /// <param name="messageReceiver">


### PR DESCRIPTION
As described in the discussion #470, the message pump-free scenarios like Azure Functions will be removed from support in favor of using the message pump as the sole point of contact for message processing. There was a Azure Service bus overload that was only used in those scenarios. This PR deprecates that overloads, so it can be removed in v3.0.  