### PR TITLE
chore(pipelines): reduce duplication by extracting tests as job templates

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -1,6 +1,3 @@
-# We are using 2 types of testing infrastructure:
-# 1. Service Bus to test the message pump itself which emits Event Grid events
-# 2. Testing infrastructure to loop the Event Grid events back in our tests (depends on Service Bus)
 name: $(date:yyyyMMdd)$(rev:.r)
 
 trigger:
@@ -75,40 +72,16 @@ stages:
     dependsOn: Build
     condition: succeeded()
     jobs:
-      - job: UnitTests
-        displayName: 'Run unit tests'
-        pool:
-          vmImage: '$(Vm.Image)'
-        steps:
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download build artifacts'
-            inputs:
-              artifact: 'Build'
-              path: '$(Build.SourcesDirectory)'
-          - task: UseDotNet@2
-            displayName: 'Import .NET Core SDK ($(DotNet.Sdk.PreviousVersion))'
-            inputs:
-              packageType: 'sdk'
-              version: '$(DotNet.Sdk.PreviousVersion)'
-              includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
-          - template: test/run-unit-tests.yml@templates
-            parameters:
-              dotnetSdkVersion: '$(DotNet.Sdk.Version)'
-              projectName: '$(Project).Tests.Unit'
+      - template: templates/unit-tests.yml
 
   - stage: IntegrationTests
     displayName: Integration Tests
     dependsOn: Build
     condition: succeeded()
     jobs:
-      - job: RunIntegrationTests
-        displayName: 'Run integration tests'
-        pool:
-          vmImage: '$(Vm.Image)'
-        steps:
-          - template: templates/integration-tests.yml
-            parameters:
-              azureServiceConnection: ${{ parameters.azureServiceConnection }}
+      - template: templates/integration-tests.yml
+        parameters:
+          azureServiceConnection: '${{ parameters.azureServiceConnection }}'
 
   - stage: ReleaseToMyGet
     displayName: 'Release to MyGet'

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -60,40 +60,16 @@ stages:
     dependsOn: Build
     condition: succeeded()
     jobs:
-      - job: UnitTests
-        displayName: 'Run unit tests'
-        pool:
-          vmImage: '$(Vm.Image)'
-        steps:
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download build artifacts'
-            inputs:
-              artifact: 'Build'
-              path: '$(Build.SourcesDirectory)'
-          - task: UseDotNet@2
-            displayName: 'Import .NET Core SDK ($(DotNet.Sdk.PreviousVersion))'
-            inputs:
-              packageType: 'sdk'
-              version: '$(DotNet.Sdk.PreviousVersion)'
-              includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
-          - template: test/run-unit-tests.yml@templates
-            parameters:
-              dotnetSdkVersion: '$(DotNet.Sdk.Version)'
-              projectName: '$(Project).Tests.Unit'
+      - template: templates/unit-tests.yml
 
   - stage: IntegrationTests
     displayName: Integration Tests
     dependsOn: Build
     condition: succeeded()
     jobs:
-      - job: RunIntegrationTests
-        displayName: 'Run integration tests'
-        pool:
-          vmImage: '$(Vm.Image)'
-        steps:
-          - template: templates/integration-tests.yml
-            parameters:
-              azureServiceConnection: ${{ parameters.azureServiceConnection }}
+      - template: templates/integration-tests.yml
+        parameters:
+          azureServiceConnection: '${{ parameters.azureServiceConnection }}'
 
   - stage: Release
     displayName: 'Release to NuGet.org'

--- a/build/templates/integration-tests.yml
+++ b/build/templates/integration-tests.yml
@@ -1,38 +1,43 @@
 parameters:
   azureServiceConnection: ''
 
