### PR TITLE
chore(az.sb): correct az sb msg handler options naming+aggregation

### DIFF
--- a/docs/preview/03-Features/01-Azure/01-service-bus.md
+++ b/docs/preview/03-Features/01-Azure/01-service-bus.md
@@ -157,10 +157,12 @@ services.AddServiceBus[Topic/Queue]MessagePump(...)
         {
             // Adds a filter to the message handler registration:
             // Only messages with 'Type=Order' property goes through this message handler.
+            // ⚡ Multiple calls will be aggregated in an AND expression.
             options.AddMessageContextFilter(ctx => ctx.Properties["Type"] == "Order");
 
             // Adds a filter to the message handler registration:
             // Only messages with certain bodies goes through this message handler.
+            // ⚡ Multiple calls will be aggregated in an AND expression.
             options.AddMessageBodyFilter((Order order) => order.OrderId = "123");
 
             // Adds a custom message deserializer to the message handler registration:
@@ -170,7 +172,7 @@ services.AddServiceBus[Topic/Queue]MessagePump(...)
             //      {
             //          Task<MessageResult> DeserializeMessageAsync(string messageBody);
             //      }
-            options.AddMessageBodySerializer(new CustomXmlMessageBodySerializer());
+            options.UseMessageBodySerializer(new CustomXmlMessageBodySerializer());
         });
 ```
 

--- a/docs/preview/03-Guides/migration-guide-v3.0.md
+++ b/docs/preview/03-Guides/migration-guide-v3.0.md
@@ -93,7 +93,7 @@ services.AddServiceBusQueueMessagePump(...)
 +           {
 +               options.AddMessageContextFilter(ctx => ctx.Properties["MessageType"] == "Order")
 +                      .AddMessageBodyFilter(order => order.Type == OrderType.Registration)
-+                      .AddMessageBodySerializer(new OrdersXmlMessageBodySerializer())
++                      .UseMessageBodySerializer(new OrdersXmlMessageBodySerializer())
 +           });
 
 ```

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/Fixture/ServiceBusMessageHandlerCollectionTestExtensions.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/Fixture/ServiceBusMessageHandlerCollectionTestExtensions.cs
@@ -43,9 +43,6 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static void WithUnrelatedHandlerFiltering<T>(ServiceBusMessageHandlerOptions<T> options)
         {
-            options.AddMessageContextFilter(_ => true)
-                   .AddMessageBodyFilter(_ => true);
-
             switch (Bogus.Random.Int(0, 2))
             {
                 case 0:
@@ -59,6 +56,9 @@ namespace Microsoft.Extensions.DependencyInjection
                     options.AddMessageBodyFilter(_ => false);
                     break;
             }
+
+            options.AddMessageContextFilter(_ => true)
+                   .AddMessageBodyFilter(_ => true);
         }
 
         internal static ServiceBusMessageHandlerCollection WithMatchedServiceBusMessageHandler(

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePump.RouterTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePump.RouterTests.cs
@@ -73,7 +73,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             serviceBus.WhenServiceBusQueueMessagePump()
                       .WithMatchedServiceBusMessageHandler<OrderBatchMessageHandler, OrderBatch>(handler =>
                       {
-                          handler.AddMessageBodySerializer(provider => ActivatorUtilities.CreateInstance<OrderBatchMessageBodySerializer>(provider));
+                          handler.UseMessageBodySerializer<OrderBatchMessageBodySerializer>();
                       });
 
             // Act
@@ -121,7 +121,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
                       {
                           handler.AddMessageContextFilter(context => context.Properties.Contains(contextProperty))
                                  .AddMessageBodyFilter(message => message.Orders.Length == 1)
-                                 .AddMessageBodySerializer(provider => ActivatorUtilities.CreateInstance<OrderBatchMessageBodySerializer>(provider));
+                                 .UseMessageBodySerializer<OrderBatchMessageBodySerializer>();
                       });
 
             // Act

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePump.RouterTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePump.RouterTests.cs
@@ -70,6 +70,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             // Arrange
             await using var serviceBus = GivenServiceBus();
 
