### PR TITLE
chore(az.sb): deprecate public message router types

### DIFF
--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
@@ -12,11 +12,14 @@ using Microsoft.Extensions.Logging;
 using Serilog.Context;
 using static Arcus.Messaging.Abstractions.MessageHandling.MessageProcessingError;
 
+#pragma warning disable S1133
+
 namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
 {
     /// <summary>
     /// Represents an <see cref="IAzureServiceBusMessageRouter"/> that can route Azure Service Bus <see cref="ServiceBusReceivedMessage"/>s.
     /// </summary>
+    [Obsolete("Will be removed in v4.0 as the message router is being made internal")]
     public class AzureServiceBusMessageRouter : MessageRouter, IAzureServiceBusMessageRouter
     {
         /// <summary>

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouterOptions.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/AzureServiceBusMessageRouterOptions.cs
@@ -3,7 +3,7 @@
 namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
 {
     /// <summary>
-    /// Represents the consumer-configurable options to change the behavior of the <see cref="AzureServiceBusMessageRouter"/>.
+    /// Represents the consumer-configurable options to change the behavior of the message router in an Azure Service Bus message pump.
     /// </summary>
     public class AzureServiceBusMessageRouterOptions : MessageRouterOptions
     {

--- a/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/IAzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/MessageHandling/IAzureServiceBusMessageRouter.cs
@@ -9,6 +9,9 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
     /// <summary>
     /// Represents an instance that can route Azure Service Bus <see cref="ServiceBusReceivedMessage"/>s through registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/>s.
     /// </summary>
+#pragma warning disable S1133
+    [Obsolete("Will be removed in v4.0 as the message router is being made internal")]
+#pragma warning restore S1133
     public interface IAzureServiceBusMessageRouter
     {
         /// <summary>


### PR DESCRIPTION
The message router for Azure Service Bus was made internal in #635 , which makes all public types of the message router obsolete. This PR deprecates those types so they can be removed in v4.0.