### PR TITLE
chore(az.sb): remove deprecated az sb fallback message handler registrations

### DIFF
--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/ServiceBusMessageHandlerExtensions.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/ServiceBusMessageHandlerExtensions.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using Arcus.Messaging.Abstractions.MessageHandling;
-using Arcus.Messaging.Abstractions.ServiceBus;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
-using Azure.Messaging.ServiceBus;
 using Microsoft.Extensions.Logging;
 
 // ReSharper disable once CheckNamespace
@@ -100,48 +98,6 @@ namespace Microsoft.Extensions.DependencyInjection
                     options.MessageContextFilter,
                     options.MessageBodySerializerImplementationFactory?.Invoke(serviceProvider)));
 
-            return handlers;
-        }
-
-        /// <summary>
-        /// Adds an <see cref="IAzureServiceBusFallbackMessageHandler"/> implementation which the message pump can use to fall back to when no message handler is found to process the message.
-        /// </summary>
-        /// <typeparam name="TMessageHandler">The type of the fallback message handler.</typeparam>
-        /// <param name="handlers">The handlers to add the fallback message handler to.</param>
-        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="handlers"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v3.0, please use the Azure service bus operations on the " + nameof(AzureServiceBusMessageContext) + " instead of defining fallback message handlers")]
-        public static ServiceBusMessageHandlerCollection WithServiceBusFallbackMessageHandler<TMessageHandler>(
-            this ServiceBusMessageHandlerCollection handlers)
-            where TMessageHandler : IAzureServiceBusFallbackMessageHandler
-        {
-            if (handlers is null)
-            {
-                throw new ArgumentNullException(nameof(handlers));
-            }
-
-            handlers.WithServiceBusFallbackMessageHandler(serviceProvider => ActivatorUtilities.CreateInstance<TMessageHandler>(serviceProvider));
-            return handlers;
-        }
-
-        /// <summary>
-        /// Adds an <see cref="IAzureServiceBusFallbackMessageHandler"/> implementation which the message pump can use to fall back to when no message handler is found to process the message.
-        /// </summary>
-        /// <typeparam name="TMessageHandler">The type of the fallback message handler.</typeparam>
-        /// <param name="handlers">The handlers to add the fallback message handler to.</param>
-        /// <param name="createImplementation">The function to create the fallback message handler.</param>
-        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="handlers"/> or the <paramref name="createImplementation"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v3.0, please use the Azure service bus operations on the " + nameof(AzureServiceBusMessageContext) + " instead of defining fallback message handlers")]
-        public static ServiceBusMessageHandlerCollection WithServiceBusFallbackMessageHandler<TMessageHandler>(
-            this ServiceBusMessageHandlerCollection handlers,
-            Func<IServiceProvider, TMessageHandler> createImplementation)
-            where TMessageHandler : IAzureServiceBusFallbackMessageHandler
-        {
-            if (handlers is null)
-            {
-                throw new ArgumentNullException(nameof(handlers));
-            }
-
-            handlers.AddFallbackMessageHandler<TMessageHandler, ServiceBusReceivedMessage, AzureServiceBusMessageContext>(createImplementation);
             return handlers;
         }
     }

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePump.RouterTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePump.RouterTests.cs
@@ -207,16 +207,5 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                        .WithFallbackMessageHandler<WriteOrderToDiskFallbackMessageHandler>();
             });
         }
-
-        [Fact]
-        public async Task ServiceBusMessagePumpWithServiceBusFallback_PublishServiceBusMessage_MessageSuccessfullyProcessed()
-        {
-            await TestServiceBusMessageHandlingAsync(Queue, options =>
-            {
-                options.AddServiceBusQueueMessagePumpUsingManagedIdentity(QueueName, HostName, configureMessagePump: opt => opt.AutoComplete = true)
-                       .WithServiceBusMessageHandler<PassThruOrderMessageHandler, Order>(opt => opt.AddMessageContextFilter(_ => false))
-                       .WithServiceBusFallbackMessageHandler<WriteOrderToDiskFallbackMessageHandler>();
-            });
-        }
     }
 }

--- a/src/Arcus.Messaging.Tests.Unit/ServiceBus/IServiceCollectionExtensionsTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/ServiceBus/IServiceCollectionExtensionsTests.cs
@@ -2,13 +2,10 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Arcus.Messaging.Abstractions;
-using Arcus.Messaging.Abstractions.MessageHandling;
-using Arcus.Messaging.Abstractions.ServiceBus;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 using Arcus.Messaging.Pumps.ServiceBus;
 using Arcus.Messaging.Tests.Unit.Fixture;
 using Arcus.Security.Core;
