### PR TITLE
docs(v3): mention telemetry client registration failure in v3 migratiation guide

### DIFF
--- a/docs/preview/03-Guides/migration-guide-v3.0.md
+++ b/docs/preview/03-Guides/migration-guide-v3.0.md
@@ -179,7 +179,7 @@ To still benefit from the original W3C message correlation tracking with **Arcus
           .WithServiceBusMessageHandler<...>()
           .WithServiceBusMessageHandler<...>();
   ```
-* 👀 Check that the `TelemetryClient` is registered in the application services (registering Azure Application Insights services is not done automatically anymore).
+* 👀 Check that the `TelemetryClient` is registered in the application services (registering Azure Application Insights services is not done automatically anymore, see [Microsoft's documentation on registering Azure Monitor in worker services](https://docs.azure.cn/en-us/azure-monitor/app/worker-service)).
 * 🎉 The original (< v3.0) message correlation is now restored.
 
 We expect other kinds of message correlation registrations in the future. Switching between them would be a matter of choosing the correct `.WithServiceBus...RequestTracking()`.


### PR DESCRIPTION
If Arcus Observability is used in combination with Arcus Messaging, and an upgrade to v3 happens, several registration failures could occur at runtime.
This PR mention this failure explicitly and guides users to the right migration section.

Closes #664 