### PR TITLE
fix(release): use custom `dotnet nuget push` for NuGet release

### DIFF
--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -20,6 +20,7 @@ resources:
 
 variables:
   - group: 'Build Configuration'
+  - group: 'NuGet.org'
   - template: ./variables/build.yml
   - template: ./variables/test.yml
   - name: 'Package.Version'
@@ -136,4 +137,4 @@ stages:
             inputs:
               command: 'custom'
               custom: 'nuget'
-              arguments: 'push src/**/*.nupkg --source https://api.nuget.org/v3/index.json'
+              arguments: 'push src/**/*.nupkg --source $(NuGet.SourceUrl) --api-key $(NuGet.ApiKey)'

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -128,4 +128,12 @@ stages:
                 None.
                 ### Removal
                 None.
-          - template: nuget/publish-official-package.yml@templates
+          - task: NuGetAuthenticate@1
+            inputs:
+              nuGetServiceConnections: 'NuGet.org'
+          - task: DotNetCoreCLI@2
+            displayName: 'Push to NuGet.org'
+            inputs:
+              command: 'custom'
+              custom: 'nuget'
+              arguments: 'push src/**/*.nupkg --source https://api.nuget.org/v3/index.json

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -129,9 +129,6 @@ stages:
                 None.
                 ### Removal
                 None.
-          - task: NuGetAuthenticate@1
-            inputs:
-              nuGetServiceConnections: 'NuGet.org'
           - task: DotNetCoreCLI@2
             displayName: 'Push to NuGet.org'
             inputs:

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -20,7 +20,7 @@ resources:
 
 variables:
   - group: 'Build Configuration'
-  - group: 'NuGet.org'
+  - group: 'NuGet'
   - template: ./variables/build.yml
   - template: ./variables/test.yml
   - name: 'Package.Version'

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -136,4 +136,4 @@ stages:
             inputs:
               command: 'custom'
               custom: 'nuget'
-              arguments: 'push src/**/*.nupkg --source https://api.nuget.org/v3/index.json
+              arguments: 'push src/**/*.nupkg --source https://api.nuget.org/v3/index.json'


### PR DESCRIPTION
Since the new Ubuntu build image on DevOps does not have `mono` installed, it means that some tools like **NuGet** are not built-in installed anymore. As a migration, they recommend doing it yourself.

This PR uses the `dotnet nuget push` instead (like we did with the MyGet release), which fixes this problem.