### PR TITLE
chore(az.sb): extract az service-bus message pump from general pump

### DIFF
--- a/src/Arcus.Messaging.Pumps.Abstractions/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/Extensions/IServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="jobId">The unique ID to distinguish the message pump to register this event handler for.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
+        [Obsolete("Will be removed in v4.0, please use dedicated extensions related to the message pumps instead")]
         public static IServiceCollection AddCircuitBreakerEventHandler<TEventHandler>(this IServiceCollection services, string jobId)
             where TEventHandler : ICircuitBreakerEventHandler
         {
@@ -33,6 +34,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="implementationFactory">The factory function to create the custom <see cref="ICircuitBreakerEventHandler"/> implementation.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> or <paramref name="implementationFactory"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
+        [Obsolete("Will be removed in v4.0, please use dedicated extensions related to the message pumps instead")]
         public static IServiceCollection AddCircuitBreakerEventHandler<TEventHandler>(
             this IServiceCollection services,
             string jobId,

--- a/src/Arcus.Messaging.Pumps.Abstractions/MessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/MessagePump.cs
@@ -13,6 +13,7 @@ namespace Arcus.Messaging.Pumps.Abstractions
     /// <summary>
     /// Represents the foundation for building message pumps.
     /// </summary>
+    [Obsolete("Will be removed in v4.0, please directly implement the " + nameof(BackgroundService) + " to represent concrete message pumps")]
     public abstract class MessagePump : BackgroundService
     {
         /// <summary>

--- a/src/Arcus.Messaging.Pumps.Abstractions/Resiliency/IMessagePumpCircuitBreaker.cs
+++ b/src/Arcus.Messaging.Pumps.Abstractions/Resiliency/IMessagePumpCircuitBreaker.cs
@@ -45,7 +45,7 @@ namespace Arcus.Messaging.Pumps.Abstractions.Resiliency
         /// <summary>
         /// Initializes a new instance of the <see cref="MessagePumpCircuitStateChangedEventArgs" /> class.
         /// </summary>
-        internal MessagePumpCircuitStateChangedEventArgs(
+        public MessagePumpCircuitStateChangedEventArgs(
             string jobId,
             MessagePumpCircuitState oldState,
             MessagePumpCircuitState newState)
@@ -115,9 +115,22 @@ namespace Arcus.Messaging.Pumps.Abstractions.Resiliency
     /// <summary>
     /// Represents the available states in the <see cref="MessagePumpCircuitState"/> in which the message pump can transition into.
     /// </summary>
-    internal enum CircuitBreakerState
+    public enum CircuitBreakerState
     {
-        Closed, HalfOpen, Open
+        /// <summary>
+        /// Represents the state in which the message pump is able to process messages normally.
+        /// </summary>
+        Closed,
+
+        /// <summary>
+        /// Represents the state in which the message pump tries to startup again after a failure,
+        /// </summary>
+        HalfOpen,
+
+        /// <summary>
+        /// Represents the state in which the message pump has stopped processing messages all together,
+        /// </summary>
+        Open
     }
 
     /// <summary>
@@ -172,12 +185,20 @@ namespace Arcus.Messaging.Pumps.Abstractions.Resiliency
         /// Gets an instance of the <see cref="MessagePumpCircuitState"/> class that represents a closed state,
         /// in which the message pump is able to process messages normally.
         /// </summary>
-        internal static MessagePumpCircuitState Closed => new(CircuitBreakerState.Closed);
+        public static MessagePumpCircuitState Closed => new(CircuitBreakerState.Closed);
 
         /// <summary>
         /// Lets the current instance of the state transition to another state.
         /// </summary>
-        internal MessagePumpCircuitState TransitionTo(CircuitBreakerState state, MessagePumpCircuitBreakerOptions options = null)
+        public MessagePumpCircuitState TransitionTo(CircuitBreakerState state)
+        {
+            return TransitionTo(state, options: null);
+        }
+
+        /// <summary>
+        /// Lets the current instance of the state transition to another state.
+        /// </summary>
+        public MessagePumpCircuitState TransitionTo(CircuitBreakerState state, MessagePumpCircuitBreakerOptions options)
         {
             return new(state, options ?? Options);
         }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/IServiceCollectionExtensions.cs
@@ -193,8 +193,8 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.TryAddSingleton<IMessagePumpCircuitBreaker>(provider =>
             {
-                var logger = provider.GetService<ILogger<DefaultMessagePumpCircuitBreaker>>();
-                return new DefaultMessagePumpCircuitBreaker(provider, logger);
+                var logger = provider.GetService<ILogger<DefaultAzureServiceBusMessagePumpCircuitBreaker>>();
+                return new DefaultAzureServiceBusMessagePumpCircuitBreaker(provider, logger);
             });
 
             services.AddHostedService(provider =>

--- a/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/ServiceBusMessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/Extensions/ServiceBusMessageHandlerCollectionExtensions.cs
@@ -39,8 +39,37 @@ namespace Microsoft.Extensions.DependencyInjection
             ArgumentNullException.ThrowIfNull(collection);
             ArgumentNullException.ThrowIfNull(implementationFactory);
 
-            collection.Services.AddCircuitBreakerEventHandler(collection.JobId, implementationFactory);
+            collection.Services.AddTransient(serviceProvider => new CircuitBreakerEventHandler(collection.JobId, implementationFactory(serviceProvider)));
             return collection;
         }
+    }
+
+    /// <summary>
+    /// Represents a registration of an <see cref="ICircuitBreakerEventHandler"/> instance in the application services,
+    /// specifically linked to a message pump.
+    /// </summary>
+    internal sealed class CircuitBreakerEventHandler
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CircuitBreakerEventHandler" /> class.
+        /// </summary>
+        public CircuitBreakerEventHandler(string jobId, ICircuitBreakerEventHandler handler)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(jobId);
+            ArgumentNullException.ThrowIfNull(handler);
+
+            JobId = jobId;
+            Handler = handler;
+        }
+
+        /// <summary>
+        /// Gets the unique ID to distinguish the linked message pump.
+        /// </summary>
+        public string JobId { get; }
+
+        /// <summary>
+        /// Gets the event handler implementation to trigger on transition changes in the linked message pump.
+        /// </summary>
+        public ICircuitBreakerEventHandler Handler { get; }
     }
 }


### PR DESCRIPTION
It came to our attention that the circuit breaker functionality that is currently in the general message pump, is not located at the right place, as not all message pump could support such advanced retry scenarios.

In a follow-up refactoring of this discussion #470 , this PR extracts the Azure Service Bus concreate message pump implementation from the general message pump one, so it can evolve on its own.