### PR TITLE
feat(sb): move service-bus operations to message-context

### DIFF
--- a/src/Arcus.Messaging.Abstractions.ServiceBus/AzureServiceBusMessageContext.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/AzureServiceBusMessageContext.cs
@@ -160,6 +160,18 @@ namespace Arcus.Messaging.Abstractions.ServiceBus
         }
 
         /// <summary>
+        /// Dead letters the Azure Service Bus message on Azure with a reason why the message needs to be dead lettered.
+        /// </summary>
+        /// <param name="deadLetterReason">The reason why the message should be dead lettered.</param>
+        /// <param name="deadLetterErrorDescription">The optional extra description of the dead letter error.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        /// <exception cref="InvalidOperationException">Thrown when the message handler was not initialized correctly.</exception>
+        public async Task DeadLetterMessageAsync(string deadLetterReason, string deadLetterErrorDescription, CancellationToken cancellationToken)
+        {
+            await DeadLetterMessageAsync(deadLetterReason, deadLetterErrorDescription, newMessageProperties: null, cancellationToken);
+        }
+
+        /// <summary>
         /// Dead letters the Azure Service Bus message on Azure while providing <paramref name="newMessageProperties"/> for properties that has to be modified in the process.
         /// </summary>
         /// <param name="deadLetterReason">The reason why the message should be dead lettered.</param>
@@ -172,20 +184,6 @@ namespace Arcus.Messaging.Abstractions.ServiceBus
             EnsureServiceBusFields();
 
             await _receiver.DeadLetterMessageAsync(_message, newMessageProperties, deadLetterReason, deadLetterErrorDescription, cancellationToken);
-        }
-
-        /// <summary>
-        /// Dead letters the Azure Service Bus message on Azure with a reason why the message needs to be dead lettered.
-        /// </summary>
-        /// <param name="deadLetterReason">The reason why the message should be dead lettered.</param>
-        /// <param name="deadLetterErrorDescription">The optional extra description of the dead letter error.</param>
-        /// <param name="cancellationToken">The optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
-        /// <exception cref="InvalidOperationException">Thrown when the message handler was not initialized correctly.</exception>
-        public async Task DeadLetterMessageAsync(string deadLetterReason, string deadLetterErrorDescription, CancellationToken cancellationToken)
-        {
-            EnsureServiceBusFields();
-
-            await _receiver.DeadLetterMessageAsync(_message, deadLetterReason, deadLetterErrorDescription, cancellationToken);
         }
 
         /// <summary>

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/AzureServiceBusMessageContext.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/AzureServiceBusMessageContext.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
 using Microsoft.Extensions.Logging;
 
@@ -11,6 +13,9 @@ namespace Arcus.Messaging.Abstractions.ServiceBus
     /// </summary>
     public class AzureServiceBusMessageContext : MessageContext
     {
+        private readonly ServiceBusReceiver _receiver;
+        private readonly ServiceBusReceivedMessage _message;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureServiceBusMessageContext"/> class.
         /// </summary>
@@ -67,6 +72,9 @@ namespace Arcus.Messaging.Abstractions.ServiceBus
             ServiceBusReceivedMessage message)
             : base(message.MessageId, jobId, message.ApplicationProperties.ToDictionary(item => item.Key, item => item.Value))
         {
+            _receiver = receiver;
+            _message = message;
+
             FullyQualifiedNamespace = receiver.FullyQualifiedNamespace;
             EntityPath = receiver.EntityPath;
             EntityType = entityType;
@@ -138,6 +146,73 @@ namespace Arcus.Messaging.Abstractions.ServiceBus
             }
 
             return new AzureServiceBusMessageContext(jobId, entityType, receiver, message);