-using Azure.Messaging.ServiceBus;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -31,14 +28,14 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             services.AddLogging();
 
             // Act
-            ServiceBusMessageHandlerCollection result = 
+            ServiceBusMessageHandlerCollection result =
                 services.AddServiceBusTopicMessagePump(
                     "topic name", "subscription name", "secret name", options =>
                     {
                         options.AutoComplete = true;
                         options.TopicSubscription = TopicSubscription.Automatic;
                     });
-            
+
             // Assert
             Assert.NotNull(result);
             ServiceProvider provider = result.Services.BuildServiceProvider();
@@ -62,10 +59,10 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             string jobId = Guid.NewGuid().ToString();
 
             // Act
-            ServiceBusMessageHandlerCollection result = 
+            ServiceBusMessageHandlerCollection result =
                 services.AddServiceBusTopicMessagePump(
                     "topic name", "subscription name", "secret name", options => options.JobId = jobId);
-            
+
             // Assert
             Assert.NotNull(result);
             IServiceProvider provider = result.Services.BuildServiceProvider();
@@ -86,7 +83,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             services.AddLogging();
 
             // Act
-            ServiceBusMessageHandlerCollection result = 
+            ServiceBusMessageHandlerCollection result =
                 services.AddServiceBusTopicMessagePump(
                     "topic name", "subscription name", "secret name", configureMessagePump: options =>
                     {
@@ -114,17 +111,17 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             services.AddSingleton(Mock.Of<ISecretProvider>());
             services.AddSingleton(Mock.Of<IConfiguration>());
             services.AddLogging();
-            
+
             // Act
             ServiceBusMessageHandlerCollection result =
                 services.AddServiceBusTopicMessagePump("subscription name", (IConfiguration config) => null);
-            
+
             // Assert
             Assert.NotNull(result);
             IServiceProvider provider = result.Services.BuildServiceProvider();
             Assert.NotNull(provider.GetService<IMessageCorrelationInfoAccessor>());
         }
-        
+
         [Fact]
         public void AddServiceBusTopicMessagePump_WithSubscriptionNameSecretProvider_RegistersDedicatedCorrelation()
         {
@@ -133,17 +130,17 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             services.AddSingleton(Mock.Of<ISecretProvider>());
             services.AddSingleton(Mock.Of<IConfiguration>());
             services.AddLogging();
-            
+
             // Act
             ServiceBusMessageHandlerCollection result =
                 services.AddServiceBusTopicMessagePump("subscription name", (ISecretProvider secretProvider) => null);
-            
+
             // Assert
             Assert.NotNull(result);
             IServiceProvider provider = result.Services.BuildServiceProvider();
             Assert.NotNull(provider.GetService<IMessageCorrelationInfoAccessor>());
         }
-        
+
         [Fact]
         public void AddServiceBusTopicMessagePump_WithSubscriptionNameSecretName_RegistersDedicatedCorrelation()
         {
@@ -152,11 +149,11 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             services.AddSingleton(Mock.Of<ISecretProvider>());
             services.AddSingleton(Mock.Of<IConfiguration>());
             services.AddLogging();
-            
+
             // Act
             ServiceBusMessageHandlerCollection result =
                 services.AddServiceBusTopicMessagePump("subscription name", "secret name");
-            
+
             // Assert
             Assert.NotNull(result);
             IServiceProvider provider = result.Services.BuildServiceProvider();
@@ -171,17 +168,17 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             services.AddSingleton(Mock.Of<ISecretProvider>());
             services.AddSingleton(Mock.Of<IConfiguration>());
             services.AddLogging();
-            
+
             // Act
             ServiceBusMessageHandlerCollection result =
                 services.AddServiceBusTopicMessagePump("topic name", "subscription name", (IConfiguration config) => null);
-            
+
             // Assert
             Assert.NotNull(result);
             IServiceProvider provider = result.Services.BuildServiceProvider();
             Assert.NotNull(provider.GetService<IMessageCorrelationInfoAccessor>());
         }
-        
+
         [Fact]
         public void AddServiceBusTopicMessagePump_WithTopicNameSubscriptionNameSecretProvider_RegistersDedicatedCorrelation()
         {
@@ -190,17 +187,17 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             services.AddSingleton(Mock.Of<ISecretProvider>());
             services.AddSingleton(Mock.Of<IConfiguration>());
             services.AddLogging();
-            
+
             // Act
             ServiceBusMessageHandlerCollection result =
                 services.AddServiceBusTopicMessagePump("topic name", "subscription name", (ISecretProvider secretProvider) => null);
-            
+
             // Assert
             Assert.NotNull(result);
             IServiceProvider provider = result.Services.BuildServiceProvider();
             Assert.NotNull(provider.GetService<IMessageCorrelationInfoAccessor>());
         }
-        
+
         [Fact]
         public void AddServiceBusTopicMessagePump_WithTopicNameSubscriptionNameSecretName_RegistersDedicatedCorrelation()
         {
@@ -209,11 +206,11 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             services.AddSingleton(Mock.Of<ISecretProvider>());
             services.AddSingleton(Mock.Of<IConfiguration>());
             services.AddLogging();
-            
+
             // Act
             ServiceBusMessageHandlerCollection result =
                 services.AddServiceBusTopicMessagePump("topic name", "subscription name", "secret name");
-            
+
             // Assert
             Assert.NotNull(result);
             IServiceProvider provider = result.Services.BuildServiceProvider();
@@ -304,17 +301,17 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             services.AddSingleton(Mock.Of<ISecretProvider>());
             services.AddSingleton(Mock.Of<IConfiguration>());
             services.AddLogging();
-            
+
             // Act
             ServiceBusMessageHandlerCollection result =
                 services.AddServiceBusTopicMessagePumpWithPrefix("topic name", "subscription prefix", (ISecretProvider secretProvider) => null);
-            
+
             // Assert
             Assert.NotNull(result);
             IServiceProvider provider = result.Services.BuildServiceProvider();
             Assert.NotNull(provider.GetService<IMessageCorrelationInfoAccessor>());
         }
-        
+
         [Fact]
         public void AddServiceBusTopicMessagePumpWithPrefix_WithTopicNameSubscriptionNameSecretName_RegistersDedicatedCorrelation()
         {
@@ -323,17 +320,17 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             services.AddSingleton(Mock.Of<ISecretProvider>());
             services.AddSingleton(Mock.Of<IConfiguration>());
             services.AddLogging();
-            
+
             // Act
             ServiceBusMessageHandlerCollection result =
                 services.AddServiceBusTopicMessagePumpWithPrefix("topic name", "subscription prefix", "secret name");
-            
+
             // Assert
             Assert.NotNull(result);
             IServiceProvider provider = result.Services.BuildServiceProvider();
             Assert.NotNull(provider.GetService<IMessageCorrelationInfoAccessor>());
         }
-        
+
         [Fact]
         public void AddServiceBusTopicMessagePumpUsingManagedIdentity_WithTopicNameSubscriptionNameSecretName_RegistersDedicatedCorrelation()
         {
@@ -342,17 +339,17 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             services.AddSingleton(Mock.Of<ISecretProvider>());
             services.AddSingleton(Mock.Of<IConfiguration>());
             services.AddLogging();
-            
+
             // Act
             ServiceBusMessageHandlerCollection result =
                 services.AddServiceBusTopicMessagePumpUsingManagedIdentity("topic name", "subscription name", "service bus namespace");
-            
+
             // Assert
             Assert.NotNull(result);
             IServiceProvider provider = result.Services.BuildServiceProvider();
             Assert.NotNull(provider.GetService<IMessageCorrelationInfoAccessor>());
         }
-        
+
         [Fact]
         public void AddServiceBusTopicMessagePumpUsingManagedIdentityWithPrefix_WithTopicNameSubscriptionNameSecretName_RegistersDedicatedCorrelation()
         {
@@ -361,17 +358,17 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             services.AddSingleton(Mock.Of<ISecretProvider>());
             services.AddSingleton(Mock.Of<IConfiguration>());
             services.AddLogging();
-            
+
             // Act
             ServiceBusMessageHandlerCollection result =
                 services.AddServiceBusTopicMessagePumpUsingManagedIdentityWithPrefix("topic name", "subscription prefix", "service bus namespace");
-            
+
             // Assert
             Assert.NotNull(result);
             IServiceProvider provider = result.Services.BuildServiceProvider();
             Assert.NotNull(provider.GetService<IMessageCorrelationInfoAccessor>());
         }
-        
+
         [Fact]
         public async Task AddServiceBusQueueMessagePump_IndirectSecretProviderWithQueueName_WiresUpCorrectly()
         {
@@ -434,7 +431,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
                 spySecretProvider.Verify(spy => spy.GetRawSecretAsync("secret name"), Times.Once);
             }
         }
