### PR TITLE
feat(msg.routing): add message handler summary logging

### DIFF
--- a/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/ServiceBusMessageHandlerOptions.cs
+++ b/src/Arcus.Messaging.Abstractions.ServiceBus/Extensions/ServiceBusMessageHandlerOptions.cs
@@ -19,8 +19,8 @@ namespace Microsoft.Extensions.DependencyInjection
         private readonly Collection<Func<AzureServiceBusMessageContext, bool>> _messageContextFilters = [];
 
         internal Func<IServiceProvider, IMessageBodySerializer> MessageBodySerializerImplementationFactory { get; private set; }
-        internal Func<TMessage, bool> MessageBodyFilter => msg => _messageBodyFilters.All(filter => filter(msg));
-        internal Func<AzureServiceBusMessageContext, bool> MessageContextFilter => ctx => _messageContextFilters.All(filter => filter(ctx));
+        internal Func<TMessage, bool> MessageBodyFilter => _messageBodyFilters.Count is 0 ? null : msg => _messageBodyFilters.All(filter => filter(msg));
+        internal Func<AzureServiceBusMessageContext, bool> MessageContextFilter => _messageContextFilters.Count is 0 ? null : ctx => _messageContextFilters.All(filter => filter(ctx));
 
         /// <summary>
         /// Adds a custom serializer instance that deserializes the incoming <see cref="ServiceBusReceivedMessage.Body"/>.

--- a/src/Arcus.Messaging.Abstractions/Arcus.Messaging.Abstractions.csproj
+++ b/src/Arcus.Messaging.Abstractions/Arcus.Messaging.Abstractions.csproj
@@ -26,6 +26,11 @@
     <None Include="..\..\docs\static\img\icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[8.*,10.0.0)" />
+    </ItemGroup>
+
   <ItemGroup>
     <!-- TODO: will be removed in v3.0 -->
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />

--- a/src/Arcus.Messaging.Pumps.ServiceBus/ServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/ServiceBusMessagePump.cs
@@ -166,11 +166,6 @@ namespace Arcus.Messaging.Pumps.ServiceBus
                 return MessageProcessingResult.Failure(message.MessageId, MessageProcessingError.ProcessingInterrupted, "Cannot process received message as the message pump is shutting down");
             }
 
-            if (string.IsNullOrEmpty(message.CorrelationId))
-            {
-                Logger.LogTrace("No operation ID was found on the message '{MessageId}' during processing in the Azure Service Bus {EntityType} message pump '{JobId}'", message.MessageId, EntityType, JobId);
-            }
-
 #pragma warning disable CS0618 // Type or member is obsolete
             using MessageCorrelationResult correlationResult = DetermineMessageCorrelation(message);
 

--- a/src/Arcus.Messaging.Pumps.ServiceBus/ServiceBusReceiverMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/ServiceBusReceiverMessagePump.cs
@@ -72,7 +72,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
                    https://github.com/arcus-azure/arcus.messaging/issues/176 */
 #pragma warning restore S1135
 
-            Logger.LogInformation("Azure Service Bus {EntityType} message pump '{JobId}' on entity path '{EntityPath}' in namespace '{Namespace}' started", EntityType, JobId, EntityName, Namespace);
+            Logger.LogTrace("Azure Service Bus {EntityType} message pump '{JobId}' on entity path '{EntityPath}' in namespace '{Namespace}' started", EntityType, JobId, EntityName, Namespace);
 
             _receiveMessagesCancellation = new CancellationTokenSource();
             while (CircuitState.IsClosed
@@ -179,7 +179,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             IsStarted = false;
             CircuitState = CircuitState.TransitionTo(CircuitBreakerState.Open);
 
-            Logger.LogInformation("Azure Service Bus {EntityType} message pump '{JobId}' on entity path '{EntityPath}' in '{Namespace}' closed : {Time}", EntityType, JobId, EntityName, Namespace, DateTimeOffset.UtcNow);
+            Logger.LogTrace("Azure Service Bus {EntityType} message pump '{JobId}' on entity path '{EntityPath}' in '{Namespace}' closed : {Time}", EntityType, JobId, EntityName, Namespace, DateTimeOffset.UtcNow);
 
             if (_receiveMessagesCancellation != null)
             {
@@ -208,11 +208,6 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             {
                 Logger.LogWarning("Received message on Azure Service Bus {EntityType} message pump '{JobId}' was null, skipping", EntityType, JobId);
                 return MessageProcessingResult.Failure("<unavailable>", MessageProcessingError.ProcessingInterrupted, "Cannot process received message as the message is was 'null'");
-            }
-
-            if (string.IsNullOrEmpty(message.CorrelationId))
-            {
-                Logger.LogTrace("No operation ID was found on the message '{MessageId}' during processing in the Azure Service Bus {EntityType} message pump '{JobId}'", message.MessageId, EntityType, JobId);
             }
 
             var messageContext = AzureServiceBusMessageContext.Create(JobId, EntityType, _messageReceiver, message);

--- a/src/Arcus.Messaging.Pumps.ServiceBus/ServiceBusSessionMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/ServiceBusSessionMessagePump.cs
@@ -74,11 +74,6 @@ namespace Arcus.Messaging.Pumps.ServiceBus
                 return;
             }
 
-            if (string.IsNullOrEmpty(message.CorrelationId))
-            {
-                Logger.LogTrace("No operation ID was found on the message '{MessageId}' during processing in the Azure Service Bus {EntityType} session-aware message pump '{JobId}'", message.MessageId, EntityType, JobId);
-            }
-
             var messageContext = AzureServiceBusMessageContext.Create(JobId, EntityType, arg);
             await RouteMessageAsync(message, messageContext, arg.CancellationToken);
         }

