### PR TITLE
fix(logging): correctly apply logging scopes in az sb messaging

### DIFF
--- a/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
+++ b/src/Arcus.Messaging.Abstractions/MessageHandling/MessageRouter.cs
@@ -168,6 +168,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
             CancellationToken cancellation)
             where TMessageContext : MessageContext
         {
+            using var _ = Logger.BeginScope(new Dictionary<string, object> { ["JobId"] = context.JobId });
             var summary = new MessageHandlerSummary();
 
             if (!handler.MatchesMessageContext(context, summary))

--- a/src/Arcus.Messaging.Pumps.ServiceBus/ServiceBusMessagePump.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/ServiceBusMessagePump.cs
@@ -26,7 +26,6 @@ namespace Arcus.Messaging.Pumps.ServiceBus
     internal abstract class ServiceBusMessagePump : BackgroundService
     {
         private readonly ServiceBusMessageRouter _messageRouter;
-        private readonly IDisposable _loggingScope;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ServiceBusMessagePump"/> class.
@@ -57,7 +56,6 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             ServiceProvider = serviceProvider;
             Logger = logger ?? NullLogger.Instance;
 
-            _loggingScope = Logger.BeginScope("Job: {JobId}", JobId);
             _messageRouter = new ServiceBusMessageRouter(serviceProvider, options.Routing, serviceProvider.GetService<ILogger<ServiceBusMessageRouter>>());
         }
 
@@ -197,9 +195,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus
         /// <returns>A <see cref="Task" /> that represents the asynchronous Stop operation.</returns>
         public override Task StopAsync(CancellationToken cancellationToken)
         {
-            _loggingScope?.Dispose();
             IsHostShuttingDown = true;
-
             return base.StopAsync(cancellationToken);
         }
     }

--- a/src/Arcus.Messaging.Pumps.ServiceBus/ServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.Pumps.ServiceBus/ServiceBusMessageRouter.cs
@@ -87,8 +87,12 @@ namespace Arcus.Messaging.Pumps.ServiceBus
             MessageCorrelationInfo correlationInfo,
             CancellationToken cancellationToken)
         {
-            using var _ = Logger.BeginScope(new Dictionary<string, string> { ["MessageId"] = messageContext.MessageId });
-
+            using var _ = Logger.BeginScope(new Dictionary<string, object>
+            {
+                ["JobId"] = messageContext.JobId,
+                ["Service Bus namespace"] = messageContext.FullyQualifiedNamespace,
+                ["Service Bus entity name"] = messageContext.EntityPath
+            });
             Logger.LogDebug("[Received] message (message ID={MessageId}) on Azure Service Bus {EntityType} message pump", messageContext.MessageId, messageContext.EntityType);
 
             string messageBody = LoadMessageBody(message, messageContext);


### PR DESCRIPTION
Logging scopes are usually alive and used within the same asynchronous context, saving it through the lifetime of an instance with asynchronous operations does not hold the state throughout.
This PR fixes the correct usages of logging scopes by placing it around messaging/Service Bus-specific logging statements.

This can be seen as a correction/follow-up of the previous #648 PR