### PR TITLE
chore(.net): remove net6.0 & netstandard2.1 from message processing projects

### DIFF
--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Arcus.Messaging.Abstractions.ServiceBus.csproj
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Arcus.Messaging.Abstractions.ServiceBus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;netstandard2.1</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>

--- a/src/Arcus.Messaging.Abstractions/Arcus.Messaging.Abstractions.csproj
+++ b/src/Arcus.Messaging.Abstractions/Arcus.Messaging.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;netstandard2.1</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>
@@ -30,7 +30,6 @@
     <!-- TODO: will be removed in v3.0 -->
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Enrichers" Version="[3.0.0,4.0.0)" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
-    <PackageReference Include="System.Text.Json" Version="8.*" Condition="'$(TargetFramework)' != 'net8.0'" />
     <!-- TODO: will be removed in v3.0 -->
   </ItemGroup>
 

--- a/src/Arcus.Messaging.Pumps.Abstractions/Arcus.Messaging.Pumps.Abstractions.csproj
+++ b/src/Arcus.Messaging.Pumps.Abstractions/Arcus.Messaging.Pumps.Abstractions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;netstandard2.1</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Arcus.Messaging.Pumps.ServiceBus.csproj
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Arcus.Messaging.Pumps.ServiceBus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0;netstandard2.1</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>

--- a/src/Arcus.Messaging.ServiceBus.Core/Arcus.Messaging.ServiceBus.Core.csproj
+++ b/src/Arcus.Messaging.ServiceBus.Core/Arcus.Messaging.ServiceBus.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>

--- a/src/Arcus.Messaging.Tests.Core/Arcus.Messaging.Tests.Core.csproj
+++ b/src/Arcus.Messaging.Tests.Core/Arcus.Messaging.Tests.Core.csproj
@@ -1,17 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.7.1" />


### PR DESCRIPTION
> 👉 Since we're working on v3.0, we can start removing stuff for real.

This PR removes all .NET 6 and .NET Standard 2.1 target frameworks from the message-processing projects (excluding Health).

Relates to #484 