### PR TITLE
chore(az.sb): remove deprecated az sb message router overload

### DIFF
--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
@@ -102,39 +102,6 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
 
         /// <summary>
         /// Handle a new <paramref name="message"/> that was received by routing them through registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/>s
-        /// and optionally through <see cref="IAzureServiceBusFallbackMessageHandler"/>
-        /// if none of the message handlers were able to process the <paramref name="message"/>.
-        /// </summary>
-        /// <param name="message">The incoming message that needs to be routed through registered message handlers.</param>
-        /// <param name="messageContext">The context in which the <paramref name="message"/> should be processed.</param>
-        /// <param name="correlationInfo">The information concerning correlation of telemetry and processes by using a variety of unique identifiers.</param>
-        /// <param name="cancellationToken">The token to cancel the message processing.</param>
-        /// <remarks>
-        ///     Note that registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/>s with specific Azure Service Bus operations (dead-letter, complete...),
-        ///     will not be able to call those operations without an <see cref="ServiceBusReceiver"/>.
-        ///     Use the <see cref="RouteMessageAsync(ServiceBusReceiver,ServiceBusReceivedMessage,AzureServiceBusMessageContext,MessageCorrelationInfo,CancellationToken)"/> instead.
-        /// </remarks>
-        /// <exception cref="ArgumentNullException">
-        ///     Thrown when the <paramref name="message"/>, <paramref name="messageContext"/>, or <paramref name="correlationInfo"/> is <c>null</c>.
-        /// </exception>
-        /// <exception cref="InvalidOperationException">Thrown when no message handlers or none matching message handlers are found to process the message.</exception>
-        [Obsolete("Will be removed in v3.0 as the message pump will be the sole point of contact for message processing instead of this overload that was used in message pump-free scenarios like Azure Functions, use the other overload instead with the " + nameof(ServiceBusReceiver))]
-        public async Task<MessageProcessingResult> RouteMessageAsync(
-            ServiceBusReceivedMessage message,
-            AzureServiceBusMessageContext messageContext,
-            MessageCorrelationInfo correlationInfo,
-            CancellationToken cancellationToken)
-        {
-            return await RouteMessageWithPotentialFallbackAsync(
-                messageReceiver: null,
-                message: message,
-                messageContext: messageContext,
-                correlationInfo: correlationInfo,
-                cancellationToken: cancellationToken);
-        }
-
-        /// <summary>
-        /// Handle a new <paramref name="message"/> that was received by routing them through registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/>s
         /// and optionally through a <see cref="IAzureServiceBusFallbackMessageHandler"/>
         /// if none of the message handlers were able to process the <paramref name="message"/>.
         /// </summary>

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/IAzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/IAzureServiceBusMessageRouter.cs
@@ -15,31 +15,6 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
     {
         /// <summary>
         /// Handle a new <paramref name="message"/> that was received by routing them through registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/>s
-        /// and optionally through <see cref="IAzureServiceBusFallbackMessageHandler"/>
-        /// if none of the message handlers were able to process the <paramref name="message"/>.
-        /// </summary>
-        /// <param name="message">The incoming message that needs to be routed through registered message handlers.</param>
-        /// <param name="messageContext">The context in which the <paramref name="message"/> should be processed.</param>
-        /// <param name="correlationInfo">The information concerning correlation of telemetry and processes by using a variety of unique identifiers.</param>
-        /// <param name="cancellationToken">The token to cancel the message processing.</param>
-        /// <remarks>
-        ///     Note that registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/>s with specific Azure Service Bus operations (dead-letter, complete...),
-        ///     will not be able to call those operations without an <see cref="ServiceBusReceiver"/>.
-        ///     Use the <see cref="RouteMessageAsync(ServiceBusReceiver,ServiceBusReceivedMessage,AzureServiceBusMessageContext,MessageCorrelationInfo,CancellationToken)"/> instead.
-        /// </remarks>
-        /// <exception cref="ArgumentNullException">
-        ///     Thrown when the <paramref name="message"/>, <paramref name="messageContext"/>, or <paramref name="correlationInfo"/> is <c>null</c>.
-        /// </exception>
-        /// <exception cref="InvalidOperationException">Thrown when no message handlers or none matching message handlers are found to process the message.</exception>
-        [Obsolete("Will be removed in v3.0 as the message pump will be the sole point of contact for message processing instead of this overload that was used in message pump-free scenarios like Azure Functions, use the other overload instead with the " + nameof(ServiceBusReceiver))]
-        Task<MessageProcessingResult> RouteMessageAsync(
-            ServiceBusReceivedMessage message,
-            AzureServiceBusMessageContext messageContext,
-            MessageCorrelationInfo correlationInfo,
-            CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Handle a new <paramref name="message"/> that was received by routing them through registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/>s
         /// and optionally through a registered <see cref="IAzureServiceBusFallbackMessageHandler"/>
         /// if none of the message handlers were able to process the <paramref name="message"/>.
         /// </summary>

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/AzureServiceBusMessageRouterTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/AzureServiceBusMessageRouterTests.cs
@@ -48,7 +48,8 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
             var context = AzureServiceBusMessageContext.Create(jobId, ServiceBusEntityType.Unknown, Mock.Of<ServiceBusReceiver>(), message);
             MessageCorrelationInfo correlationInfo = message.GetCorrelationInfo();
 
-            await router.RouteMessageAsync(message, context, correlationInfo, CancellationToken.None);
+            MessageProcessingResult result = await router.RouteMessageAsync(Mock.Of<ServiceBusReceiver>(), message, context, correlationInfo, CancellationToken.None);
+            Assert.True(result.IsSuccessful, result.ErrorMessage);
         }
 
         [Fact]
@@ -72,9 +73,10 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
             var correlationInfo = message.GetCorrelationInfo();
 
             // Act / Assert
-            await router.RouteMessageAsync(receiver.Object, message, context, correlationInfo, CancellationToken.None);
+            MessageProcessingResult result = await router.RouteMessageAsync(receiver.Object, message, context, correlationInfo, CancellationToken.None);
 
             // Assert
+            Assert.False(result.IsSuccessful, result.ErrorMessage);
             Assert.True(sabotageHandler.IsProcessed, "sabotage message handler should be tried");
         }
 
