### PR TITLE
feat(correlation): add open-telemetry as msg correlation scope

### DIFF
--- a/docs/preview/02-getting-started.md
+++ b/docs/preview/02-getting-started.md
@@ -80,4 +80,4 @@ Host.CreateDefaultBuilder()
 
 The way *'message handlers'* are registered determines when the received message will be routed to them.
 
-> 🔗 See the [Azure Service Bus messaging feature documentation](./03-Features/01-Azure/01-service-bus.md) for more information on providing additional routing filters to your message handlers.
+> 🔗 See the [Azure Service Bus messaging feature documentation](./03-Features/01-Azure/01-service-bus.mdx) for more information on providing additional routing filters to your message handlers.

--- a/docs/preview/03-Features/01-Azure/01-service-bus.mdx
+++ b/docs/preview/03-Features/01-Azure/01-service-bus.mdx
@@ -2,6 +2,9 @@
 sidebar_label: Service Bus
 ---
 
+import Tabs from '@theme/Tabs'; 
+import TabItem from '@theme/TabItem';
+
 # Azure Service Bus messaging
 The `Arcus.Messaging.Pumps.ServiceBus` library provides a way to process Azure Service Bus messages on queues/topic subscriptions via custom routed *message handlers*, instead of interacting with the [`ServiceBusReceiver`](https://learn.microsoft.com/en-us/dotnet/api/azure.messaging.servicebus.servicebusreceiver) yourself. 
 
@@ -138,11 +141,51 @@ services.AddServiceBus[Topic/Queue]MessagePump(..., options =>
     // this job instance in a multi-instance deployment (default: generated GUID).
     options.JobId = Guid.NewGuid().ToString();
 
+    // The name for the request operation which will be used in the chosen message correlation system.
+    // Default: Process  
+    options.Telemetry.OperationName = "ReceiveOrder";
+
     // Indicate whether or not the default built-in JSON deserialization should ignore additional members 
     // when deserializing the incoming message (default: AdditionalMemberHandling.Error).
     options.Routing.Deserialization.AdditionalMembers = AdditionalMemberHandling.Ignore;
 });
 ```
+
+#### Correlation system
+The following correlation systems are available when registering the message pump. These systems will use the incoming Azure Service Bus message to start a request operation. A `MessageCorrelationInfo` model is passed to your registered message handlers, which represents the current request operation. All interactions to dependent systems should be children of this operation for a transactional service-to-service relationship.
+
+<Tabs groupId="correlation-systems">
+<TabItem value="open-telemetry" label="OpenTelemetry">
+
+```powershell
+PS> Install-Package -Name Arcus.Messaging.ServiceBus.Telemetry.OpenTelemetry
+```
+
+Make sure to include the following line to your message pump registration:
+```diff
++ ActivitySource applicationSource = new("<activity-source-name>");
+
+services.AddServiceBusTopicMessagePump(...)
++       .UseServiceBusOpenTelemetryRequestTracking(applicationSource)           
+        .WithServiceBusMessageHandler<...>()
+        .WithServiceBusMessageHandler<...>();
+```
+
+Now Arcus will use the OpenTelemetry approach to track Azure Service Bus messages. Make sure that the `ActivitySource` that is passed, is also tracked by OpenTelemetry:
+```csharp
+IServiceCollection services = ...
+
+services.AddOpenTelemetry()
+        .AddTraces(traces =>
+        {
+            traces.AddSource("<activity-source-name>");
+        });
+```
+
+> 🔗 [More info on OpenTelemetry on Azure](https://learn.microsoft.com/en-us/azure/azure-monitor/app/opentelemetry) 
+
+</TabItem>
+</Tabs>
 
 ### Message handler routing customization
 The following routing options are available when registering an Azure Service Bus message handler on a message pump.
@@ -265,7 +308,9 @@ Both the recovery period after the circuit is open and the interval between mess
 }
 ```
 