--- a/src/Arcus.Messaging.Tests.Core/ServiceBus/MessageBodyHandlers/OrderBatchMessageBodySerializer.cs
+++ b/src/Arcus.Messaging.Tests.Core/ServiceBus/MessageBodyHandlers/OrderBatchMessageBodySerializer.cs
@@ -28,17 +28,14 @@ namespace Arcus.Messaging.Tests.Workers.MessageBodyHandlers
         /// </returns>
         public Task<MessageResult> DeserializeMessageAsync(string messageBody)
         {
-            _logger.LogTrace("Start deserializing to an 'Order'...");
             var order = JsonConvert.DeserializeObject<Order>(messageBody);
-            
+
             if (order is null)
             {
-                _logger.LogError("Cannot deserialize incoming message to an 'Order', so can't use 'Order'");
                 return Task.FromResult(MessageResult.Failure("Cannot deserialize incoming message to an 'Order', so can't use 'Order'"));
             }
 
-            _logger.LogInformation("Deserialized to an 'Order', using 'Order'");
-            return Task.FromResult(MessageResult.Success(new OrderBatch { Orders = new [] { order } }));
+            return Task.FromResult(MessageResult.Success(new OrderBatch { Orders = new[] { order } }));
         }
     }
 }

--- a/src/Arcus.Messaging.Tests.Core/ServiceBus/MessageHandlers/WriteOrderToDiskAzureServiceBusMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Core/ServiceBus/MessageHandlers/WriteOrderToDiskAzureServiceBusMessageHandler.cs
@@ -30,7 +30,7 @@ namespace Arcus.Messaging.Tests.Workers.MessageHandlers
             MessageCorrelationInfo correlationInfo,
             CancellationToken cancellationToken)
         {
-            _logger.LogTrace("Write order v1 message to disk: {MessageId}", message.Id);
+            _logger.LogTrace("[Test] Write order v1 message to disk: {MessageId}", message.Id);
 
             string fileName = message.Id + ".json";
             string dirPath = Directory.GetCurrentDirectory();

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/WorkerOptions.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/WorkerOptions.cs
@@ -86,6 +86,8 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
             LoggerConfiguration config =
                 new LoggerConfiguration()
                     .MinimumLevel.Verbose()
+                    .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
+                    .MinimumLevel.Override("Microsoft.Hosting.Lifetime", LogEventLevel.Fatal)
                     .Enrich.FromLogContext();
 
             foreach (Action<LoggerConfiguration> configure in _additionalSerilogConfigOptions)

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/Fixture/ServiceBusTestContext.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/Fixture/ServiceBusTestContext.cs
@@ -92,6 +92,13 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump.Fixture
         /// </summary>
         internal ServiceBusMessageHandlerCollection WhenServiceBusQueueMessagePump(Action<ServiceBusMessagePumpOptions> configureOptions = null)
         {
+            return WhenOnlyServiceBusQueueMessagePump(configureOptions)
+                   .WithUnrelatedServiceBusMessageHandler()
+                   .WithUnrelatedServiceBusMessageHandler();
+        }
+
+        internal ServiceBusMessageHandlerCollection WhenOnlyServiceBusQueueMessagePump(Action<ServiceBusMessagePumpOptions> configureOptions = null)
+        {
             string sessionAwareDescription = UseSessions ? " session-aware" : string.Empty;
             _logger.LogTrace("[Test:Setup] Register Azure Service Bus{SessionDescription} queue message pump", sessionAwareDescription);
 
@@ -125,7 +132,9 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump.Fixture
                 }
 
                 configureOptions?.Invoke(options);
-            });
+
+            }).WithUnrelatedServiceBusMessageHandler()
+              .WithUnrelatedServiceBusMessageHandler();
         }
 
         /// <summary>
