### PR TITLE
docs(migration.v3.0): add new service-bus message pump registration to v3.0 migration guide

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -61,7 +61,7 @@ module.exports = {
     prism: {
       theme: lightCodeTheme,
       darkTheme: darkCodeTheme,
-      additionalLanguages: ['csharp'],
+      additionalLanguages: ['csharp', 'diff'],
     },
   },
   presets: [

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -61,7 +61,7 @@ module.exports = {
     prism: {
       theme: lightCodeTheme,
       darkTheme: darkCodeTheme,
-      additionalLanguages: ['csharp', 'diff'],
+      additionalLanguages: ['csharp', 'powershell', 'diff'],
     },
   },
   presets: [

--- a/docs/preview/03-Guides/migration-guide-v3.0.md
+++ b/docs/preview/03-Guides/migration-guide-v3.0.md
@@ -1,6 +1,34 @@
 # Migrate from v2.x to v3.0
 Starting from v3.0, there are some major breaking changes related to the [lightweight exercise](https://github.com/arcus-azure/arcus.messaging/discussions/470) that the Messaging library gone through. This guide will make it easier for you to migrate towards this version from an older v2.x version.
 
+## New Service bus message pump registration
+Previously, the registration of the Azure Service bus message pump involved navigating through the many available extensions, making it rather tedious to find the right authentication mechanism.
+
+Starting from v3.0, the registrations of the Azure Service bus message pump is simplified with two simple approaches:
+1. Register message pump with custom `TokenCredential`.
+2. Register message pump with custom implementation factory, that creates a `ServiceBusClient`.
+
+```diff
+// #1 Via custom `TokenCredential`
+
+- services.AddServiceBusQueueMessagePumpUsingManagedIdentity("<queue-name>", "<namespace>")
++ services.AddServiceBusQueueMessagePump("<queue-name>", "<namespace>", new ManagedIdentityCredential())
+
+// #2 Via custom implementation factory (using Arcus secret store)
+
+services.AddSecretStore(...);
+
+- services.AddServiceBusTopicMessagePump("<topic-name>", "<subscription-name>", (ISecretProvider secrets) =>
+- {
+-       return secrets.GetSecret("ConnectionString"));
+- })
++ services.AddServiceBusTopicMessagePump("<topic-name>", "<subscription-name>", (IServiceProvider services) =>
++ {
++       var secrets = services.GetRequiredService<ISecretProvider>();        
++       return new ServiceBusClient(secrets.GetSecret("ConnectionString"));
++})
+```
+
 ## New Service bus message handler registration
 Previously, the registration of custom `IAzureServiceBusMessageHandler<>` implementations involved navigating through the many available extensions, making it rather tedious to find the right overload.
 


### PR DESCRIPTION
In a previous phase, the Azure Service bus message pump registration was reviewed and simplified to handle a dependency-less approach without overload the user with overloads.

This PR adds this new way of registering the message pump to the v3.0 migration guide.
Relates to #506 