-#### 🔔 Get notified on a circuit breaker state transition
+<details>
+<summary>**🔔 Get notified on a circuit breaker state transition**</summary>
+
 To get notified on circuit-breaker state transitions, you can register one or more event handlers on a message pump.
 
 These event handlers should implement the `ICircuitBreakerEventHandler` interface:
@@ -294,3 +339,4 @@ services.AddServiceBus[Queue/Topic]MessagePump(...)
         .WithCircuitBreakerStateChangedEventHandler<MyFirstCircuitBreakerEventHandler>()
         .WithCircuitBreakerStateChangedEventHandler<MySecondCircuitBreakerEventHandler>();
 ```
+</details>

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Telemetry/IServiceBusMessageCorrelationScope.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Telemetry/IServiceBusMessageCorrelationScope.cs
@@ -1,0 +1,18 @@
+﻿using Arcus.Messaging.Abstractions.MessageHandling;
+using Arcus.Messaging.Abstractions.Telemetry;
+
+namespace Arcus.Messaging.Abstractions.ServiceBus.Telemetry
+{
+    /// <summary>
+    /// Represents an approach to track the correlation information of a received Azure Service Bus message within a message pump.
+    /// </summary>
+    public interface IServiceBusMessageCorrelationScope
+    {
+        /// <summary>
+        /// Starts a new Azure Service bus request operation on the telemetry system.
+        /// </summary>
+        /// <param name="messageContext">The message context for the currently received Azure Service bus message.</param>
+        /// <param name="options">The user-configurable options to manipulate the telemetry.</param>
+        MessageOperationResult StartOperation(AzureServiceBusMessageContext messageContext, MessageTelemetryOptions options);
+    }
+}

--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageTelemetryOptions.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageTelemetryOptions.cs
@@ -7,7 +7,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
     /// </summary>
     public class MessageTelemetryOptions
     {
-        private string _operationName;
+        private string _operationName = "Process";
 
         /// <summary>
         /// Gets or sets the name of the operation that is used when a request telemetry is tracked - default 'Process' is used as operation name.

--- a/src/Arcus.Messaging.ServiceBus.Telemetry.OpenTelemetry/Arcus.Messaging.ServiceBus.Telemetry.OpenTelemetry.csproj
+++ b/src/Arcus.Messaging.ServiceBus.Telemetry.OpenTelemetry/Arcus.Messaging.ServiceBus.Telemetry.OpenTelemetry.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <LangVersion>latest</LangVersion>
+        <Authors>Arcus</Authors>
+        <Company>Arcus</Company>
+        <Product>Arcus.Messaging</Product>
+        <Description>Provides capability to track message correlation information using OpenTelemetry for Azure Service Bus message pumps</Description>
+        <Copyright>Copyright (c) Arcus</Copyright>
+        <PackageProjectUrl>https://messaging.arcus-azure.net/</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/arcus-azure/arcus.messaging</RepositoryUrl>
+        <PackageLicenseFile>LICENSE</PackageLicenseFile>
+        <PackageIcon>icon.png</PackageIcon>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <RepositoryType>Git</RepositoryType>
+        <PackageTags>Azure;Messaging;ServiceBus</PackageTags>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+        <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
+        <None Include="..\..\docs\static\img\icon.png" Pack="true" PackagePath="\" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Arcus.Messaging.Abstractions.ServiceBus\Arcus.Messaging.Abstractions.ServiceBus.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Arcus.Messaging.ServiceBus.Telemetry.OpenTelemetry/Extensions/ServiceBusMessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.ServiceBus.Telemetry.OpenTelemetry/Extensions/ServiceBusMessageHandlerCollectionExtensions.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Diagnostics;
+using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
+using Arcus.Messaging.Abstractions.ServiceBus.Telemetry;
+using Arcus.Messaging.ServiceBus.Telemetry.OpenTelemetry;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// Extensions on the <see cref="ServiceBusMessageHandlerCollection"/> to register OpenTelemetry services for Azure Service Bus message pumps.
+    /// </summary>
+    public static class ServiceBusMessageHandlerCollectionExtensions
+    {
+        /// <summary>
+        /// Register OpenTelemetry as the correlation system to track Azure Service Bus message requests within the message pump.
+        /// </summary>
+        /// <param name="handlers">The collection of Azure Service Bus message handler collection.</param>
+        /// <param name="activitySource">The activity source to start <see cref="Activity"/> instances from upon receiving Azure Service Bus messages.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="handlers"/> or the <paramref name="activitySource"/> is <c>null</c>.</exception>
+        public static ServiceBusMessageHandlerCollection UseServiceBusOpenTelemetryRequestTracking(
+            this ServiceBusMessageHandlerCollection handlers,
+            ActivitySource activitySource)
+        {
+            ArgumentNullException.ThrowIfNull(handlers);
+            ArgumentNullException.ThrowIfNull(activitySource);
+
+            handlers.Services.TryAddSingleton<IServiceBusMessageCorrelationScope>(new OpenTelemetryServiceBusMessageCorrelationScope(activitySource));
+            return handlers;
+        }
+    }
+}

--- a/src/Arcus.Messaging.ServiceBus.Telemetry.OpenTelemetry/OpenTelemetryServiceBusMessageCorrelationScope.cs
+++ b/src/Arcus.Messaging.ServiceBus.Telemetry.OpenTelemetry/OpenTelemetryServiceBusMessageCorrelationScope.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Diagnostics;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Abstractions.MessageHandling;
+using Arcus.Messaging.Abstractions.ServiceBus;
+using Arcus.Messaging.Abstractions.ServiceBus.Telemetry;
+using Arcus.Messaging.Abstractions.Telemetry;
+
+namespace Arcus.Messaging.ServiceBus.Telemetry.OpenTelemetry
+{
+    /// <summary>
+    /// Represents the OpenTelemetry implementation of the <see cref="IServiceBusMessageCorrelationScope"/>
+    /// to track the correlation information of a received Azure Service Bus message within a message pump.
+    /// </summary>
+    internal class OpenTelemetryServiceBusMessageCorrelationScope : IServiceBusMessageCorrelationScope
+    {
+        private readonly ActivitySource _activitySource;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenTelemetryServiceBusMessageCorrelationScope"/> class.
+        /// </summary>
+        internal OpenTelemetryServiceBusMessageCorrelationScope(ActivitySource activitySource)
+        {
+            ArgumentNullException.ThrowIfNull(activitySource);
+            _activitySource = activitySource;
+        }
+
+        /// <summary>
+        /// Starts a new Azure Service bus request operation on the telemetry system.
+        /// </summary>
+        /// <param name="messageContext">The message context for the currently received Azure Service bus message.</param>
+        /// <param name="options">The user-configurable options to manipulate the telemetry.</param>
+        public MessageOperationResult StartOperation(AzureServiceBusMessageContext messageContext, MessageTelemetryOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(messageContext);
+            ArgumentNullException.ThrowIfNull(options);
+
+            (string transactionId, string operationParentId) = messageContext.Properties.GetTraceParent();
+
+            ActivityContext context = new(
+                ActivityTraceId.CreateFromString(transactionId),
+                ActivitySpanId.CreateFromString(operationParentId),
+                ActivityTraceFlags.None);
+
+            Activity activity = _activitySource.CreateActivity(
+                name: options.OperationName,
+                kind: ActivityKind.Server,
+                context);
+
+            activity?.Start();
+            if (activity is null)
+            {
+                return new UnlinkedMessageOperationResult(transactionId, operationParentId);
+            }
+
+            activity.SetTag("az.namespace", "Microsoft.ServiceBus");
+            activity.SetTag("messaging.system", "servicebus");
+            activity.SetTag("messaging.operation", "receive");
+
+            activity.SetTag("ServiceBus-Endpoint", messageContext.FullyQualifiedNamespace);
+            activity.SetTag("ServiceBus-Entity", messageContext.EntityPath);
+            activity.SetTag("ServiceBus-EntityType", messageContext.EntityType.ToString());
+
+            return new OpenTelemetryMessageOperationResult(activity);
+        }
+
+        private sealed class OpenTelemetryMessageOperationResult : MessageOperationResult
+        {
+            private readonly Activity _activity;
+
+            internal OpenTelemetryMessageOperationResult(Activity activity)
+                : base(new MessageCorrelationInfo(activity.TraceId.ToString(), activity.SpanId.ToString(), activity.ParentSpanId.ToString()))
+            {
+                _activity = activity;
+            }
+
+            protected override void StopOperation(bool isSuccessful, DateTimeOffset startTime, TimeSpan duration)
+            {
+                _activity.SetStatus(isSuccessful ? ActivityStatusCode.Ok : ActivityStatusCode.Error);
+                _activity.SetEndTime(_activity.StartTimeUtc.Add(duration));
+                _activity.Dispose();
+            }
+        }
+
+        private sealed class UnlinkedMessageOperationResult : MessageOperationResult
+        {
+            internal UnlinkedMessageOperationResult(string transactionId, string operationParentId) 
+                : base(new MessageCorrelationInfo(Guid.NewGuid().ToString(), transactionId, operationParentId))
+            {
+            }
+
+            protected override void StopOperation(bool isSuccessful, DateTimeOffset startTime, TimeSpan duration)
+            {
+            }
+        }
+    }
+}

--- a/src/Arcus.Messaging.Tests.Integration/Arcus.Messaging.Tests.Integration.csproj
+++ b/src/Arcus.Messaging.Tests.Integration/Arcus.Messaging.Tests.Integration.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Arcus.Testing.Logging.Xunit" Version="2.0.0" />
     <PackageReference Include="Arcus.Testing.Messaging.ServiceBus" Version="2.0.0" />
     <PackageReference Include="Arcus.Testing.Security.Providers.InMemory" Version="1.1.0" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.4.0" />
     <PackageReference Include="Azure.ResourceManager.Authorization" Version="1.1.3" />
     <PackageReference Include="Azure.ResourceManager.EventHubs" Version="1.1.0" />
     <PackageReference Include="Azure.ResourceManager.ServiceBus" Version="1.0.1" />
@@ -22,6 +23,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.InMemory" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.11.0-beta.1" />
     <PackageReference Include="Serilog" Version="2.11.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
@@ -31,6 +35,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Arcus.Messaging.Pumps.ServiceBus\Arcus.Messaging.Pumps.ServiceBus.csproj" />
+    <ProjectReference Include="..\Arcus.Messaging.ServiceBus.Telemetry.OpenTelemetry\Arcus.Messaging.ServiceBus.Telemetry.OpenTelemetry.csproj" />
     <ProjectReference Include="..\Arcus.Messaging.Tests.Core\Arcus.Messaging.Tests.Core.csproj" />
     <ProjectReference Include="..\Arcus.Messaging.Health\Arcus.Messaging.Health.csproj" />
     <ProjectReference Include="..\Arcus.Messaging.Tests.Workers.ServiceBus\Arcus.Messaging.Tests.Workers.ServiceBus.csproj" />

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePump.TelemetryTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePump.TelemetryTests.cs
@@ -1,16 +1,16 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Linq;
+using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
-using Arcus.Messaging.Abstractions.MessageHandling;
-using Arcus.Messaging.Pumps.ServiceBus;
-using Arcus.Messaging.Tests.Core.Events.v1;
 using Arcus.Messaging.Tests.Core.Generators;
 using Arcus.Messaging.Tests.Core.Messages.v1;
 using Arcus.Messaging.Tests.Integration.Fixture;
 using Arcus.Messaging.Tests.Integration.Fixture.Logging;
 using Arcus.Messaging.Tests.Integration.MessagePump.Fixture;
-using Arcus.Messaging.Tests.Integration.MessagePump.ServiceBus;
-using Arcus.Messaging.Tests.Workers.MessageHandlers;
 using Arcus.Messaging.Tests.Workers.ServiceBus.MessageHandlers;
 using Arcus.Testing;
 using Azure.Identity;
@@ -20,12 +20,11 @@ using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using OpenTelemetry.Trace;
 using Serilog;
-using Serilog.Events;
 using Serilog.Sinks.ApplicationInsights.TelemetryConverters;
 using Xunit;
-using static Arcus.Messaging.Tests.Integration.MessagePump.ServiceBus.DiskMessageEventConsumer;
-using static Arcus.Observability.Telemetry.Core.ContextProperties.Correlation;
+using Xunit.Sdk;
 using static Arcus.Observability.Telemetry.Core.ContextProperties.RequestTracking.ServiceBus;
 using static Microsoft.Extensions.Logging.ServiceBusEntityType;
 
@@ -33,6 +32,130 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
 {
     public partial class ServiceBusMessagePumpTests
     {
+        private const string DefaultSqlTable = "master";
+
+        private string CustomOperationName { get; } = $"operation-{Guid.NewGuid()}";
+        private bool IsSuccessful { get; } = Bogus.Random.Bool();
+
+        [Fact]
+        public async Task ServiceBusMessagePump_WithW3CCorrelationFormatNewParentViaOpenTelemetry_AutomaticallyTracksMicrosoftDependencies()
+        {
+            // Arrange
+            var options = new WorkerOptions();
+            using ActivitySource source = CreateActivitySource();
+
+            options.AddServiceBusQueueMessagePump(QueueName, HostName, new DefaultAzureCredential(), pump =>
+            {
+                pump.Telemetry.OperationName = CustomOperationName;
+
+            }).UseServiceBusOpenTelemetryRequestTracking(source)
+              .WithServiceBusMessageHandler<OrderWithAutoTrackingAzureServiceBusMessageHandler, Order>(CreateAutoTrackingMessageHandler);
+
+            var activities = new Collection<Activity>();
+            options.AddOpenTelemetry()
+                   .WithTracing(traces =>
+                   {
+                       traces.AddSource(source.Name);
+                       traces.AddInMemoryExporter(activities);
+                       traces.AddSqlClientInstrumentation();
+                       traces.SetSampler(new AlwaysOnSampler());
+                   }); 
+
+            ServiceBusMessage message = CreateOrderServiceBusMessage();
+
+            // Act
+            await TestServiceBusMessageHandlingAsync(options, Queue, message, async () =>
+            {
+                Activity serviceBusRequest = await GetQueueRequestActivityAsync(activities, CustomOperationName);
+                Activity sqlDependency = await GetDependencyActivityAsync(activities, DefaultSqlTable, a => a.ParentId == serviceBusRequest.Id);
+
+                Assert.Equal(serviceBusRequest, sqlDependency.Parent);
+            });
+        }
+
+        private static ServiceBusMessage CreateOrderServiceBusMessage()
+        {
+            return new ServiceBusMessage(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(OrderGenerator.Generate())));
+        }
+
+        [Fact]
+        public async Task ServiceBusMessagePump_WithW3CCorrelationFormatViaOpenTelemetry_AutomaticallyTracksMicrosoftDependencies()
+        {
+            // Arrange
+            var options = new WorkerOptions();
+            using ActivitySource source = CreateActivitySource();
+
+            options.AddServiceBusQueueMessagePump(QueueName, HostName, new DefaultAzureCredential(), pump =>
+            {
+                pump.Telemetry.OperationName = CustomOperationName;
+
+            }).WithServiceBusMessageHandler<OrderWithAutoTrackingAzureServiceBusMessageHandler, Order>(CreateAutoTrackingMessageHandler)
+              .UseServiceBusOpenTelemetryRequestTracking(source);
+
+            var activities = new Collection<Activity>();
+            options.AddOpenTelemetry()
+                   .WithTracing(traces =>
+                   {
+                       traces.AddSource(source.Name);
+                       traces.AddInMemoryExporter(activities);
+                       traces.AddSqlClientInstrumentation();
+                       traces.SetSampler(new AlwaysOnSampler());
+                   });
+
+            ServiceBusMessage message = CreateOrderServiceBusMessageForW3C();
+
+            // Act / Assert
+            await TestServiceBusMessageHandlingAsync(options, Queue, message, async () =>
+            {
+                (string transactionId, string operationParentId) = message.ApplicationProperties.GetTraceParent();
+
+                Activity serviceBusRequest = await GetQueueRequestActivityAsync(activities, CustomOperationName, a => a.TraceId.ToString() == transactionId && a.ParentSpanId.ToString() == operationParentId);
+                Activity sqlDependency = await GetDependencyActivityAsync(activities, DefaultSqlTable, a => a.TraceId.ToString() == transactionId && a.ParentId == serviceBusRequest.Id);
+
+                Assert.Equal(serviceBusRequest, sqlDependency.Parent);
+            });
+        }
+
+        private OrderWithAutoTrackingAzureServiceBusMessageHandler CreateAutoTrackingMessageHandler(IServiceProvider provider)
+        {
+            return new OrderWithAutoTrackingAzureServiceBusMessageHandler(
+                IsSuccessful,
+                provider.GetRequiredService<ILogger<OrderWithAutoTrackingAzureServiceBusMessageHandler>>());
+        }
+
+        private static ActivitySource CreateActivitySource()
+        {
+            return new ActivitySource("Arcus.Messaging.Tests.Integration");
+        }
+
+        private async Task<Activity> GetQueueRequestActivityAsync(IReadOnlyCollection<Activity> activities, string operationName, Func<Activity, bool> filter = null)
+        {
+            return await Poll.Target<Activity, XunitException>(() =>
+            {
+                Assert.NotEmpty(activities);
+                return AssertX.Any(activities.Where(a => a.OperationName == operationName), request =>
+                {
+                    Assert.True(IsSuccessful == request.Status is ActivityStatusCode.Ok, $"request for operation '{operationName}' did not match the expected status, expected '{(IsSuccessful ? ActivityStatusCode.Ok : ActivityStatusCode.Error)}' but got '{request.Status}'");
+                    Assert.Contains(request.Tags, tag => tag is { Key: "ServiceBus-EntityType", Value: "Queue" });
+                    Assert.True(filter is null || filter(request), $"request for operation '{operationName}' did not match the given custom filter assertion, please check whether the OpenTelemetry correlation system did add all the necessary properties");
+                });
+
+            }).FailWith("cannot find request telemetry in spied-upon OpenTelemetry activities");
+        }
+
+        private static async Task<Activity> GetDependencyActivityAsync(IReadOnlyCollection<Activity> activities, string operationName, Func<Activity, bool> filter = null)
+        {
+            return await Poll.Target<Activity, XunitException>(() =>
+            {
+                Assert.NotEmpty(activities);
+                return AssertX.Any(activities.Where(a => a.OperationName == operationName), dependency =>
+                {
+                    Assert.True(filter is null || filter(dependency), $"dependency for operation '{operationName}' did not match the given custom filter assertion, please check whether the OpenTelemetry correlation system did add all the necessary properties");
+                });
+
+            }).FailWith("cannot find dependency telemetry in spied-upon OpenTelemetry activities");
+        }
+
         [Fact]
         public async Task ServiceBusMessagePump_WithW3CCorrelationFormat_AutomaticallyTracksMicrosoftDependencies()
         {

--- a/src/Arcus.Messaging.Tests.Workers.ServiceBus/MessageHandlers/OrderWithAutoTrackingAzureServiceBusMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Workers.ServiceBus/MessageHandlers/OrderWithAutoTrackingAzureServiceBusMessageHandler.cs
@@ -13,6 +13,7 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus.MessageHandlers
 {
     public class OrderWithAutoTrackingAzureServiceBusMessageHandler : IAzureServiceBusMessageHandler<Order>
     {
+        private readonly bool _isSuccessful;
         private readonly ILogger<OrderWithAutoTrackingAzureServiceBusMessageHandler> _logger;
 
         /// <summary>
@@ -23,6 +24,15 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus.MessageHandlers
             _logger = logger;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrderWithAutoTrackingAzureServiceBusMessageHandler"/> class.
+        /// </summary>
+        public OrderWithAutoTrackingAzureServiceBusMessageHandler(bool isSuccessful, ILogger<OrderWithAutoTrackingAzureServiceBusMessageHandler> logger)
+            : this(logger)
+        {
+            _isSuccessful = isSuccessful;
+        }
+
         public Task ProcessMessageAsync(
             Order message,
             AzureServiceBusMessageContext messageContext,
@@ -31,6 +41,12 @@ namespace Arcus.Messaging.Tests.Workers.ServiceBus.MessageHandlers
         {
             _logger.LogAzureKeyVaultDependency("https://my-vault.azure.net", "Sql-connection-string", isSuccessful: true, DateTimeOffset.UtcNow, TimeSpan.FromSeconds(5));
             SimulateSqlQueryWithMicrosoftTracking();
+
+            if (!_isSuccessful)
+            {
+                throw new InvalidOperationException(
+                    "[Test] Sabotage this message processing to let the message correlation system pick up an 'unsuccessful request'");
+            }
 
             return Task.CompletedTask;
         }

--- a/src/Arcus.Messaging.sln
+++ b/src/Arcus.Messaging.sln
@@ -32,6 +32,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arcus.Messaging.ServiceBus.Telemetry.OpenTelemetry", "Arcus.Messaging.ServiceBus.Telemetry.OpenTelemetry\Arcus.Messaging.ServiceBus.Telemetry.OpenTelemetry.csproj", "{4C2DCD91-2D47-493C-82FC-03A76CFA2CB1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -78,6 +80,10 @@ Global
 		{F1B24FD4-099E-489D-B45D-A1A992CA5C3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F1B24FD4-099E-489D-B45D-A1A992CA5C3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F1B24FD4-099E-489D-B45D-A1A992CA5C3A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4C2DCD91-2D47-493C-82FC-03A76CFA2CB1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4C2DCD91-2D47-493C-82FC-03A76CFA2CB1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4C2DCD91-2D47-493C-82FC-03A76CFA2CB1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4C2DCD91-2D47-493C-82FC-03A76CFA2CB1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -90,6 +96,7 @@ Global
 		{55DE6D12-4C54-4570-BDFA-00B0FFDE5AB6} = {A1369CCD-42D1-43F6-98BC-D8EDA62C2B13}
 		{864C12DF-DE3D-421F-8687-EC3918FFB8BE} = {2CD090E7-7306-49A0-9680-6ED78CFECAE1}
 		{F1B24FD4-099E-489D-B45D-A1A992CA5C3A} = {A1369CCD-42D1-43F6-98BC-D8EDA62C2B13}
+		{4C2DCD91-2D47-493C-82FC-03A76CFA2CB1} = {2CD090E7-7306-49A0-9680-6ED78CFECAE1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {066FD85A-3DDE-4615-B550-BF67ACCDAA51}


### PR DESCRIPTION
Introduce OpenTelemetry as a concrete implementation of an Azure Service Bus message correlation scope for the message pump, by introducing a new package called `Arcus.Messaging.ServiceBus.Telemetry.OpenTelemetry` that provides an extension on a message pump registration setup.

This PR provides concrete implementations with a new interface called `IServiceBusMessageCorrelatinoScope` and also updates the feature documentation to accompany this correlation option.

> [!Note]
> Currently, the message pump still uses the deprecated `MessageCorrelationResult` to minimize the PR changes. This can later be either removed, or its content be moved to a new `Arcus.Messaging.ServiceBus.Telemetry.Serilog` package, if we want users to keep using the Serilog setup.

Relates to #464 