### PR TITLE
Chore/use arcus.testing v2.0

### DIFF
--- a/src/Arcus.Messaging.Tests.Core/Arcus.Messaging.Tests.Core.csproj
+++ b/src/Arcus.Messaging.Tests.Core/Arcus.Messaging.Tests.Core.csproj
@@ -6,6 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="NewFolder\**" />
+    <EmbeddedResource Remove="NewFolder\**" />
+    <None Remove="NewFolder\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.7.1" />
     <PackageReference Include="Bogus" Version="29.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />

--- a/src/Arcus.Messaging.Tests.Core/Arcus.Messaging.Tests.Core.csproj
+++ b/src/Arcus.Messaging.Tests.Core/Arcus.Messaging.Tests.Core.csproj
@@ -6,12 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="NewFolder\**" />
-    <EmbeddedResource Remove="NewFolder\**" />
-    <None Remove="NewFolder\**" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.7.1" />
     <PackageReference Include="Bogus" Version="29.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />

--- a/src/Arcus.Messaging.Tests.Core/Correlation/CustomLoggerProvider.cs
+++ b/src/Arcus.Messaging.Tests.Core/Correlation/CustomLoggerProvider.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+
+namespace Arcus.Testing
+{
+    public class CustomLoggerProvider : ILoggerProvider
+    {
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomLoggerProvider"/> class.
+        /// </summary>
+        public CustomLoggerProvider(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public void Dispose()
+        {
+            throw new NotImplementedException();
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return _logger;
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Core/Correlation/InMemoryLogSink.cs
+++ b/src/Arcus.Messaging.Tests.Core/Correlation/InMemoryLogSink.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Arcus.Testing
+{
+    public class InMemoryLogSink : ILogEventSink
+    {
+        private readonly Collection<LogEvent> _events = new();
+
+        public IReadOnlyCollection<LogEvent> CurrentLogEmits => _events;
+
+        public void Emit(LogEvent logEvent)
+        {
+            _events.Add(logEvent);
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Core/Correlation/InMemoryLogger.cs
+++ b/src/Arcus.Messaging.Tests.Core/Correlation/InMemoryLogger.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Microsoft.Extensions.Logging;
+
+namespace Arcus.Testing
+{
+    public class LogEntry
+    {
+        public LogLevel Level { get; set; }
+        public string Message { get; set; }
+    }
+
+    public class InMemoryLogger : ILogger
+    {
+        private readonly Collection<string> _messages = new();
+        private readonly Collection<LogEntry> _entries = new();
+
+        public IReadOnlyCollection<string> Messages => _messages;
+        public IReadOnlyCollection<LogEntry> Entries => _entries;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            string message = formatter(state, exception);
+            _entries.Add(new LogEntry { Message = message, Level = logLevel });
+            _messages.Add(message);
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/Arcus.Messaging.Tests.Integration.csproj
+++ b/src/Arcus.Messaging.Tests.Integration/Arcus.Messaging.Tests.Integration.csproj
@@ -11,10 +11,10 @@
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="3.0.0" />
     <PackageReference Include="Arcus.Security.Core" Version="2.0.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="2.0.0" />
-    <PackageReference Include="Arcus.Testing.Logging.Xunit" Version="1.1.0" />
-    <PackageReference Include="Arcus.Testing.Messaging.ServiceBus" Version="1.3.0" />
+    <PackageReference Include="Arcus.Testing.Logging.Xunit" Version="2.0.0" />
+    <PackageReference Include="Arcus.Testing.Messaging.ServiceBus" Version="2.0.0" />
     <PackageReference Include="Arcus.Testing.Security.Providers.InMemory" Version="1.1.0" />
-    <PackageReference Include="Arcus.Testing.Storage.Blob" Version="1.2.0" />
+    <PackageReference Include="Arcus.Testing.Storage.Blob" Version="2.0.0" />
     <PackageReference Include="Azure.ResourceManager.Authorization" Version="1.1.3" />
     <PackageReference Include="Azure.ResourceManager.EventHubs" Version="1.1.0" />
     <PackageReference Include="Azure.ResourceManager.ServiceBus" Version="1.0.1" />

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/WorkerOptions.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/WorkerOptions.cs
@@ -7,6 +7,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Serilog;
 using Serilog.Configuration;
+using Serilog.Core;
+using Serilog.Events;
 using Xunit.Abstractions;
 
 namespace Arcus.Messaging.Tests.Integration.Fixture
@@ -85,7 +87,7 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
 
             if (_outputWriter != null)
             {
-                config.WriteTo.XunitTestLogging(_outputWriter);
+                config.WriteTo.Sink(new XunitTestLogSink(_outputWriter));
             }
 
             foreach (Action<LoggerConfiguration> configure in _additionalSerilogConfigOptions)
@@ -108,6 +110,21 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
             foreach (Action<IHostBuilder> additionalHostOption in _additionalHostOptions)
             {
                 additionalHostOption(hostBuilder);
+            }
+        }
+
+        private sealed class XunitTestLogSink : ILogEventSink
+        {
+            private readonly ITestOutputHelper _outputWriter;
+
+            internal XunitTestLogSink(ITestOutputHelper outputWriter)
+            {
+                _outputWriter = outputWriter;
+            }
+
+            public void Emit(LogEvent logEvent)
+            {
+                _outputWriter.WriteLine(logEvent.RenderMessage());
             }
         }
 

--- a/src/Arcus.Messaging.Tests.Integration/IntegrationTest.cs
+++ b/src/Arcus.Messaging.Tests.Integration/IntegrationTest.cs
@@ -7,21 +7,15 @@ namespace Arcus.Messaging.Tests.Integration
     /// <summary>
     /// Represents default environment values required in describing integration tests.
     /// </summary>
-    public class IntegrationTest
+    public abstract class IntegrationTest
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="IntegrationTest"/> class.
         /// </summary>
-        public IntegrationTest(ITestOutputHelper testOutput)
+        protected IntegrationTest(ITestOutputHelper testOutput)
         {
             Logger = new XunitTestLogger(testOutput);
-
-            Configuration = 
-                new ConfigurationBuilder()
-                    .AddJsonFile(path: "appsettings.json")
-                    .AddJsonFile(path: "appsettings.local.json", optional: true)
-                    .AddEnvironmentVariables()
-                    .Build();
+            Configuration = TestConfig.Create();
         }
 
         /// <summary>

--- a/src/Arcus.Messaging.Tests.Unit/Arcus.Messaging.Tests.Unit.csproj
+++ b/src/Arcus.Messaging.Tests.Unit/Arcus.Messaging.Tests.Unit.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Arcus.Security.Core" Version="2.0.0" />
     <PackageReference Include="Arcus.Testing.Security.Providers.InMemory" Version="1.2.0" />
-    <PackageReference Include="Arcus.Testing.Logging.Xunit" Version="1.2.0" />
+    <PackageReference Include="Arcus.Testing.Logging.Xunit" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />


### PR DESCRIPTION
Use the new Arcus.Testing v2 with `TemporaryTopicSubscription`, `TestConfig` and since some in-memory logging functionality has been removed - replace it with our own.