### PR TITLE
chore(general): deprecate message pump lifetime restartable functionality

### DIFF
--- a/src/Arcus.Messaging.Pumps.Abstractions/DefaultMessagePumpLifetime.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/DefaultMessagePumpLifetime.cs
@@ -12,6 +12,7 @@ namespace Arcus.Messaging.Pumps.Abstractions
     /// <summary>
     /// Represents the default <see cref="IMessagePumpLifetime"/> implementation to control the lifetime of registered message pumps.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 since the circuit breaker functionality handles start/pause automatically now")]
     public class DefaultMessagePumpLifetime : IMessagePumpLifetime
     {
         private readonly IServiceProvider _serviceProvider;
@@ -42,7 +43,7 @@ namespace Arcus.Messaging.Pumps.Abstractions
             }
 
             MessagePump messagePump = GetMessagePump(jobId);
-            
+
             _logger.LogTrace("Starting message pump '{JobId}' via message pump lifetime...", jobId);
             await messagePump.StartProcessingMessagesAsync(cancellationToken);
             _logger.LogTrace("Started message pump '{JobId}' via message pump lifetime", jobId);

--- a/src/Arcus.Messaging.Pumps.Abstractions/IMessagePumpLifetime.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/IMessagePumpLifetime.cs
@@ -7,6 +7,7 @@ namespace Arcus.Messaging.Pumps.Abstractions
     /// <summary>
     /// Represents the handler to control the lifetime of a certain message pump.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 since the circuit breaker functionality handles start/pause automatically now")]
     public interface IMessagePumpLifetime
     {
         /// <summary>

--- a/src/Arcus.Messaging.Pumps.Abstractions/IRestartableMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/IRestartableMessagePump.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 
@@ -7,6 +8,7 @@ namespace Arcus.Messaging.Pumps.Abstractions
     /// <summary>
     /// Represents an <see cref="MessagePump"/> that can be restarted programmatically.
     /// </summary>
+    [Obsolete("Will be removed in v3.0 since the circuit breaker functionality handles start/pause automatically now")]
     public interface IRestartableMessagePump : IHostedService
     {
         /// <summary>

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -393,6 +393,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
         /// <summary>
         /// Restart core functionality of the message pump.
         /// </summary>
+        [Obsolete("Will be removed in v3.0 since the circuit breaker functionality handles start/pause automatically now")]
         public async Task RestartAsync()
         {
             Interlocked.Exchange(ref _unauthorizedExceptionCount, 0);
@@ -406,6 +407,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
         /// <summary>
         /// Restart core functionality of the message pump.
         /// </summary>
+        [Obsolete("Will be removed in v3.0 since the circuit breaker functionality handles start/pause automatically now")]
         public async Task RestartAsync(CancellationToken cancellationToken)
         {
             Interlocked.Exchange(ref _unauthorizedExceptionCount, 0);

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Configuration/AzureServiceBusMessagePumpOptions.cs
@@ -129,6 +129,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Configuration
         /// how many times should the message pump run into an <see cref="UnauthorizedAccessException"/> before restarting.
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="value"/> is less than zero.</exception>
+        [Obsolete("Will be removed in v3.0 as the Azure Service Bus authentication has been moved outside of the message pump's responsibility")]
         public int MaximumUnauthorizedExceptionsBeforeRestart
         {
             get => _maximumUnauthorizedExceptionsBeforeRestart;


### PR DESCRIPTION
As first mentioned in the discussion #470 and re-confirmed in #546 , the `IMessagePumpLifetime`/`IRestarableMessagePump` are deprecated since their initial purpose was to be able to provide a system to 'pause' the message pump when the external dependency system can't keep up - which is exactly what the new circuit breaker functionality provides.