### PR TITLE
docs(para.highlight): use docusaurus admonitions to highlight paragraphs

### DIFF
--- a/docs/preview/02-getting-started.md
+++ b/docs/preview/02-getting-started.md
@@ -12,7 +12,9 @@ This page is dedicated to be used as a walkthrough on how to set up Arcus Messag
 * *message pump:* an Arcus Messaging-provided registered service that receives Azure Service Bus messages for you, and "pumps" them through your *message handlers*.
 
 ## The basics
-> 👉 Arcus Messaging is currently only supported for [Azure Service Bus](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-overview) solutions.
+:::note
+Arcus Messaging is currently only supported for [Azure Service Bus](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-overview) solutions.
+:::
 
 Arcus Messaging helps with receiving messages from a message broker. This walkthrough uses Azure Service Bus as an example.
 

--- a/docs/preview/03-Features/01-Azure/01-service-bus.md
+++ b/docs/preview/03-Features/01-Azure/01-service-bus.md
@@ -56,7 +56,9 @@ All your custom *message handlers* need to be registered on a *message pump*. Th
 ### Register the Arcus message pump
 There exists two types of Azure Service Bus *message pumps*: for queues and for topic subscriptions. During the registration of the pump in the application services, the type of authentication mechanism can be configured.
 
-> 🎖️ Use the [`ManagedIdentityCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.managedidentitycredential) where possible.
+:::tip
+Use the [`ManagedIdentityCredential`](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.managedidentitycredential) where possible.
+:::
 
 ```csharp
 using Microsoft.Extensions.DependencyInjection;
@@ -102,10 +104,11 @@ Host.CreateDefaultBuilder()
     });
 ```
 
-> **⚠️ Considerations:**
-> * The order in which the *message handlers* are registered matters when a message is routed.
-> * Only the first matching *message handler* will be used to process the message, even when multiple match.
-> * Multiple *message handlers* with the same (message) type can registered, but they need to distinguish themselves with [routing options](#message-handler-routing-customization).
+:::warning[Considerations]
+* The order in which the *message handlers* are registered matters when a message is routed.
+* Only the first matching *message handler* will be used to process the message, even when multiple match.
+* Multiple *message handlers* with the same (message) type can registered, but they need to distinguish themselves with [routing options](#message-handler-routing-customization).
+:::
 
 ## Customization
 Due to the wide range of situations within messaging solutions, Arcus Messaging supports highly customizable message pump/handler registrations.
@@ -142,7 +145,9 @@ services.AddServiceBus[Topic/Queue]MessagePump(..., options =>
 ### Message handler routing customization
 The following routing options are available when registering an Azure Service Bus message handler on a message pump.
 
-> 💡 Setting one or more of the routing options helps the message pump to better select the right *message handler* for the received message.
+:::tip
+Setting one or more of the routing options helps the message pump to better select the right *message handler* for the received message.
+:::
 
 ```csharp
 services.AddServiceBus[Topic/Queue]MessagePump(...)
@@ -172,7 +177,9 @@ When messages can't be matched to any of your custom registered message handlers
 
 This settlement of received Azure Service Bus messages can also be customized by calling one of the Service Bus operations yourself via the message context.
 
-> 🎖️ It is a good practice as application developer to dead-letter the message yourself when a non-transient/fatal error occurs.
+:::tip
+It is a good practice as application developer to dead-letter the message yourself when a non-transient/fatal error occurs.
+:::
 
 ```csharp
 public class OrderMessageHandler : IAzureServiceBusMessageHandler<Order>
@@ -229,11 +236,13 @@ public class OrderMessageHandler : CircuitBreakerServiceBusMessageHandler<Order>
 }
 ```
 
-> The circuit-breaker functionality will follow this pattern when the handler lets the message processing fail:
-> * Message processing pause for a **recovery period** of time (circuit=OPEN).
-> * Message processing tries a single message (circuit=HALF-OPEN).
->   * Message handler still throws exception? => message processing pauses for an **interval** and tries again (circuit=OPEN).
->   * Message handler stops throwing exception? => message processing resumes in full (circuit=CLOSED).
+:::info
+The circuit-breaker functionality will follow this pattern when the handler lets the message processing fail:
+* Message processing pause for a **recovery period** of time (circuit=OPEN).
+* Message processing tries a single message (circuit=HALF-OPEN).
+  * Message handler still throws exception? => message processing pauses for an **interval** and tries again (circuit=OPEN).
+  * Message handler stops throwing exception? => message processing resumes in full (circuit=CLOSED).
+:::
 
 Both the recovery period after the circuit is open and the interval between messages when the circuit is half-open is configurable with the `MessagePumpCircuitBreakerOptions`.
 


### PR DESCRIPTION
Use docusaurus admonitions to highlight certain paragraphs instead of less visible Markdown quotes.