### PR TITLE
chore(general): remove deprecated general message pump members

### DIFF
--- a/src/Arcus.Messaging.Pumps.Abstractions/MessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/MessagePump.cs
@@ -1,16 +1,12 @@
 ﻿using System;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Arcus.Messaging.Pumps.Abstractions.Resiliency;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-
-#pragma warning disable CS0618 // Type or member is obsolete: lots of deprecated functionality will be removed in v3.0.
 
 namespace Arcus.Messaging.Pumps.Abstractions
 {
@@ -22,36 +18,12 @@ namespace Arcus.Messaging.Pumps.Abstractions
         /// <summary>
         /// Initializes a new instance of the <see cref="MessagePump"/> class.
         /// </summary>
-        /// <param name="configuration">The configuration of the application.</param>
-        /// <param name="serviceProvider">The collection of services that are configured.</param>
-        /// <param name="logger">The logger to write telemetry to.</param>
-        /// <exception cref="ArgumentNullException">
-        ///     Thrown when the <paramref name="configuration"/>, the <paramref name="serviceProvider"/>, or <paramref name="logger"/> is <c>null</c>.
-        /// </exception>
-        [Obsolete("Will be removed in v3.0 as the application configuration is not needed anymore by the message pump")]
-        protected MessagePump(IConfiguration configuration, IServiceProvider serviceProvider, ILogger logger)
-            : this(serviceProvider, logger)
-        {
-            if (configuration is null)
-            {
-                throw new ArgumentNullException(nameof(configuration));
-            }
-
-            Configuration = configuration;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessagePump"/> class.
-        /// </summary>
         /// <param name="serviceProvider">The collection of services that are configured.</param>
         /// <param name="logger">The logger to write telemetry to.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serviceProvider"/> is <c>null</c>.</exception>
         protected MessagePump(IServiceProvider serviceProvider, ILogger logger)
         {
-            if (serviceProvider is null)
-            {
-                throw new ArgumentNullException(nameof(serviceProvider));
-            }
+            ArgumentNullException.ThrowIfNull(serviceProvider);
 
             ServiceProvider = serviceProvider;
             Logger = logger ?? NullLogger.Instance;
@@ -73,33 +45,9 @@ namespace Arcus.Messaging.Pumps.Abstractions
         public MessagePumpCircuitState CircuitState { get; private set; } = MessagePumpCircuitState.Closed;
 
         /// <summary>
-        /// Gets hte ID of the client being used to connect to the messaging service.
-        /// </summary>
-        [Obsolete("Will be removed in v3.0 in favor of using the " + nameof(JobId) + " to identifying a message pump")]
-        protected string ClientId { get; private set; }
-
-        /// <summary>
-        /// Gets entity path that is being processed.
-        /// </summary>
-        [Obsolete("Will be moved down to the Azure Service bus message pump in v3.0, as it is related to Azure Service bus")]
-        public string EntityPath { get; private set; }
-
-        /// <summary>
-        /// Gets the configuration of the application.
-        /// </summary>
-        [Obsolete("Will be removed in v3.0 as it is not used in the messaging system with the removal of using the application configuration directly to retrieve connection strings")]
-        protected IConfiguration Configuration { get; }
-
-        /// <summary>
         /// Gets the collection of application services that are configured.
         /// </summary>
         protected IServiceProvider ServiceProvider { get; }
-
-        /// <summary>
-        /// Gets the default encoding used during the message processing through the message pump.
-        /// </summary>
-        [Obsolete("Will be removed in v3.0 as it is not used by the messaging system")]
-        protected Encoding DefaultEncoding { get; } = Encoding.UTF8;
 
         /// <summary>
         /// Gets the logger to write telemetry to.
@@ -112,7 +60,7 @@ namespace Arcus.Messaging.Pumps.Abstractions
         /// <param name="receiveException">Exception that occurred</param>
         protected virtual Task HandleReceiveExceptionAsync(Exception receiveException)
         {
-            Logger.LogCritical(receiveException, "Unable to process message from {EntityPath} with client {ClientId}: {Message}", EntityPath, ClientId, receiveException.Message);
+            Logger.LogCritical(receiveException, "Message pump '{JobId}' was unable to process message: {Message}", JobId, receiveException.Message);
             return Task.CompletedTask;
         }
 

--- a/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/AzureServiceBusMessagePump.cs
@@ -208,11 +208,11 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             catch (Exception exception) when (exception is TaskCanceledException || exception is OperationCanceledException)
             {
 #pragma warning disable CS0618 // Type or member is obsolete: the entity type will be moved down to this message pump in v3.0.
-                Logger.LogDebug("Azure Service Bus {EntityType} message pump '{JobId}' on entity path '{EntityPath}' in namespace '{Namespace}' was cancelled", Settings.ServiceBusEntity, JobId, EntityPath, Namespace);
+                Logger.LogDebug("Azure Service Bus {EntityType} message pump '{JobId}' on entity path '{EntityPath}' in namespace '{Namespace}' was cancelled", Settings.ServiceBusEntity, JobId, Settings.EntityName, Namespace);
             }
             catch (Exception exception)
             {
-                Logger.LogCritical(exception, "Unexpected failure occurred during processing of messages in the Azure Service Bus {EntityType} message pump '{JobId}' on entity path '{EntityPath}' in namespace '{Namespace}'", Settings.ServiceBusEntity, JobId, EntityPath, Namespace);
+                Logger.LogCritical(exception, "Unexpected failure occurred during processing of messages in the Azure Service Bus {EntityType} message pump '{JobId}' on entity path '{EntityPath}' in namespace '{Namespace}'", Settings.ServiceBusEntity, JobId, Settings.EntityName, Namespace);
             }
             finally
             {
@@ -235,7 +235,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             /* TODO: we can't support Azure Service Bus plug-ins yet because the new Azure SDK doesn't yet support this:
                    https://github.com/arcus-azure/arcus.messaging/issues/176 */
 
-            Logger.LogInformation("Azure Service Bus {EntityType} message pump '{JobId}' on entity path '{EntityPath}' in namespace '{Namespace}' started", Settings.ServiceBusEntity, JobId, EntityPath, Namespace);
+            Logger.LogInformation("Azure Service Bus {EntityType} message pump '{JobId}' on entity path '{EntityPath}' in namespace '{Namespace}' started", Settings.ServiceBusEntity, JobId, Settings.EntityName, Namespace);
 
             Namespace = _messageReceiver.FullyQualifiedNamespace;
 
@@ -270,7 +270,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
                 {
                     IsStarted = false;
 
-                    Logger.LogTrace("Azure Service Bus {EntityType} message pump '{JobId}' on entity path '{EntityPath}' in '{Namespace}' was cancelled", Settings.ServiceBusEntity, JobId, EntityPath, Namespace);
+                    Logger.LogTrace("Azure Service Bus {EntityType} message pump '{JobId}' on entity path '{EntityPath}' in '{Namespace}' was cancelled", Settings.ServiceBusEntity, JobId, Settings.EntityName, Namespace);
                     return;
                 }
                 catch (Exception exception)
@@ -293,11 +293,11 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             if (_messageReceiver is null)
             {
                 throw new InvalidOperationException(
-                    $"Cannot try process a single message in the Azure Service Bus {EntityPath} message pump '{JobId}' because there was not a message receiver set before this point, " +
+                    $"Cannot try process a single message in the Azure Service Bus {Settings.EntityName} message pump '{JobId}' because there was not a message receiver set before this point, " +
                     $"this probably happens when the message pump is used in the wrong way or manually called, please let only the circuit breaker functionality call this functionality");
             }
 
-            Logger.LogDebug("Azure Service Bus {EntityType} message pump '{JobId}' on entity path '{EntityPath}' in namespace '{Namespace}' tries to process single message during half-open circuit...", Settings.ServiceBusEntity, JobId, EntityPath, Namespace);
+            Logger.LogDebug("Azure Service Bus {EntityType} message pump '{JobId}' on entity path '{EntityPath}' in namespace '{Namespace}' tries to process single message during half-open circuit...", Settings.ServiceBusEntity, JobId, Settings.EntityName, Namespace);
 
             ServiceBusReceivedMessage message = null;
             while (message is null)
@@ -305,7 +305,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
                 message = await _messageReceiver.ReceiveMessageAsync();
                 if (message is null)
                 {
-                    Logger.LogTrace("Azure Service Bus {EntityType} message pump '{JobId}' on entity path '{EntityPath}' in namespace '{Namespace}' failed to receive a single message, trying again...", Settings.ServiceBusEntity, JobId, EntityPath, Namespace);
+                    Logger.LogTrace("Azure Service Bus {EntityType} message pump '{JobId}' on entity path '{EntityPath}' in namespace '{Namespace}' failed to receive a single message, trying again...", Settings.ServiceBusEntity, JobId, Settings.EntityName, Namespace);
                     await Task.Delay(MessagePollingWaitTime);
                 }
             }
@@ -317,7 +317,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             }
             catch (Exception exception)
             {
-                Logger.LogError(exception, "Azure Service Bus {EntityType} message pump '{JobId}' on entity path '{EntityPath}' in namespace '{Namespace}' failed to process single message during half-open circuit, retrying after circuit delay", Settings.ServiceBusEntity, JobId, EntityPath, Namespace);
+                Logger.LogError(exception, "Azure Service Bus {EntityType} message pump '{JobId}' on entity path '{EntityPath}' in namespace '{Namespace}' failed to process single message during half-open circuit, retrying after circuit delay", Settings.ServiceBusEntity, JobId, Settings.EntityName, Namespace);
                 return MessageProcessingResult.Failure(message.MessageId, MessageProcessingError.ProcessingInterrupted, "Failed to process single message during half-open circuit due to an unexpected exception", exception);
             }
         }
@@ -330,7 +330,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
                 return;
             }
 