-        
+
         [Fact]
         public void AddServiceBusQueueMessagePump_WithSecretProvider_RegistersDedicatedCorrelation()
         {
@@ -443,11 +440,11 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             services.AddSingleton(Mock.Of<ISecretProvider>());
             services.AddSingleton(Mock.Of<IConfiguration>());
             services.AddLogging();
-            
+
             // Act
             ServiceBusMessageHandlerCollection result =
                 services.AddServiceBusQueueMessagePump((ISecretProvider secretProvider) => null);
-            
+
             // Assert
             Assert.NotNull(result);
             IServiceProvider provider = result.Services.BuildServiceProvider();
@@ -467,14 +464,14 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             // Act
             ServiceBusMessageHandlerCollection result =
                 services.AddServiceBusQueueMessagePump("queue-name", "secret-name", options => options.JobId = jobId);
-            
+
             // Assert
             Assert.NotNull(result);
             IServiceProvider provider = result.Services.BuildServiceProvider();
             Assert.IsType<AzureServiceBusMessagePump>(provider.GetRequiredService<IHostedService>());
             Assert.Equal(jobId, result.JobId);
         }
-        
+
         [Fact]
         public void AddServiceBusQueueMessagePump_WithConfiguration_RegistersDedicatedCorrelation()
         {
@@ -483,17 +480,17 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             services.AddSingleton(Mock.Of<ISecretProvider>());
             services.AddSingleton(Mock.Of<IConfiguration>());
             services.AddLogging();
-            
+
             // Act
             ServiceBusMessageHandlerCollection result =
                 services.AddServiceBusQueueMessagePump((IConfiguration config) => null);
-            
+
             // Assert
             Assert.NotNull(result);
             IServiceProvider provider = result.Services.BuildServiceProvider();
             Assert.NotNull(provider.GetService<IMessageCorrelationInfoAccessor>());
         }
