### PR TITLE
chore(deps): solely use .NET 8 in pipelines

### DIFF
--- a/build/variables/build.yml
+++ b/build/variables/build.yml
@@ -1,6 +1,6 @@
 variables:
   DotNet.Sdk.Version: '8.0.x'
-  DotNet.Sdk.PreviousVersion: '6.0.100'
+  DotNet.Sdk.PreviousVersion: '8.0.x'
   DotNet.Sdk.IncludePreviewVersions: false
   Project: 'Arcus.Messaging'
   Vm.Image: 'ubuntu-latest'


### PR DESCRIPTION
We should solely use .NET 8 now, so we don't have to use a previous version just yet.
This PR removes this from the pipelines by updating the variables.