+        }
+
+        /// <summary>
+        /// Completes the Azure Service Bus message on Azure. This will delete the message from the service.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown when the message handler was not initialized yet.</exception>
+        public async Task CompleteMessageAsync(CancellationToken cancellationToken)
+        {
+            EnsureServiceBusFields();
+
+            await _receiver.CompleteMessageAsync(_message, cancellationToken);
+        }
+
+        /// <summary>
+        /// Dead letters the Azure Service Bus message on Azure while providing <paramref name="newMessageProperties"/> for properties that has to be modified in the process.
+        /// </summary>
+        /// <param name="deadLetterReason">The reason why the message should be dead lettered.</param>
+        /// <param name="deadLetterErrorDescription">The optional extra description of the dead letter error.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        /// <param name="newMessageProperties">The properties to modify on the message during the dead lettering of the message.</param>
+        /// <exception cref="InvalidOperationException">Thrown when the message handler was not initialized yet.</exception>
+        public async Task DeadLetterMessageAsync(string deadLetterReason, string deadLetterErrorDescription, IDictionary<string, object> newMessageProperties, CancellationToken cancellationToken)
+        {
+            EnsureServiceBusFields();
+
+            await _receiver.DeadLetterMessageAsync(_message, newMessageProperties, deadLetterReason, deadLetterErrorDescription, cancellationToken);
+        }
+
+        /// <summary>
+        /// Dead letters the Azure Service Bus message on Azure with a reason why the message needs to be dead lettered.
+        /// </summary>
+        /// <param name="deadLetterReason">The reason why the message should be dead lettered.</param>
+        /// <param name="deadLetterErrorDescription">The optional extra description of the dead letter error.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        /// <exception cref="InvalidOperationException">Thrown when the message handler was not initialized correctly.</exception>
+        public async Task DeadLetterMessageAsync(string deadLetterReason, string deadLetterErrorDescription, CancellationToken cancellationToken)
+        {
+            EnsureServiceBusFields();
+
+            await _receiver.DeadLetterMessageAsync(_message, deadLetterReason, deadLetterErrorDescription, cancellationToken);
+        }
+
+        /// <summary>
+        /// <para>
+        ///     Abandon the Azure Service Bus message on Azure while providing <paramref name="newMessageProperties"/> for properties that has to be modified in the process.
+        /// </para>
+        /// <para>
+        ///     This will make the message available again for immediate processing as the lock of the message will be released.
+        /// </para>
+        /// </summary>
+        /// <param name="newMessageProperties">The properties to modify on the message during the abandoning of the message.</param>
+        /// <param name="cancellationToken">The optional <see cref="CancellationToken" /> instance to signal the request to cancel the operation.</param>
+        /// <exception cref="InvalidOperationException">Thrown when the message context was not initialized correctly.</exception>
+        public async Task AbandonMessageAsync(IDictionary<string, object> newMessageProperties, CancellationToken cancellationToken)
+        {
+            EnsureServiceBusFields();
+
+            await _receiver.AbandonMessageAsync(_message, newMessageProperties, cancellationToken);
+        }
+
+        private void EnsureServiceBusFields()
+        {
+            if (_receiver is null || _message is null)
+            {
+                throw new InvalidOperationException(
+                    "Cannot run Azure Service bus operations on this message context, as it wasn't initialized with a Service bus receiver and message");
+            }
         }
     }
 }

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/ServiceBusMessageHandlerExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/ServiceBusMessageHandlerExtensions.cs
@@ -109,6 +109,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="TMessageHandler">The type of the fallback message handler.</typeparam>
         /// <param name="handlers">The handlers to add the fallback message handler to.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="handlers"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0, please use the Azure service bus operations on the " + nameof(AzureServiceBusMessageContext) + " instead of defining fallback message handlers")]
         public static ServiceBusMessageHandlerCollection WithServiceBusFallbackMessageHandler<TMessageHandler>(
             this ServiceBusMessageHandlerCollection handlers)
             where TMessageHandler : IAzureServiceBusFallbackMessageHandler
