### PR TITLE
chore(messaging.abstractions): remove propertynames.operationparentid

### DIFF
--- a/src/Arcus.Messaging.Abstractions/PropertyNames.cs
+++ b/src/Arcus.Messaging.Abstractions/PropertyNames.cs
@@ -10,12 +10,6 @@ namespace Arcus.Messaging.Abstractions
     public static class PropertyNames
     {
         /// <summary>
-        /// Gets the default context property name to get the operation ID of the parent operation.
-        /// </summary>
-        [Obsolete("Will be removed in v3.0 as the property name is only used in the deprecated 'Hierarchical' correlation format")]
-        public const string OperationParentId = "Operation-Parent-Id";
-
-        /// <summary>
         /// Gets the context property name to get the correlation transaction ID.
         /// </summary>
         [Obsolete("Will be removed in v3.0 as the property name is only used in the deprecated 'Hierarchical' correlation format")]


### PR DESCRIPTION
Remove `OperationParentId` from `PropertyNames`.