+            serviceBus.Services.AddSingleton<OrderBatchMessageBodySerializer>();
             serviceBus.WhenServiceBusQueueMessagePump()
                       .WithMatchedServiceBusMessageHandler<OrderBatchMessageHandler, OrderBatch>(handler =>
                       {
@@ -115,6 +116,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             // Arrange
             await using var serviceBus = GivenServiceBus();
 
+            serviceBus.Services.AddSingleton<OrderBatchMessageBodySerializer>();
             var contextProperty = new KeyValuePair<string, object>(Bogus.Lorem.Word(), Bogus.Lorem.Sentence());
             serviceBus.WhenServiceBusQueueMessagePump()
                       .WithMatchedServiceBusMessageHandler<OrderBatchMessageHandler, OrderBatch>(handler =>

--- a/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/AzureServiceBusMessageRouterTests.cs
+++ b/src/Arcus.Messaging.Tests.Unit/MessageHandling/ServiceBus/AzureServiceBusMessageRouterTests.cs
@@ -212,7 +212,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
             var expectedMessage = new TestMessage { TestProperty = "Some value" };
             string expectedBody = JsonConvert.SerializeObject(expectedMessage);
             var serializer = new TestMessageBodySerializer(expectedBody, OrderGenerator.Generate());
-            collection.WithServiceBusMessageHandler<StubServiceBusMessageHandler<Order>, Order>(implementationFactory: _ => spyHandler, options => options.AddMessageBodySerializer(serializer))
+            collection.WithServiceBusMessageHandler<StubServiceBusMessageHandler<Order>, Order>(implementationFactory: _ => spyHandler, options => options.UseMessageBodySerializer(serializer))
                       .WithServiceBusMessageHandler<StubServiceBusMessageHandler<TestMessage>, TestMessage>(implementationFactory: _ => ignoredHandler);
 
             AzureServiceBusMessageRouter router = CreateMessageRouter(collection);
@@ -241,7 +241,7 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
             var expectedMessage = new TestMessage { TestProperty = "Some value" };
             string expectedBody = JsonConvert.SerializeObject(expectedMessage);
             var serializer = new TestMessageBodySerializer(expectedBody, new SubOrder());
-            collection.WithServiceBusMessageHandler<StubServiceBusMessageHandler<Order>, Order>(implementationFactory: _ => spyHandler, options => options.AddMessageBodySerializer(serializer))
+            collection.WithServiceBusMessageHandler<StubServiceBusMessageHandler<Order>, Order>(implementationFactory: _ => spyHandler, options => options.UseMessageBodySerializer(serializer))
                       .WithServiceBusMessageHandler<StubServiceBusMessageHandler<TestMessage>, TestMessage>(implementationFactory: _ => ignoredHandler);
 
             AzureServiceBusMessageRouter router = CreateMessageRouter(collection);
@@ -279,13 +279,13 @@ namespace Arcus.Messaging.Tests.Unit.MessageHandling.ServiceBus
                           implementationFactory: _ => ignoredHandler3,
                           options => options.AddMessageContextFilter(ctx => ctx != null)
                                             .AddMessageBodyFilter(body => body != null)
-                                            .AddMessageBodySerializer(new TestMessageBodySerializer(expectedBody, new Customer())))
+                                            .UseMessageBodySerializer(new TestMessageBodySerializer(expectedBody, new Customer())))
                       .WithServiceBusMessageHandler<StubServiceBusMessageHandler<TestMessage>, TestMessage>(
                           implementationFactory: _ => ignoredHandler2,
                           opt => opt.AddMessageBodyFilter(body => body is null))
                       .WithServiceBusMessageHandler<StubServiceBusMessageHandler<Order>, Order>(
                           implementationFactory: _ => spyHandler,
-                          options => options.AddMessageBodySerializer(serializer)
+                          options => options.UseMessageBodySerializer(serializer)
                                             .AddMessageBodyFilter(body => body.Customer != null)
                                             .AddMessageContextFilter(ctx => ctx.MessageId.StartsWith("message-id")))
                       .WithServiceBusMessageHandler<StubServiceBusMessageHandler<TestMessage>, TestMessage>()


### PR DESCRIPTION
Corrects the behind-the-scenes functionality and naming of the Azure Service Bus message handler options to more reflect what is expected from an user-perspective:
* Multiple calls to `options.Add...Filter` should be aggregated into an AND expression;
* `options.UseMessageBodySerializer` more correctly shows that only a single instance is used, instead of `options.Add...` 

This PR also immediately provides the easy-access message body serializer overload, described in #622.

Closes #623 
Closes #622 