### PR TITLE
docs(az.sb): Update Autocomplete documentation on Service Bus Arcus.Messaging

### DIFF
--- a/docs/preview/03-Features/01-Azure/01-service-bus.md
+++ b/docs/preview/03-Features/01-Azure/01-service-bus.md
@@ -135,7 +135,7 @@ services.AddServiceBus[Topic/Queue]MessagePump(..., options =>
     options.JobId = Guid.NewGuid().ToString();
 
     // Indicate whether or not messages should be automatically marked as completed when the handler succeeded (no exceptions thrown) (default: true)
-    // If you put this on false you are responsible yourself for completing the message.
+    // ⚠️ If you put this on false, you are responsible for completing the message yourself.
     options.Routing.AutoComplete = false;
 
     // Indicate whether or not the default built-in JSON deserialization should ignore additional members 

--- a/docs/preview/03-Features/01-Azure/01-service-bus.md
+++ b/docs/preview/03-Features/01-Azure/01-service-bus.md
@@ -134,8 +134,8 @@ services.AddServiceBus[Topic/Queue]MessagePump(..., options =>
     // this job instance in a multi-instance deployment (default: generated GUID).
     options.JobId = Guid.NewGuid().ToString();
 
-    // Indicate whether or not messages should be automatically marked as completed 
-    // if no exceptions occurred and processing has finished (default: true).
+    // Indicate whether or not messages should be automatically marked as completed when the handler succeeded (no exceptions) (default: true)
+    // If you put this on false you are responsible yourself for completing the message.
     options.Routing.AutoComplete = false;
 
     // Indicate whether or not the default built-in JSON deserialization should ignore additional members 

--- a/docs/preview/03-Features/01-Azure/01-service-bus.md
+++ b/docs/preview/03-Features/01-Azure/01-service-bus.md
@@ -135,7 +135,7 @@ services.AddServiceBus[Topic/Queue]MessagePump(..., options =>
     options.JobId = Guid.NewGuid().ToString();
 
     // Indicate whether or not messages should be automatically marked as completed when the handler succeeded (no exceptions thrown) (default: true)
-    // ⚠️ If you put this on false, you are responsible for completing the message yourself.
+    // ⚠️ Setting this property to false means you are responsible for completing the message yourself.
     options.Routing.AutoComplete = false;
 
     // Indicate whether or not the default built-in JSON deserialization should ignore additional members 

--- a/docs/preview/03-Features/01-Azure/01-service-bus.md
+++ b/docs/preview/03-Features/01-Azure/01-service-bus.md
@@ -134,7 +134,7 @@ services.AddServiceBus[Topic/Queue]MessagePump(..., options =>
     // this job instance in a multi-instance deployment (default: generated GUID).
     options.JobId = Guid.NewGuid().ToString();
 
-    // Indicate whether or not messages should be automatically marked as completed when the handler succeeded (no exceptions) (default: true)
+    // Indicate whether or not messages should be automatically marked as completed when the handler succeeded (no exceptions thrown) (default: true)
     // If you put this on false you are responsible yourself for completing the message.
     options.Routing.AutoComplete = false;
 


### PR DESCRIPTION
Adds warning on `options.AutoComplete` to point to the fact that consumers are responsible for completing the message themselves, if not auto-completing it.