### PR TITLE
fix(az.sb.test): add missing queue w/ session teardown

### DIFF
--- a/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
+++ b/src/Arcus.Messaging.Tests.Integration/MessagePump/ServiceBusMessagePumpTests.cs
@@ -95,6 +95,7 @@ namespace Arcus.Messaging.Tests.Integration.MessagePump
         {
             await using var disposables = new DisposableCollection(NullLogger.Instance);
             disposables.Add(Queue);
+            disposables.Add(QueueWithSession);
             disposables.Add(Topic);
             disposables.Add(_client);
         }


### PR DESCRIPTION
The Azure Service Bus queue with session-support was not teared down in the integration tests, this PR fixes that.