@@ -101,10 +103,10 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
             Order order = OrderGenerator.Generate();
             ServiceBusReceivedMessage message = order.AsServiceBusReceivedMessage();
 
-            await router.RouteMessageAsync(message, context, correlationInfo, CancellationToken.None);
-
-            Assert.True(spyHandler.IsProcessed);
-            Assert.False(ignoredHandler.IsProcessed);
+            MessageProcessingResult result = await router.RouteMessageAsync(Mock.Of<ServiceBusReceiver>(), message, context, correlationInfo, CancellationToken.None);
+            Assert.True(result.IsSuccessful, result.ErrorMessage);
+            Assert.True(spyHandler.IsProcessed, result.ErrorMessage);
+            Assert.False(ignoredHandler.IsProcessed, result.ErrorMessage);
         }
 
         [Fact]
@@ -131,8 +133,8 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
 
             Order order = OrderGenerator.Generate();
             ServiceBusReceivedMessage message = order.AsServiceBusReceivedMessage();
-            await router.RouteMessageAsync(message, context, correlationInfo, CancellationToken.None);
-
+            MessageProcessingResult result = await router.RouteMessageAsync(Mock.Of<ServiceBusReceiver>(), message, context, correlationInfo, CancellationToken.None);
+            Assert.True(result.IsSuccessful, result.ErrorMessage);
             Assert.True(spyHandler.IsProcessed);
             Assert.False(ignoredHandler.IsProcessed);
         }
@@ -161,8 +163,8 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
 
             Order order = OrderGenerator.Generate();
             ServiceBusReceivedMessage message = order.AsServiceBusReceivedMessage();
-            await router.RouteMessageAsync(message, context, correlationInfo, CancellationToken.None);
-
+            MessageProcessingResult result = await router.RouteMessageAsync(Mock.Of<ServiceBusReceiver>(), message, context, correlationInfo, CancellationToken.None);
+            Assert.True(result.IsSuccessful, result.ErrorMessage);
             Assert.True(spyHandler.IsProcessed);
             Assert.False(ignoredHandler.IsProcessed);
         }