-            Logger.LogInformation("Azure Service Bus {EntityType} message pump '{JobId}' on entity path '{EntityPath}' in '{Namespace}' closed : {Time}", Settings.ServiceBusEntity, JobId, EntityPath, Namespace, DateTimeOffset.UtcNow);
+            Logger.LogInformation("Azure Service Bus {EntityType} message pump '{JobId}' on entity path '{EntityPath}' in '{Namespace}' closed : {Time}", Settings.ServiceBusEntity, JobId, Settings.EntityName, Namespace, DateTimeOffset.UtcNow);
 
             _receiveMessagesCancellation?.Cancel();
             await base.StopProcessingMessagesAsync(cancellationToken);

--- a/src/Arcus.Messaging.Tests.Unit/MessagePump/Fixture/TestMessagePump.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessagePump/Fixture/TestMessagePump.cs
@@ -10,10 +10,10 @@ namespace Arcus.Messaging.Tests.Unit.MessagePump.Fixture
     {
         public TestMessagePump(
             string jobId,
-            IConfiguration configuration, 
+            IConfiguration _, 
             IServiceProvider serviceProvider, 
             ILogger logger) 
-            : base(configuration, serviceProvider, logger)
+            : base(serviceProvider, logger)
         {
             JobId = jobId;
             IsRunning = false;


### PR DESCRIPTION
> 👉 Since we're working on v3.0, we can start removing stuff for real.

This PR removes the deprecated members of the general `MessagePump`, including properties and constructors.

Relates to #484 