-        
+
         [Fact]
         public void AddServiceBusQueueMessagePump_WithQueueNameSecretName_RegistersDedicatedCorrelation()
         {
@@ -502,17 +499,17 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             services.AddSingleton(Mock.Of<ISecretProvider>());
             services.AddSingleton(Mock.Of<IConfiguration>());
             services.AddLogging();
-            
+
             // Act
             ServiceBusMessageHandlerCollection result =
                 services.AddServiceBusQueueMessagePump("queue name", "secret name");
-            
+
             // Assert
             Assert.NotNull(result);
             IServiceProvider provider = result.Services.BuildServiceProvider();
             Assert.NotNull(provider.GetService<IMessageCorrelationInfoAccessor>());
         }
-        
+
         [Fact]
         public void AddServiceBusQueueMessagePump_WithQueueNameSecretProvider_RegistersDedicatedCorrelation()
         {
@@ -521,17 +518,17 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             services.AddSingleton(Mock.Of<ISecretProvider>());
             services.AddSingleton(Mock.Of<IConfiguration>());
             services.AddLogging();
-            
+
             // Act
             ServiceBusMessageHandlerCollection result =
                 services.AddServiceBusQueueMessagePump("queue name", (ISecretProvider secretProvider) => null);
-            
+
             // Assert
             Assert.NotNull(result);
             IServiceProvider provider = result.Services.BuildServiceProvider();
             Assert.NotNull(provider.GetService<IMessageCorrelationInfoAccessor>());
         }
-        
+
         [Fact]
         public void AddServiceBusQueueMessagePump_WithQueueNameConfiguration_RegistersDedicatedCorrelation()
         {
@@ -540,17 +537,17 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             services.AddSingleton(Mock.Of<ISecretProvider>());
             services.AddSingleton(Mock.Of<IConfiguration>());
             services.AddLogging();
-            
+
             // Act
             ServiceBusMessageHandlerCollection result =
                 services.AddServiceBusQueueMessagePump("queue name", (IConfiguration config) => null);
-            
+
             // Assert
             Assert.NotNull(result);
             IServiceProvider provider = result.Services.BuildServiceProvider();
             Assert.NotNull(provider.GetService<IMessageCorrelationInfoAccessor>());
         }
-        
+
         [Fact]
         public void AddServiceBusQueueMessagePumpUsingManagedIdentity_WithQueueNameConfiguration_RegistersDedicatedCorrelation()
         {
@@ -559,11 +556,11 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             services.AddSingleton(Mock.Of<ISecretProvider>());
             services.AddSingleton(Mock.Of<IConfiguration>());
             services.AddLogging();
-            
+
             // Act
             ServiceBusMessageHandlerCollection result =
                 services.AddServiceBusQueueMessagePumpUsingManagedIdentity("queue name", "service bus namespace");
-            
+
             // Assert
             Assert.NotNull(result);
             IServiceProvider provider = result.Services.BuildServiceProvider();
@@ -641,7 +638,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
-                    implementationFactory: serviceProvider => new TestServiceBusMessageHandler(), 
+                    implementationFactory: serviceProvider => new TestServiceBusMessageHandler(),
                     messageContextFilter: null));
         }
 
