### PR TITLE
chore(general): remove now unused add message handler member on collection

### DIFF
--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageHandlerCollection.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageHandlerCollection.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 
 namespace Arcus.Messaging.Abstractions.MessageHandling
 {
@@ -8,16 +7,17 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
     /// Represents the model that exposes the available <see cref="IMessageHandler{TMessage,TMessageContext}"/>s
     /// and possible additional configurations that can be configured with the current state.
     /// </summary>
-    public class MessageHandlerCollection
+    public abstract class MessageHandlerCollection
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="MessageHandlerCollection" /> class.
         /// </summary>
         /// <param name="services">The current available collection services to register the message handling logic into.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="services"/> is <c>null</c>.</exception>
-        public MessageHandlerCollection(IServiceCollection services)
+        protected MessageHandlerCollection(IServiceCollection services)
         {
-            Services = services ?? throw new ArgumentNullException(nameof(services));
+            ArgumentNullException.ThrowIfNull(services);
+            Services = services;
         }
 
         /// <summary>
@@ -30,37 +30,5 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// Gets the current available collection of services to register the message handling logic into.
         /// </summary>
         public IServiceCollection Services { get; }
-
-        /// <summary>
-        /// Adds a general <see cref="MessageHandler"/> instance to the registered application services.
-        /// </summary>
-        /// <typeparam name="TMessage">The type of message the message handler created from the <paramref name="implementationFactory"/> processes.</typeparam>
-        /// <typeparam name="TMessageContext">The type of context the message handler created from the <paramref name="implementationFactory"/> processes.</typeparam>
-        /// <param name="implementationFactory">The function to create an user-defined message handler instance.</param>
-        /// <param name="messageBodyFilter">The optional function to filter on the message body before processing.</param>
-        /// <param name="messageContextFilter">The optional function to filter on the message context before processing.</param>
-        /// <param name="implementationFactoryMessageBodySerializer">The function to create an optional message body serializer instance to customize how the message should be deserialized.</param>
-        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="implementationFactory"/> is <c>null</c>.</exception>
-        internal void AddMessageHandler<TMessage, TMessageContext>(
-            Func<IServiceProvider, IMessageHandler<TMessage, TMessageContext>> implementationFactory,
-            Func<TMessage, bool> messageBodyFilter = null,
-            Func<TMessageContext, bool> messageContextFilter = null,
-            Func<IServiceProvider, IMessageBodySerializer> implementationFactoryMessageBodySerializer = null)
-            where TMessageContext : MessageContext
-        {
-            if (implementationFactory is null)
-            {
-                throw new ArgumentNullException(nameof(implementationFactory));
-            }
-
-            Services.AddTransient(
-                serviceProvider => MessageHandler.Create(
-                    implementationFactory(serviceProvider),
-                    serviceProvider.GetService<ILogger<IMessageHandler<TMessage, TMessageContext>>>(),
-                    JobId,
-                    messageBodyFilter,
-                    messageContextFilter,
-                    implementationFactoryMessageBodySerializer?.Invoke(serviceProvider)));
-        }
     }
 }


### PR DESCRIPTION
The `internal` memnber on the general message handler collection is not used anymore since all the concrete implementations use their own version. This PR removes this (now) unused member.

Relates to #484 