-steps:
-  - task: UseDotNet@2
-    displayName: 'Import .NET Core SDK ($(DotNet.Sdk.PreviousVersion))'
-    inputs:
-      packageType: 'sdk'
-      version: '$(DotNet.Sdk.PreviousVersion)'
-
-  - task: AzureCLI@2
-    displayName: 'Import secrets from Azure Key Vault'
-    inputs:
-      azureSubscription: '${{ parameters.azureServiceConnection }}'
-      addSpnToEnvironment: true
-      scriptType: 'pscore'
-      scriptLocation: 'inlineScript'
-      inlineScript: |
-        Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-        Install-Module -Name Arcus.Scripting.DevOps -AllowClobber -MinimumVersion 1.3.0
-
-        $subscriptionId = (az account show | ConvertFrom-Json).id
-        $objectId = (az ad sp show --id $env:servicePrincipalId | ConvertFrom-Json).id
-        Set-AzDevOpsVariable -Name 'Arcus.Infra.SubscriptionId' -Value $subscriptionId
-        Set-AzDevOpsVariable -Name 'Arcus.Infra.TenantId' -Value $env:tenantId -AsSecret
-        Set-AzDevOpsVariable -Name 'Arcus.Infra.ServicePrincipal.ObjectId' -Value $objectId
-        Set-AzDevOpsVariable -Name 'Arcus.Infra.ServicePrincipal.ClientId' -Value $env:servicePrincipalId -AsSecret
-        Set-AzDevOpsVariable -Name 'Arcus.Infra.ServicePrincipal.ClientSecret' -Value $env:servicePrincipalKey -AsSecret
-
-        $serviceBusConnectionString = az keyvault secret show --name $env:ARCUS_MESSAGING_SERVICEBUS_CONNECTIONSTRING_SECRETNAME --vault-name $env:ARCUS_MESSAGING_KEYVAULT_NAME | ConvertFrom-Json
-        Set-AzDevOpsVariable -Name 'Arcus.Messaging.ServiceBus.ConnectionString' -Value $serviceBusConnectionString.value -AsSecret
-
-  - template: test/run-integration-tests.yml@templates
-    parameters:
-      dotnetSdkVersion: '$(DotNet.Sdk.Version)'
-      includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
-      projectName: '$(Project).Tests.Integration'
-      category: 'Integration'
+jobs:
+- job: RunIntegrationTests
+  displayName: 'Run integration tests'
+  pool:
+    vmImage: '$(Vm.Image)'
+  steps:
+    - task: UseDotNet@2
+      displayName: 'Import .NET Core SDK ($(DotNet.Sdk.PreviousVersion))'
+      inputs:
+        packageType: 'sdk'
+        version: '$(DotNet.Sdk.PreviousVersion)'
+  
+    - task: AzureCLI@2
+      displayName: 'Import secrets from Azure Key Vault'
+      inputs:
+        azureSubscription: '${{ parameters.azureServiceConnection }}'
+        addSpnToEnvironment: true
+        scriptType: 'pscore'
+        scriptLocation: 'inlineScript'
+        inlineScript: |
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+          Install-Module -Name Arcus.Scripting.DevOps -AllowClobber -MinimumVersion 1.3.0
+  
+          $subscriptionId = (az account show | ConvertFrom-Json).id
+          $objectId = (az ad sp show --id $env:servicePrincipalId | ConvertFrom-Json).id
+          Set-AzDevOpsVariable -Name 'Arcus.Infra.SubscriptionId' -Value $subscriptionId
+          Set-AzDevOpsVariable -Name 'Arcus.Infra.TenantId' -Value $env:tenantId -AsSecret
+          Set-AzDevOpsVariable -Name 'Arcus.Infra.ServicePrincipal.ObjectId' -Value $objectId
+          Set-AzDevOpsVariable -Name 'Arcus.Infra.ServicePrincipal.ClientId' -Value $env:servicePrincipalId -AsSecret
+          Set-AzDevOpsVariable -Name 'Arcus.Infra.ServicePrincipal.ClientSecret' -Value $env:servicePrincipalKey -AsSecret
+  
+          $serviceBusConnectionString = az keyvault secret show --name $env:ARCUS_MESSAGING_SERVICEBUS_CONNECTIONSTRING_SECRETNAME --vault-name $env:ARCUS_MESSAGING_KEYVAULT_NAME | ConvertFrom-Json
+          Set-AzDevOpsVariable -Name 'Arcus.Messaging.ServiceBus.ConnectionString' -Value $serviceBusConnectionString.value -AsSecret
+  
+    - template: test/run-integration-tests.yml@templates
+      parameters:
+        dotnetSdkVersion: '$(DotNet.Sdk.Version)'
+        includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
+        projectName: '$(Project).Tests.Integration'
+        category: 'Integration'

--- a/build/templates/unit-tests.yml
+++ b/build/templates/unit-tests.yml
@@ -1,0 +1,21 @@
+jobs:
+  - job: UnitTests
+    displayName: 'Run unit tests'
+    pool:
+      vmImage: '$(Vm.Image)'
+    steps:
+      - task: DownloadPipelineArtifact@2
+        displayName: 'Download build artifacts'
+        inputs:
+          artifact: 'Build'
+          path: '$(Build.SourcesDirectory)'
+      - task: UseDotNet@2
+        displayName: 'Import .NET Core SDK ($(DotNet.Sdk.PreviousVersion))'
+        inputs:
+          packageType: 'sdk'
+          version: '$(DotNet.Sdk.PreviousVersion)'
+          includePreviewVersions: $(DotNet.Sdk.IncludePreviewVersions)
+      - template: test/run-unit-tests.yml@templates
+        parameters:
+          dotnetSdkVersion: '$(DotNet.Sdk.Version)'
+          projectName: '$(Project).Tests.Unit'


### PR DESCRIPTION
This PR extracts both the unit & integration tests job runs in separate job templates. This allows for less duplication between the CI build and the NuGet release pipeline, as they now both towards the same job template.

By reducing the duplication and having a direct reference, changes to one pipeline immediately effects the other - which in this case, is expected/best-practice as we want. It also helps with any possible failures/missing code in the NuGet release, which would only be flagged upon actually releasing.

This approach was already taken in Arcus Testing, but is now also introduced in Messaging.