### PR TITLE
feat(correlation): deprecate message correlation result in favor of message operation result

### DIFF
--- a/src/Arcus.Messaging.Abstractions/MessageCorrelationResult.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageCorrelationResult.cs
@@ -10,6 +10,7 @@ namespace Arcus.Messaging.Abstractions
     /// Represents the correlation result of a received Azure Service Bus message.
     /// This result will act as the scope of the request telemetry.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 in favor of " + nameof(MessageOperationResult))]
     public sealed class MessageCorrelationResult : IDisposable
     {
         private readonly TelemetryClient _telemetryClient;

--- a/src/Arcus.Messaging.Abstractions/MessageOperationResult.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageOperationResult.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace Arcus.Messaging.Abstractions
+{
+    /// <summary>
+    /// Represents the result of a request tracking operation.
+    /// </summary>
+    public class MessageOperationResult : IDisposable
+    {
+        private readonly DateTimeOffset _startTime;
+        private readonly Stopwatch _watch;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessageOperationResult"/> class.
+        /// </summary>
+        /// <param name="correlationInfo">The correlation information of the current received message.</param>
+        protected MessageOperationResult(MessageCorrelationInfo correlationInfo)
+        {
+            _startTime = DateTimeOffset.UtcNow;
+            _watch = Stopwatch.StartNew();
+
+            Correlation = correlationInfo;
+        }
+
+        /// <summary>
+        /// Gets the correlation information of the current received message.
+        /// </summary>
+        public MessageCorrelationInfo Correlation { get; }
+
+        /// <summary>
+        /// Gets or sets the boolean flag to indicate that the tracked operation for the correlated context was successful.
+        /// </summary>
+        /// <remarks>
+        ///     Used in telemetry tracking systems as a way to provide additional context on the operation.
+        /// </remarks>
+        public bool IsSuccessful { get; set; }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+        /// </summary>
+        protected virtual void Dispose(bool disposing)
+        {
+            _watch.Stop();
+            StopOperation(IsSuccessful, _startTime, _watch.Elapsed);
+        }
+
+        /// <summary>
+        /// Finalizes the tracked operation in the concrete telemetry system, based on the operation results.
+        /// </summary>
+        /// <param name="isSuccessful">The boolean flag to indicate whether the operation was successful.</param>
+        /// <param name="startTime">The date when the operation started.</param>
+        /// <param name="duration">The time it took for the operation to run.</param>
+        protected virtual void StopOperation(bool isSuccessful, DateTimeOffset startTime, TimeSpan duration)
+        {
+        }
+    }
+}

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
@@ -1139,13 +1139,11 @@ namespace Microsoft.Extensions.DependencyInjection
             AzureServiceBusMessagePumpOptions options =
                 DetermineMessagePumpOptions(configureQueueMessagePump, configureTopicMessagePump);
 
-#pragma warning disable CS0618 // Type or member is obsolete: message router will be initiated directly in v3.0.
             ServiceBusMessageHandlerCollection collection = services.AddServiceBusMessageRouting(provider =>
             {
                 var logger = provider.GetService<ILogger<AzureServiceBusMessageRouter>>();
                 return new AzureServiceBusMessageRouter(provider, options.Routing, logger);
             });
-#pragma warning restore CS0618 // Type or member is obsolete
             collection.JobId = options.JobId;
 
             services.TryAddSingleton<IMessagePumpLifetime, DefaultMessagePumpLifetime>();


### PR DESCRIPTION
As described in the discussion #470, the message corelation system should be extracted from the core messaging functionality to support multiple systems.
This PR deprecates the `MessageCorrelationResult` (as it was incorrectly hard-linked to the Serilog/AppInsights correlation system), in favor of a mor general `MessageOperationResult` which will get used when tracking requests in message pumps.