### PR TITLE
chore(ci): remove event-hubs key-vault secrets from ci

### DIFF
--- a/build/templates/integration-tests.yml
+++ b/build/templates/integration-tests.yml
@@ -27,14 +27,8 @@ steps:
         Set-AzDevOpsVariable -Name 'Arcus.Infra.ServicePrincipal.ClientId' -Value $env:servicePrincipalId -AsSecret
         Set-AzDevOpsVariable -Name 'Arcus.Infra.ServicePrincipal.ClientSecret' -Value $env:servicePrincipalKey -AsSecret
 
-        $accountKey = az keyvault secret show --name $env:ARCUS_MESSAGING_STORAGEACCOUNT_KEY_SECRETNAME --vault-name $env:ARCUS_MESSAGING_KEYVAULT_NAME | ConvertFrom-Json
-        Set-AzDevOpsVariable -Name 'Arcus.Messaging.StorageAccount.Key' -Value $accountKey.value -AsSecret
-
         $serviceBusConnectionString = az keyvault secret show --name $env:ARCUS_MESSAGING_SERVICEBUS_CONNECTIONSTRING_SECRETNAME --vault-name $env:ARCUS_MESSAGING_KEYVAULT_NAME | ConvertFrom-Json
         Set-AzDevOpsVariable -Name 'Arcus.Messaging.ServiceBus.ConnectionString' -Value $serviceBusConnectionString.value -AsSecret
-
-        $eventHubsConnectionString = az keyvault secret show --name $env:ARCUS_MESSAGING_EVENTHUBS_CONNECTIONSTRING_SECRETNAME --vault-name $env:ARCUS_MESSAGING_KEYVAULT_NAME | ConvertFrom-Json
-        Set-AzDevOpsVariable -Name 'Arcus.Messaging.EventHubs.ConnectionString' -Value $eventHubsConnectionString.value -AsSecret
 
   - template: test/run-integration-tests.yml@templates
     parameters:


### PR DESCRIPTION
The CI pipeline still had references to EventHubs Key Vault secrets, this PR removes these.