### PR TITLE
docs(az.sb): update docs w/ recent serilog correlation scope changes

### DIFF
--- a/docs/preview/03-Features/01-Azure/01-service-bus.mdx
+++ b/docs/preview/03-Features/01-Azure/01-service-bus.mdx
@@ -299,7 +299,7 @@ public class OrderMessageHandler : CircuitBreakerServiceBusMessageHandler<Order>
         if (!IsMyDependentSystemHealthy())
         {
             // Let the message processing fail with a custom exception.
-            throw new MyDependencyUnnavailableException("My dependency system is temporarily unavailable, please halt message processing for now");
+            throw new MyDependencyUnavailableException("My dependency system is temporarily unavailable, please halt message processing for now");
         }
         // highlight-end
     }

--- a/docs/preview/03-Guides/migration-guide-v3.0.md
+++ b/docs/preview/03-Guides/migration-guide-v3.0.md
@@ -41,6 +41,8 @@ All Azure EventHubs-related functionality has been removed from v3.0. This means
   * Removed `(I)MessageCorrelationInfoAccessor`: message correlation is already available via message handlers.
   * Removed `MessageCorrelationResult`: in favor of the new `MessageOperationResult`.
   * `MessageCorrelationInfo` is separated from parent `CorrelationInfo` (originates from Arcus.Observability)
+  * Removed `MessageRouterOptions.Telemetry` options in favor of new `ServiceBusMessagePumpOptions.Telemetry`.
+  * Removed `MessageRouterOptions.CorrelationEnricher` in favor of dedicated (Serilog telemetry package)(#-new-service-bus-message-correlation) where those options are also available.
 * Removed **Arcus.Messaging.ServiceBus.Core** package and transient dependency for **Arcus.Messaging.Pumps.ServiceBus**. This means that the following types/extensions are removed:
   * `ServiceBusMessageBuilder`
   * `ServiceBusSenderMessageCorrelationOptions`


### PR DESCRIPTION
In a previous PR #644 , the Serilog correlation was moved to a separate project, but some minor details were not being passed to the feature documentation. This PR fixes that.