@@ -189,8 +191,8 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
 
             Order order = OrderGenerator.Generate();
             ServiceBusReceivedMessage message = order.AsServiceBusReceivedMessage();
-            await router.RouteMessageAsync(message, context, correlationInfo, CancellationToken.None);
-
+            MessageProcessingResult result = await router.RouteMessageAsync(Mock.Of<ServiceBusReceiver>(), message, context, correlationInfo, CancellationToken.None);
+            Assert.True(result.IsSuccessful, result.ErrorMessage);
             Assert.True(spyHandler.IsProcessed);
             Assert.False(ignoredHandler.IsProcessed);
         }
@@ -220,8 +222,8 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
             var correlationInfo = new MessageCorrelationInfo("operation-id", "transaction-id");
 
             ServiceBusReceivedMessage message = expectedMessage.AsServiceBusReceivedMessage();
-            await router.RouteMessageAsync(message, context, correlationInfo, CancellationToken.None);
-
+            MessageProcessingResult result = await router.RouteMessageAsync(Mock.Of<ServiceBusReceiver>(), message, context, correlationInfo, CancellationToken.None);
+            Assert.True(result.IsSuccessful, result.ErrorMessage);
             Assert.True(spyHandler.IsProcessed);
             Assert.False(ignoredHandler.IsProcessed);
         }
@@ -251,8 +253,8 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
             var correlationInfo = new MessageCorrelationInfo("operation-id", "transaction-id");
 
             ServiceBusReceivedMessage message = expectedMessage.AsServiceBusReceivedMessage();
-            await router.RouteMessageAsync(message, context, correlationInfo, CancellationToken.None);
-
+            MessageProcessingResult result = await router.RouteMessageAsync(Mock.Of<ServiceBusReceiver>(), message, context, correlationInfo, CancellationToken.None);
+            Assert.True(result.IsSuccessful, result.ErrorMessage);
             Assert.True(spyHandler.IsProcessed);
             Assert.False(ignoredHandler.IsProcessed);
         }
@@ -299,8 +301,8 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
 
             var correlationInfo = new MessageCorrelationInfo("operation-id", "transaction-id");
             ServiceBusReceivedMessage message = expectedMessage.AsServiceBusReceivedMessage();
-            await router.RouteMessageAsync(message, context, correlationInfo, CancellationToken.None);
-
+            MessageProcessingResult result = await router.RouteMessageAsync(Mock.Of<ServiceBusReceiver>(), message, context, correlationInfo, CancellationToken.None);
+            Assert.True(result.IsSuccessful, result.ErrorMessage);
             Assert.True(spyHandler.IsProcessed);
             Assert.False(ignoredHandler1.IsProcessed);
             Assert.False(ignoredHandler2.IsProcessed);
@@ -349,8 +351,8 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
             ServiceBusReceivedMessage message = orderV2.AsServiceBusReceivedMessage();
             AzureServiceBusMessageContext context = AzureServiceBusMessageContextFactory.Generate();
             var correlationInfo = new MessageCorrelationInfo("operation-id", "transaction-id");
-            await router.RouteMessageAsync(message, context, correlationInfo, CancellationToken.None);
-
+            MessageProcessingResult result = await router.RouteMessageAsync(Mock.Of<ServiceBusReceiver>(), message, context, correlationInfo, CancellationToken.None);
+            Assert.True(result.IsSuccessful, result.ErrorMessage);
             Assert.Equal(additionalMemberHandling is AdditionalMemberHandling.Error, messageHandlerV2.IsProcessed);
             Assert.Equal(additionalMemberHandling is AdditionalMemberHandling.Ignore, messageHandlerV1.IsProcessed);
         }
@@ -390,7 +392,9 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
 
             foreach (ServiceBusReceivedMessage message in messages)
             {
-                await router.RouteMessageAsync(message,
+                await router.RouteMessageAsync(
+                    Mock.Of<ServiceBusReceiver>(),
+                    message,
                     AzureServiceBusMessageContext.Create(
                         $"job-{Guid.NewGuid()}",
                         ServiceBusEntityType.Unknown,


### PR DESCRIPTION
> 👉 Since we're working on v3.0, we can start removing stuff for real.

This PR removes the deprecated Azure Service Bus message routing overload w/o the `ServiceBusReceiver`.

Relates to #484 