### PR TITLE
fix(ci): use custom dotnet command for myget preview release

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -35,6 +35,7 @@ resources:
 
 variables:
   - group: 'Build Configuration'
+  - group: 'MyGet'
   - template: ./variables/build.yml
   - template: ./variables/test.yml
 
@@ -125,4 +126,9 @@ stages:
             inputs:
               artifact: 'Build'
               path: '$(Build.SourcesDirectory)'
-          - template: nuget/publish-preview-package.yml@templates
+          - task: DotNetCoreCLI@2
+            displayName: 'Push to MyGet.org'
+            inputs:
+              command: 'custom'
+              custom: 'nuget'
+              arguments: 'push src/**/*.nupkg --skip-duplicate --source $(MyGet.SourceUrl) --api-key $(MyGet.ApiKey)'


### PR DESCRIPTION
Since we use the `ubuntu-latest` in our CI pipelines, it notified us that the current approach on pushing NuGet packages to our MyGet feed (which gets pushed on every open PR), is now not working anymore with the newest Ubuntu release (v24.04).

Because of this, and the fact that we use YAML templates to streamline throughout Arcus repo's, we are left with a broken CI build.

This PR removes the YAML template in favor of a custom `dotnet nuget` command, as this will both fix the CI build, as well as removing a bit of unnecessary relationship with other Arcus repo's. It allows for Arcus repositories to grow more on their own, and to fix issues (like these) more quicker, without the overhead of other repo's. The downside, is that there might be some duplicated code, but since the amount of Arcus repositories is under review, that duplication might be very little.