### PR TITLE
chore(correlation): deprecate general message correlation options

### DIFF
--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageCorrelationEnricherOptions.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageCorrelationEnricherOptions.cs
@@ -7,6 +7,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
     /// <summary>
     /// Represents the consumer configurable options model to change the behavior of the Serilog <see cref="MessageCorrelationInfoEnricher"/>.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 as W3C will be the only supported correlation format")]
     public class MessageCorrelationEnricherOptions : CorrelationInfoEnricherOptions
     {
         private string _cycleIdPropertyName = "CycleId";

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageCorrelationFormat.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageCorrelationFormat.cs
@@ -7,6 +7,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
     /// <summary>
     /// Represents the message correlation format of the received message.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 as W3C will be the only supported correlation format")]
     public enum MessageCorrelationFormat
     {
         /// <summary>

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageCorrelationOptions.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageCorrelationOptions.cs
@@ -7,6 +7,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
     /// <summary>
     /// Represents the user-configurable options to control the correlation information tracking during the receiving of the messages in the message router.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 as W3C will be the only supported correlation format")]
     public class MessageCorrelationOptions
     {
         [Obsolete("Will be removed in v3.0")]

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
@@ -1139,13 +1139,11 @@ namespace Microsoft.Extensions.DependencyInjection
             AzureServiceBusMessagePumpOptions options =
                 DetermineMessagePumpOptions(configureQueueMessagePump, configureTopicMessagePump);
 
-#pragma warning disable CS0618 // Type or member is obsolete: message router will be initiated directly in v3.0.
             ServiceBusMessageHandlerCollection collection = services.AddServiceBusMessageRouting(provider =>
             {
                 var logger = provider.GetService<ILogger<AzureServiceBusMessageRouter>>();
                 return new AzureServiceBusMessageRouter(provider, options.Routing, logger);
             });
-#pragma warning restore CS0618 // Type or member is obsolete
             collection.JobId = options.JobId;
 
             services.TryAddSingleton<IMessagePumpLifetime, DefaultMessagePumpLifetime>();


### PR DESCRIPTION
As described in the discussion #470 , the core messaging functionality will not hold specific correlation systems, which makes all correlation-specific options deprecated within the core messaging.

This PR deprecates the remaining message correlation properties that only make sense in a specific correlation system: W3C.