@@ -289,7 +298,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump.Fixture
 
         internal sealed class ServiceBusMessageBuilder
         {
-            private string _sessionId;
+            private string _messageId, _sessionId;
             private Encoding _encoding = Encoding.UTF8;
             private TraceParent _traceParent = TraceParent.Generate();
             private readonly Dictionary<string, object> _applicationProperties = new();
@@ -298,6 +307,12 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump.Fixture
             internal ServiceBusMessageBuilder WithSessionId(string sessionId)
             {
                 _sessionId = sessionId;
+                return this;
+            }
+
+            internal ServiceBusMessageBuilder WithMessageId(string messageId)
+            {
+                _messageId = messageId;
                 return this;
             }
 
@@ -352,7 +367,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump.Fixture
 
                 var message = new ServiceBusMessage(raw)
                 {
-                    MessageId = order.Id,
+                    MessageId = _messageId ?? order.Id,
                     SessionId = _sessionId,
                     ApplicationProperties =
                     {

--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePump.RouterTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePump.RouterTests.cs
@@ -142,7 +142,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
             // Arrange
             await using var serviceBus = GivenServiceBus();
 
-            serviceBus.WhenServiceBusQueueMessagePump(pump =>
+            serviceBus.WhenOnlyServiceBusQueueMessagePump(pump =>
             {
                 pump.Routing.Deserialization.AdditionalMembers = AdditionalMemberHandling.Ignore;
 


### PR DESCRIPTION
Provides a summary-logging structure during the message routing which focuses on the functionality rather than the technicality of message handler registration. An example of these logs:

### Error, that results in dead-lettering
```log
2025-09-08T08:38:42 Debug > [Received] message (message ID="c353d940-fb6e-4990-a8d4-3e15be9e874e") on Azure Service Bus Queue message pump
2025-09-08T08:38:42 Debug > Message "c353d940-fb6e-4990-a8d4-3e15be9e874e" [Skipped by] "PassThruOrderMessageHandler" => "✗ custom context filter failed (returns 'false')"
2025-09-08T08:38:42 Debug > Message "c353d940-fb6e-4990-a8d4-3e15be9e874e" [Skipped by] "ShipmentAzureServiceBusMessageHandler" => "✗ default JSON body parsing failed (exception thrown)": System.Text.Json.JsonException: The JSON property 'Amount' could not be mapped to any .NET member contained in type 'Arcus.Messaging.Tests.Core.Messages.v1.Shipment'.
2025-09-08T08:38:42 Debug > Message "c353d940-fb6e-4990-a8d4-3e15be9e874e" [Skipped by] "OrderBatchMessageHandler" => "
✓ custom context filter passed (against type=AzureServiceBusMessageContext)
✗ default JSON body parsing failed (exception thrown)": System.Text.Json.JsonException: The JSON property 'Id' could not be mapped to any .NET member contained in type 'Arcus.Messaging.Tests.Core.Messages.v1.OrderBatch'.
2025-09-08T08:38:42 Error > Message '"c353d940-fb6e-4990-a8d4-3e15be9e874e"' [Failed in] message pump => ✗ no matched handler handled found for message
2025-09-08T08:38:42 Debug > [Settle:DeadLetter] message (message ID="c353d940-fb6e-4990-a8d4-3e15be9e874e") on Azure Service Bus Queue message pump => "no matched handler handled found for message"
```

### Success, after skipping some handlers
```log
2025-09-08T08:40:10 Debug > [Received] message (message ID="9988e52e-030b-ea6c-9bf5-0629cb0727cf") on Azure Service Bus Queue message pump
2025-09-08T08:40:10 Debug > Message "9988e52e-030b-ea6c-9bf5-0629cb0727cf" [Skipped by] "PassThruOrderMessageHandler" => "✗ custom context filter failed (returns 'false')"
2025-09-08T08:40:10 Debug > Message "9988e52e-030b-ea6c-9bf5-0629cb0727cf" [Skipped by] "PassThruOrderMessageHandler" => "✗ custom context filter failed (returns 'false')"
2025-09-08T08:40:10 Trace > [Test] Write order v1 message to disk: "9988e52e-030b-ea6c-9bf5-0629cb0727cf"
2025-09-08T08:40:10 Debug > "Order" "9988e52e-030b-ea6c-9bf5-0629cb0727cf" [Processed by] "WriteOrderToDiskAzureServiceBusMessageHandler" => "
✓ custom context filter passed (against type=AzureServiceBusMessageContext)
✓ default JSON body parsing passed (additional members=Error)
✓ custom body filter passed (against type=Order)"
2025-09-08T08:40:10 Information > Message '"9988e52e-030b-ea6c-9bf5-0629cb0727cf"' was processed by "WriteOrderToDiskAzureServiceBusMessageHandler" | skipped by "2 other handlers"
```

The `DEBUG` is used to write the matching pre-checks, `INFO`/`ERROR` is used as the final summary, written as a single sentence.

To accomplish this, this PR places all the logging within the non-Azure Service Bus-related message routing functionality. This gives us the opportunity to only focus on Azure Service Bus-related code in the `ServiceBusMessageRouter` 👉 which it should be.

Furthermore, the integration tests have been enhanced to always add 'unrelated' message handlers, to trigger the message routing more and not to rely on unit tests (which are not only there to test deprecated functionality).

Closes #647 