### PR TITLE
chore(deps): use serilog w/ v4-5 package range

### DIFF
--- a/src/Arcus.Messaging.ServiceBus.Telemetry.Serilog/Arcus.Messaging.ServiceBus.Telemetry.Serilog.csproj
+++ b/src/Arcus.Messaging.ServiceBus.Telemetry.Serilog/Arcus.Messaging.ServiceBus.Telemetry.Serilog.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="[2.*,3.0.0)" />
-    <PackageReference Include="Serilog" Version="[2.*,3.0.0)" />
+    <PackageReference Include="Serilog" Version="[4.*,5.0.0)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Move the package range of the `Arcus.Messaging.ServiceBus.Telemetry.Serilog` project to v4-5 so that modern projects can benefit from this functionality.

Closes #663 