@@ -667,7 +664,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
-                    implementationFactory: serviceProvider => new TestServiceBusMessageHandler(), 
+                    implementationFactory: serviceProvider => new TestServiceBusMessageHandler(),
                     messageBodyFilter: null));
         }
 
@@ -694,7 +691,7 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
-                    implementationFactory: servivceProvider => new TestServiceBusMessageHandler(), 
+                    implementationFactory: servivceProvider => new TestServiceBusMessageHandler(),
                     messageContextFilter: null,
                     messageBodyFilter: body => true));
         }
@@ -708,67 +705,9 @@ namespace Arcus.Messaging.Tests.Unit.ServiceBus
             // Act / Assert
             Assert.ThrowsAny<ArgumentException>(
                 () => collection.WithServiceBusMessageHandler<TestServiceBusMessageHandler, TestMessage>(
-                    implementationFactory: serviceProvider => new TestServiceBusMessageHandler(), 
+                    implementationFactory: serviceProvider => new TestServiceBusMessageHandler(),
                     messageContextFilter: context => true,
                     messageBodyFilter: null));
-        }
-
-        [Fact]
-        public void WithServiceBusFallbackMessageHandler_WithValidType_RegistersInterface()
-        {
-            // Arrange
-            var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
-
-            // Act
-            collection.WithServiceBusFallbackMessageHandler<PassThruServiceBusFallbackMessageHandler>();
-
-            // Assert
-            IServiceProvider provider = collection.Services.BuildServiceProvider();
-            var messageHandler = provider.GetRequiredService<FallbackMessageHandler<ServiceBusReceivedMessage, AzureServiceBusMessageContext>>();
-
-            Assert.IsType<PassThruServiceBusFallbackMessageHandler>(messageHandler.MessageHandlerInstance);
-        }
-
-        [Fact]
-        public void WithServiceBusFallbackMessageHandler_WithValidImplementationFunction_RegistersInterface()
-        {
-            // Arrange
-            var collection = new ServiceBusMessageHandlerCollection(new ServiceCollection());
-            var expected = new PassThruServiceBusFallbackMessageHandler();
-
-            // Act
-            collection.WithServiceBusFallbackMessageHandler(serviceProvider => expected);
-
-            // Assert
-            IServiceProvider provider = collection.Services.BuildServiceProvider();
-            var actual = provider.GetRequiredService<FallbackMessageHandler<ServiceBusReceivedMessage, AzureServiceBusMessageContext>>();
-
-            Assert.Same(expected, actual.MessageHandlerInstance);
-        }
-
-        [Fact]
-        public void WithServiceBusFallbackMessageHandlerType_WithoutServices_Throws()
-        {
-            Assert.ThrowsAny<ArgumentException>(
-                () => ((ServiceBusMessageHandlerCollection) null).WithServiceBusFallbackMessageHandler<PassThruServiceBusFallbackMessageHandler>());
-        }
-
-        [Fact]
-        public void WithServiceBusFallbackMessageHandlerImplementationFunction_WithoutServices_Throws()
-        {
-            Assert.ThrowsAny<ArgumentException>(
-                () => ((ServiceBusMessageHandlerCollection) null).WithServiceBusFallbackMessageHandler(serviceProvider => new PassThruServiceBusFallbackMessageHandler()));
-        }
-
-        [Fact]
-        public void WithServiceBusFallbackMessageHandlerImplementationFunction_WithoutImplementationFunction_Throws()
-        {
-            // Arrange
-            var services = new ServiceBusMessageHandlerCollection(new ServiceCollection());
-
-            // Act / Assert
-            Assert.ThrowsAny<ArgumentException>(
-                () => services.WithServiceBusFallbackMessageHandler(createImplementation: (Func<IServiceProvider, PassThruServiceBusFallbackMessageHandler>)null));
         }
     }
 }


### PR DESCRIPTION
> 👉 Since we're working on the v3.0 release, we can start removing stuff for real.

This PR removes the Azure Service Bus fallback message handler registration from the codebase, which means that no fallback message handlers can be registered in the message routing. The fallback message handling functionality was an old idea of having a way to easily place Azure Service Bus operations in a dedicated message handler, but with the moving of those operations to the message context (#551), we allow for a more easy access to those operations and more flexibility to the developer, without implementating dedicated message handlers.

Relates to #484 