### PR TITLE
feat(az.sb.telemetry): add telemetry options alternative in message pump options

### DIFF
--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Arcus.Messaging.Abstractions.MessageHandling;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 
 #pragma warning disable CS0618
@@ -146,6 +147,11 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// Gets the consumer-configurable options to change the behavior of the message router.
         /// </summary>
         public AzureServiceBusMessageRouterOptions Routing { get; }
+
+        /// <summary>
+        /// Gets the consumer configurable options model to change the behavior of the tracked Azure Service bus request telemetry.
+        /// </summary>
+        public MessageTelemetryOptions Telemetry => Routing.Telemetry;
 
         /// <summary>
         /// Gets the default consumer-configurable options for Azure Service Bus Queue message pumps.

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
@@ -1139,13 +1139,11 @@ namespace Microsoft.Extensions.DependencyInjection
             AzureServiceBusMessagePumpOptions options =
                 DetermineMessagePumpOptions(configureQueueMessagePump, configureTopicMessagePump);
 
-#pragma warning disable CS0618 // Type or member is obsolete: message router will be initiated directly in v3.0.
             ServiceBusMessageHandlerCollection collection = services.AddServiceBusMessageRouting(provider =>
             {
                 var logger = provider.GetService<ILogger<AzureServiceBusMessageRouter>>();
                 return new AzureServiceBusMessageRouter(provider, options.Routing, logger);
             });
-#pragma warning restore CS0618 // Type or member is obsolete
             collection.JobId = options.JobId;
 
             services.TryAddSingleton<IMessagePumpLifetime, DefaultMessagePumpLifetime>();


### PR DESCRIPTION
As described in discussion #470, the message correlation system choice should be extracted from the core messaging functionality. The plan is to expose an interface that can be implemented by specific message correlation systems. Interacting with this interface will be done in the message pump, therefore, the telemetry options to manipulate the message correlation should also be in the message pump options.

This PR creates a new `.Telemetry` options property in the Azure Service bus message options, which should be used instead of the (now) deprecated `.Routing.Telemetry` options. Making it more clear, correct and maintainable.