@@ -129,6 +130,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="handlers">The handlers to add the fallback message handler to.</param>
         /// <param name="createImplementation">The function to create the fallback message handler.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="handlers"/> or the <paramref name="createImplementation"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0, please use the Azure service bus operations on the " + nameof(AzureServiceBusMessageContext) + " instead of defining fallback message handlers")]
         public static ServiceBusMessageHandlerCollection WithServiceBusFallbackMessageHandler<TMessageHandler>(
             this ServiceBusMessageHandlerCollection handlers,
             Func<IServiceProvider, TMessageHandler> createImplementation)

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusFallbackMessageHandler.cs
@@ -10,6 +10,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
     /// <summary>
     /// Represents a <see cref="IAzureServiceBusFallbackMessageHandler"/> template to control the Azure Service Bus message operations during the fallback handling of the message.
     /// </summary>
+    [Obsolete("Will be removed in v3.0, please use the Azure service bus operations on the " + nameof(AzureServiceBusMessageContext) + " instead")]
     public abstract class AzureServiceBusFallbackMessageHandler : AzureServiceBusMessageHandlerTemplate, IAzureServiceBusFallbackMessageHandler
     {
         /// <summary>

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusFallbackMessageHandler.cs
@@ -10,7 +10,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
     /// <summary>
     /// Represents a <see cref="IAzureServiceBusFallbackMessageHandler"/> template to control the Azure Service Bus message operations during the fallback handling of the message.
     /// </summary>
-    [Obsolete("Will be removed in v3.0, please use the Azure service bus operations on the " + nameof(AzureServiceBusMessageContext) + " instead")]
+    [Obsolete("Will be removed in v3.0, please implement the " + nameof(IAzureServiceBusMessageHandler<object>) + " directly instead and call the Azure service bus operations on the " + nameof(AzureServiceBusMessageContext) + " to complete/dead-letter/abandon messages")]
     public abstract class AzureServiceBusFallbackMessageHandler : AzureServiceBusMessageHandlerTemplate, IAzureServiceBusFallbackMessageHandler
     {
         /// <summary>

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageHandler.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageHandler.cs
@@ -9,6 +9,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
     /// <summary>
     /// Represents a <see cref="IAzureServiceBusMessageHandler{TMessage}"/> template to control the Azure Service Bus message operations during the handling of the deserialized message.
     /// </summary>
+    [Obsolete("Will be removed in v3.0, please use the Azure service bus operations on the " + nameof(AzureServiceBusMessageContext) + " instead")]
     public abstract class AzureServiceBusMessageHandler<TMessage> : AzureServiceBusMessageHandlerTemplate, IAzureServiceBusMessageHandler<TMessage>
     {
         /// <summary>

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageHandler.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageHandler.cs
@@ -9,7 +9,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
     /// <summary>
     /// Represents a <see cref="IAzureServiceBusMessageHandler{TMessage}"/> template to control the Azure Service Bus message operations during the handling of the deserialized message.
     /// </summary>
-    [Obsolete("Will be removed in v3.0, please use the Azure service bus operations on the " + nameof(AzureServiceBusMessageContext) + " instead")]
+    [Obsolete("Will be removed in v3.0, please implement the " + nameof(IAzureServiceBusMessageHandler<object>) + " directly instead and call the Azure service bus operations on the " + nameof(AzureServiceBusMessageContext) + " to complete/dead-letter/abandon messages")]
     public abstract class AzureServiceBusMessageHandler<TMessage> : AzureServiceBusMessageHandlerTemplate, IAzureServiceBusMessageHandler<TMessage>
     {
         /// <summary>

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageHandlerTemplate.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageHandlerTemplate.cs
@@ -8,6 +8,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
     /// <summary>
     /// Represents the default template when handling Azure Service Bus messages and controlling how the message is being handled by Azure Service Bus.
     /// </summary>
+    [Obsolete("Will be removed in v3.0, please use the Azure service bus operations on the " + nameof(AzureServiceBusMessageContext) + " instead")]
     public abstract class AzureServiceBusMessageHandlerTemplate
     {
         /// <summary>

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageHandlerTemplate.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageHandlerTemplate.cs
@@ -8,7 +8,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
     /// <summary>
     /// Represents the default template when handling Azure Service Bus messages and controlling how the message is being handled by Azure Service Bus.
     /// </summary>
-    [Obsolete("Will be removed in v3.0, please use the Azure service bus operations on the " + nameof(AzureServiceBusMessageContext) + " instead")]
+    [Obsolete("Will be removed in v3.0, please implement the " + nameof(IAzureServiceBusMessageHandler<object>) + " directly instead and call the Azure service bus operations on the " + nameof(AzureServiceBusMessageContext) + " to complete/dead-letter/abandon messages")]
     public abstract class AzureServiceBusMessageHandlerTemplate
     {
         /// <summary>

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
@@ -197,7 +197,9 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
             MessageCorrelationInfo correlationInfo,
             CancellationToken cancellationToken)
         {
+#pragma warning disable CS0618 // Type or member is obsolete: fallback handlers will be removed in v3.0.
             return await RouteMessageWithPotentialFallbackAsync(messageReceiver, message, messageContext, correlationInfo, cancellationToken);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         /// <summary>
@@ -217,6 +219,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         ///     Thrown when the <paramref name="messageReceiver"/>, <paramref name="message"/>, <paramref name="messageContext"/>, or <paramref name="correlationInfo"/> is <c>null</c>.
         /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when no message handlers or none matching message handlers are found to process the message.</exception>
+        [Obsolete("Will be removed in v3.0, please use the Azure service bus operations on the " + nameof(AzureServiceBusMessageContext) + " instead of defining fallback message handlers")]
         protected async Task<MessageProcessingResult> RouteMessageWithPotentialFallbackAsync(
             ServiceBusReceiver messageReceiver,
             ServiceBusReceivedMessage message,
@@ -297,7 +300,9 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
                     if (result.IsSuccess)
                     {
                         var args = new ProcessMessageEventArgs(message, messageReceiver, cancellationToken);
+#pragma warning disable CS0618 // Type or member is obsolete: Azure Service bus-specific message handler templates will be removed in v3.0.
                         SetServiceBusPropertiesForSpecificOperations(messageHandler, args, messageContext);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                         bool isProcessed = await messageHandler.ProcessMessageAsync(result.DeserializedMessage, messageContext, correlationInfo, cancellationToken);
 
@@ -309,11 +314,13 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
                     }
                 }
 
+#pragma warning disable CS0618 // Type or member is obsolete: fallback message handlers will be removed in v3.0.
                 ServiceBusFallbackMessageHandler[] serviceBusFallbackHandlers =
                     GetAvailableFallbackMessageHandlersByContext<ServiceBusReceivedMessage, AzureServiceBusMessageContext>(messageContext);
 
                 FallbackMessageHandler<string, MessageContext>[] generalFallbackHandlers =
                     GetAvailableFallbackMessageHandlersByContext<string, MessageContext>(messageContext);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 bool fallbackAvailable = serviceBusFallbackHandlers.Length > 0 || generalFallbackHandlers.Length > 0;
 
@@ -337,7 +344,9 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
                     return MessageProcessingResult.Success(message.MessageId);
                 }
 
+#pragma warning disable CS0618 // Type or member is obsolete: fallback message handling will be removed in v3.0.
                 return await TryServiceBusFallbackMessageAsync(messageReceiver, message, messageContext, correlationInfo, cancellationToken);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             }
             catch (Exception exception)
@@ -413,6 +422,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         /// <param name="eventArgs">The event args of the incoming Service Bus message.</param>
         /// <param name="messageContext">The context in which the received Service Bus message is processed.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="messageHandler"/> or <paramref name="messageContext"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0, please use the Azure service bus operations on the " + nameof(AzureServiceBusMessageContext) + " instead")]
         protected void SetServiceBusPropertiesForSpecificOperations(
             MessageHandler messageHandler,
             ProcessMessageEventArgs eventArgs,
@@ -457,6 +467,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         /// <exception cref="ArgumentNullException">
         ///     Thrown when the <paramref name="messageReceiver"/>, <paramref name="message"/>, <paramref name="messageContext"/>, or <paramref name="correlationInfo"/> is <c>null</c>.
         /// </exception>
+        [Obsolete("Will be removed in v3.0, please use the Azure service bus operations on the " + nameof(AzureServiceBusMessageContext) + " instead of defining fallback message handlers")]
         protected async Task<MessageProcessingResult> TryServiceBusFallbackMessageAsync(
             ServiceBusReceiver messageReceiver,
             ServiceBusReceivedMessage message,

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/IAzureServiceBusFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/IAzureServiceBusFallbackMessageHandler.cs
@@ -1,4 +1,5 @@
-﻿using Arcus.Messaging.Abstractions.MessageHandling;
+﻿using System;
+using Arcus.Messaging.Abstractions.MessageHandling;
 using Azure.Messaging.ServiceBus;
 
 namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
@@ -6,6 +7,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
     /// <summary>
     /// Fallback version of the <see cref="IAzureServiceBusMessageHandler{TMessage}"/> to have a safety net when no handlers are found could process the message.
     /// </summary>
+    [Obsolete("Will be removed in v3.0, please use the Azure service bus operations on the " + nameof(AzureServiceBusMessageContext) + " instead of defining fallback message handlers")]
     public interface IAzureServiceBusFallbackMessageHandler : IFallbackMessageHandler<ServiceBusReceivedMessage, AzureServiceBusMessageContext>
     {
     }

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/FallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/FallbackMessageHandler.cs
@@ -11,7 +11,8 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
     /// </summary>
     /// <typeparam name="TMessage">The type of the message that this fallback message handler can handle.</typeparam>
     /// <typeparam name="TMessageContext">The type of the context in which the message is being processed.</typeparam>
-    public class FallbackMessageHandler<TMessage, TMessageContext> 
+    [Obsolete("Will be removed in v3.0, as the entire fallback message handler structure becomes unnecessary")]
+    public class FallbackMessageHandler<TMessage, TMessageContext>
         where TMessage : class
         where TMessageContext : MessageContext
     {
@@ -110,7 +111,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
                 catch (Exception exception)
                 {
                     _logger.LogError(exception, "Fallback message handler '{MessageHandlerType}' failed to handle '{MessageType}' message due to an exception: {Message}", MessageHandlerType.Name, typeof(TMessage).Name, exception.Message);
-                    return false;   
+                    return false;
                 }
             }
 

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/IFallbackMessageHandler.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/IFallbackMessageHandler.cs
@@ -9,6 +9,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
     /// </summary>
     /// <typeparam name="TMessage">The type of the message that this fallback message handler can handle.</typeparam>
     /// <typeparam name="TMessageContext">The type of the context in which the message is being processed.</typeparam>
+    [Obsolete("Will be removed in v3.0, as the entire fallback message handler structure becomes unnecessary")]
     public interface IFallbackMessageHandler<in TMessage, in TMessageContext>
         where TMessage : class
         where TMessageContext : MessageContext

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageHandlerCollection.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageHandlerCollection.cs
@@ -52,7 +52,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             {
                 throw new ArgumentNullException(nameof(implementationFactory));
             }
-            
+
             Services.AddTransient(
                 serviceProvider => MessageHandler.Create(
                     implementationFactory(serviceProvider),
@@ -71,6 +71,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// <typeparam name="TMessageContext">The type of the context in which the message is being processed.</typeparam>
         /// <param name="implementationFactory">The function to create the user-defined fallback message handler instance.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="implementationFactory"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0, as the entire fallback message handler structure becomes unnecessary")]
         public void AddFallbackMessageHandler<TMessageHandler, TMessage, TMessageContext>(
             Func<IServiceProvider, TMessageHandler> implementationFactory)
             where TMessageHandler : IFallbackMessageHandler<TMessage, TMessageContext>

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
@@ -263,6 +263,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             }
         }
 
+        [Obsolete("Will be removed in v3.0, as the entire fallback message handler structure becomes unnecessary")]
         private async Task<bool> TryProcessMessageAsync<TMessageContext>(
             IServiceProvider serviceProvider,
             string message,
@@ -423,6 +424,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             return isProcessedByGeneralContext;
         }
 
+        [Obsolete("Will be removed in v3.0, as the entire fallback message handler structure becomes unnecessary")]
         private async Task<bool> TryFallbackProcessMessageByContextAsync<TMessageContext>(
             string message,
             TMessageContext messageContext,
@@ -478,6 +480,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// </summary>
         /// <param name="messageContext">The message context in which the message is received and where the fallback message handler should take up.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="messageContext"/> is <c>null</c>.</exception>
+        [Obsolete("Will be removed in v3.0, as the entire fallback message handler structure becomes unnecessary")]
         protected FallbackMessageHandler<TMessage, TMessageContext>[] GetAvailableFallbackMessageHandlersByContext<TMessage, TMessageContext>(
             TMessageContext messageContext)
             where TMessage : class

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Resiliency/CircuitBreakerServiceBusMessageHandler.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Resiliency/CircuitBreakerServiceBusMessageHandler.cs
@@ -14,7 +14,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Resiliency
     /// Represents a template for a message handler that interacts with an unstable dependency system that requires a circuit breaker to prevent overloading the system.
     /// </summary>
     /// <typeparam name="TMessage">The type of the message that this handler can process.</typeparam>
-    public abstract class CircuitBreakerServiceBusMessageHandler<TMessage> : AzureServiceBusMessageHandler<TMessage>
+    public abstract class CircuitBreakerServiceBusMessageHandler<TMessage> : IAzureServiceBusMessageHandler<TMessage>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CircuitBreakerServiceBusMessageHandler{TMessage}" /> class.
@@ -24,9 +24,9 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Resiliency
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="circuitBreaker"/> or <paramref name="logger"/> is <c>null</c>.</exception>
         protected CircuitBreakerServiceBusMessageHandler(
             IMessagePumpCircuitBreaker circuitBreaker,
-            ILogger<CircuitBreakerServiceBusMessageHandler<TMessage>> logger) 
-            : base(logger)
+            ILogger<CircuitBreakerServiceBusMessageHandler<TMessage>> logger)
         {
+            Logger = logger;
             CircuitBreaker = circuitBreaker;
         }
 
@@ -34,6 +34,11 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Resiliency
         /// Gets the circuit breaker that controls the activation of the message pump.
         /// </summary>
         protected IMessagePumpCircuitBreaker CircuitBreaker { get; }
+
+        /// <summary>
+        /// Gets the current instance to write diagnostic messages during the circuit breaker-enhanced message handler.
+        /// </summary>
+        protected ILogger Logger { get; }
 
         /// <summary>
         /// Process a new message that was received.
@@ -45,7 +50,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Resiliency
         /// <exception cref="ArgumentNullException">
         ///     Thrown when the <paramref name="message"/>, <paramref name="messageContext"/>, or the <paramref name="correlationInfo"/> is <c>null</c>.
         /// </exception>
-        public override async Task ProcessMessageAsync(
+        public async Task ProcessMessageAsync(
             TMessage message,
             AzureServiceBusMessageContext messageContext,
             MessageCorrelationInfo correlationInfo,

--- a/src/Arcus.Messaging.Tests.Workers.ServiceBus/MessageHandlers/AbandonAzureServiceBusMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Workers.ServiceBus/MessageHandlers/AbandonAzureServiceBusMessageHandler.cs
@@ -4,23 +4,18 @@ using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.ServiceBus;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 using Arcus.Messaging.Tests.Core.Messages.v1;
-using Microsoft.Extensions.Logging;
 
 namespace Arcus.Messaging.Tests.Workers.MessageHandlers
 {
-    public class AbandonAzureServiceBusMessageHandler : AzureServiceBusMessageHandler<Order>
+    public class AbandonAzureServiceBusMessageHandler : IAzureServiceBusMessageHandler<Order>
     {
-        public AbandonAzureServiceBusMessageHandler (ILogger<AbandonAzureServiceBusMessageHandler > logger) : base(logger)
-        {
-        }
-
-        public override async Task ProcessMessageAsync(
+        public async Task ProcessMessageAsync(
             Order message,
             AzureServiceBusMessageContext messageContext,
             MessageCorrelationInfo correlationInfo,
             CancellationToken cancellationToken)
         {
-            await AbandonMessageAsync();
+            await messageContext.AbandonMessageAsync(messageContext.Properties, cancellationToken);
         }
     }
 }

--- a/src/Arcus.Messaging.Tests.Workers.ServiceBus/MessageHandlers/CompleteAzureServiceBusMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Workers.ServiceBus/MessageHandlers/CompleteAzureServiceBusMessageHandler.cs
@@ -4,24 +4,18 @@ using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.ServiceBus;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 using Arcus.Messaging.Tests.Core.Messages.v1;
-using Microsoft.Extensions.Logging;
 
 namespace Arcus.Messaging.Tests.Workers.MessageHandlers
 {
-    public class CompleteAzureServiceBusMessageHandler : AzureServiceBusMessageHandler<Order>
+    public class CompleteAzureServiceBusMessageHandler : IAzureServiceBusMessageHandler<Order>
     {
-        public CompleteAzureServiceBusMessageHandler(
-            ILogger<WriteOrderToDiskAzureServiceBusMessageHandler> logger) : base(logger)
-        {
-        }
-
-        public override async Task ProcessMessageAsync(
+        public async Task ProcessMessageAsync(
             Order message,
             AzureServiceBusMessageContext messageContext,
             MessageCorrelationInfo correlationInfo,
             CancellationToken cancellationToken)
         {
-            await CompleteMessageAsync();
+            await messageContext.CompleteMessageAsync(cancellationToken);
         }
     }
 }

--- a/src/Arcus.Messaging.Tests.Workers.ServiceBus/MessageHandlers/DeadLetterAzureServiceMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Workers.ServiceBus/MessageHandlers/DeadLetterAzureServiceMessageHandler.cs
@@ -8,13 +8,16 @@ using Microsoft.Extensions.Logging;
 
 namespace Arcus.Messaging.Tests.Workers.MessageHandlers
 {
-    public class DeadLetterAzureServiceMessageHandler : AzureServiceBusMessageHandler<Order>
+    public class DeadLetterAzureServiceMessageHandler : IAzureServiceBusMessageHandler<Order>
     {
+        private readonly ILogger<DeadLetterAzureServiceMessageHandler> _logger;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AzureServiceBusMessageHandlerTemplate"/> class.
         /// </summary>
-        public DeadLetterAzureServiceMessageHandler(ILogger<DeadLetterAzureServiceMessageHandler> logger) : base(logger)
+        public DeadLetterAzureServiceMessageHandler(ILogger<DeadLetterAzureServiceMessageHandler> logger)
         {
+            _logger = logger;
         }
 
         /// <summary>
@@ -27,15 +30,15 @@ namespace Arcus.Messaging.Tests.Workers.MessageHandlers
         ///     identifiers
         /// </param>
         /// <param name="cancellationToken">Cancellation token</param>
-        public override async Task ProcessMessageAsync(
+        public async Task ProcessMessageAsync(
             Order message,
             AzureServiceBusMessageContext messageContext,
             MessageCorrelationInfo correlationInfo,
             CancellationToken cancellationToken)
         {
-            Logger.LogTrace("Dead letter message '{OrderId}'...", message.Id);
-            await DeadLetterMessageAsync();
-            Logger.LogInformation("Message '{OrderId}' is dead lettered", message.Id);
+            _logger.LogTrace("Dead letter message '{OrderId}'...", message.Id);
+            await messageContext.DeadLetterMessageAsync("Test dead-letter reason", "dead-lettered by test", cancellationToken);
+            _logger.LogInformation("Message '{OrderId}' is dead lettered", message.Id);
         }
     }
 }


### PR DESCRIPTION
Moves the Azure Service bus-specific operations (Complete, Abandon, Dead-Letter) to the message context, so that the following functionality can be made deprecated:
* Azure Service bus message template classes for regular/fallback message handlers, as these were solely used to trigger the Azure Service bus operations;
* General fallback functionality, as this is now also unnecessary for any of the 'messaging' implementations;

Relates to #547 