### PR TITLE
chore(v3): use arcus-specific diagnostic id for deprecation

### DIFF
--- a/src/Arcus.Messaging.Core/Arcus.Messaging.Core.csproj
+++ b/src/Arcus.Messaging.Core/Arcus.Messaging.Core.csproj
@@ -18,6 +18,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>S1133</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Messaging.Core/MessageHandling/IMessageBodySerializer.cs
+++ b/src/Arcus.Messaging.Core/MessageHandling/IMessageBodySerializer.cs
@@ -8,7 +8,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
     /// Represents a handler that provides a deserialization strategy for the incoming message during the message processing of message pump or router.
     /// </summary>
     /// <seealso cref="IMessageHandler{TMessage,TMessageContext}"/>
-    [Obsolete("Will be removed in v3.0 in favor of using the new " + nameof(IMessageBodyDeserializer) + " interface")]
+    [Obsolete("Will be removed in v3.0 in favor of using the new " + nameof(IMessageBodyDeserializer) + " interface", DiagnosticId = "ARCUS")]
     public interface IMessageBodySerializer
     {
         /// <summary>

--- a/src/Arcus.Messaging.Core/MessageHandling/MessageHandler.cs
+++ b/src/Arcus.Messaging.Core/MessageHandling/MessageHandler.cs
@@ -180,7 +180,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// <param name="logger">The logger instance to write diagnostic messages during the message handler interaction.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="messageHandler"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">Thrown when the <paramref name="jobId"/> is blank.</exception>
-        [Obsolete("Will be removed in v3.0 in favor of the new factory method with message handler options")]
+        [Obsolete("Will be removed in v3.0 in favor of the new factory method with message handler options", DiagnosticId = "ARCUS")]
         public static MessageHandler Create<TMessage, TMessageContext>(
             IMessageHandler<TMessage, TMessageContext> messageHandler,
             ILogger logger,
@@ -206,7 +206,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
                 logger: logger);
         }
 
-        [Obsolete("Will be removed in v3.0")]
+        [Obsolete("Will be removed in v3.0", DiagnosticId = "ARCUS")]
         private sealed class DeprecatedMessageBodyDeserializerAdapter(IMessageBodySerializer deprecated) : IMessageBodyDeserializer
         {
             public async Task<MessageBodyResult> DeserializeMessageAsync(BinaryData messageBody)
@@ -320,7 +320,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// <summary>
         /// Gets the concrete class type of the <see cref="IMessageHandler{TMessage,TMessageContext}"/> instance.
         /// </summary>
-        [Obsolete("Will be removed in v3.0 in favor of centralizing message handler matching in message router")]
+        [Obsolete("Will be removed in v3.0 in favor of centralizing message handler matching in message router", DiagnosticId = "ARCUS")]
         public object GetMessageHandlerInstance()
         {
             return _messageHandlerInstance;
@@ -329,7 +329,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// <summary>
         /// Gets the type of the <see cref="IMessageHandler{TMessage,TMessageContext}"/> instance.
         /// </summary>
-        [Obsolete("Will be removed in v3.0 in favor of centralizing message handler matching in message router")]
+        [Obsolete("Will be removed in v3.0 in favor of centralizing message handler matching in message router", DiagnosticId = "ARCUS")]
         public Type GetMessageHandlerType()
         {
             return MessageHandlerType;
@@ -355,7 +355,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// </summary>
         /// <typeparam name="TMessageContext">The type of the message context.</typeparam>
         /// <param name="messageContext">The context in which the incoming message is processed.</param>
-        [Obsolete("Will be removed in v3.0 in favor of centralizing message handler matching in message router")]
+        [Obsolete("Will be removed in v3.0 in favor of centralizing message handler matching in message router", DiagnosticId = "ARCUS")]
         public bool CanProcessMessageBasedOnContext<TMessageContext>(TMessageContext messageContext)
             where TMessageContext : MessageContext
         {
@@ -380,7 +380,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// Determines if the registered <see cref="IMessageHandler{TMessage,TMessageContext}"/> can process the incoming deserialized message based on the consumer-provided message predicate.
         /// </summary>
         /// <param name="message">The incoming deserialized message body.</param>
-        [Obsolete("Will be removed in v3.0 in favor of centralizing message handler matching in message router")]
+        [Obsolete("Will be removed in v3.0 in favor of centralizing message handler matching in message router", DiagnosticId = "ARCUS")]
         public bool CanProcessMessageBasedOnMessage(object message)
         {
             return MatchesMessageBody(message, new MessageHandlerSummary());
@@ -460,7 +460,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// <returns>
         ///     A <see cref="MessageResult"/> instance that either represents a successful or faulted deserialization of the incoming <paramref name="message"/>.
         /// </returns>
-        [Obsolete("Will be removed in v3.0 in favor of centralizing message handler matching in message router")]
+        [Obsolete("Will be removed in v3.0 in favor of centralizing message handler matching in message router", DiagnosticId = "ARCUS")]
         public async Task<MessageResult> TryCustomDeserializeMessageAsync(string message)
         {
             if (_messageBodyDeserializer is null)
@@ -525,7 +525,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
         /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when the message handler cannot process the message correctly.</exception>
         /// <exception cref="AmbiguousMatchException">Thrown when more than a single processing method was found on the message handler.</exception>
-        [Obsolete("Will be removed in v3.0 in favor of centralizing message handler matching in message router")]
+        [Obsolete("Will be removed in v3.0 in favor of centralizing message handler matching in message router", DiagnosticId = "ARCUS")]
         public async Task<bool> ProcessMessageAsync<TMessageContext>(
             object message,
             TMessageContext messageContext,

--- a/src/Arcus.Messaging.Core/MessageHandling/MessageResult.cs
+++ b/src/Arcus.Messaging.Core/MessageHandling/MessageResult.cs
@@ -6,7 +6,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
     /// Represents a type that's the result of a successful or faulted message deserialization of an <see cref="IMessageBodySerializer"/> instance.
     /// </summary>
     /// <seealso cref="IMessageBodySerializer"/>
-    [Obsolete("Will be removed in v3.0 in favor of using the new " + nameof(MessageBodyResult) + " model")]
+    [Obsolete("Will be removed in v3.0 in favor of using the new " + nameof(MessageBodyResult) + " model", DiagnosticId = "ARCUS")]
     public class MessageResult
     {
         private MessageResult(object result)

--- a/src/Arcus.Messaging.ServiceBus/AzureServiceBusMessageContext.cs
+++ b/src/Arcus.Messaging.ServiceBus/AzureServiceBusMessageContext.cs
@@ -257,7 +257,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus
     /// <summary>
     /// Represents the contextual information concerning an Azure Service Bus message.
     /// </summary>
-    [Obsolete("Will be removed in v4.0, please use the " + nameof(ServiceBusMessageContext) + " instead")]
+    [Obsolete("Will be removed in v4.0, please use the " + nameof(ServiceBusMessageContext) + " instead", DiagnosticId = "ARCUS")]
     public class AzureServiceBusMessageContext : ServiceBusMessageContext
     {
         internal AzureServiceBusMessageContext(

--- a/src/Arcus.Messaging.ServiceBus/Extensions/ServiceBusMessageHandlerCollectionExtensions.cs
+++ b/src/Arcus.Messaging.ServiceBus/Extensions/ServiceBusMessageHandlerCollectionExtensions.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="TMessage">The type of the message that the message handler will process.</typeparam>
         /// <param name="handlers">The collection of handlers to use in the application.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="handlers"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v4.0, please implement " + nameof(IServiceBusMessageHandler<object>) + " instead")]
+        [Obsolete("Will be removed in v4.0, please implement " + nameof(IServiceBusMessageHandler<object>) + " instead", DiagnosticId = "ARCUS")]
         public static ServiceBusMessageHandlerCollection WithServiceBusMessageHandler<TMessageHandler, TMessage>(this ServiceBusMessageHandlerCollection handlers)
             where TMessageHandler : class, IAzureServiceBusMessageHandler<TMessage>
             where TMessage : class
@@ -126,7 +126,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="handlers">The collection of handlers to use in the application.</param>
         /// <param name="configureOptions">The additional set of options to configure the registration of the message handler.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="handlers"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v4.0, please implement " + nameof(IServiceBusMessageHandler<object>) + " instead")]
+        [Obsolete("Will be removed in v4.0, please implement " + nameof(IServiceBusMessageHandler<object>) + " instead", DiagnosticId = "ARCUS")]
         public static ServiceBusMessageHandlerCollection WithServiceBusMessageHandler<TMessageHandler, TMessage>(
             this ServiceBusMessageHandlerCollection handlers,
             Action<ServiceBusMessageHandlerOptions<TMessage>> configureOptions)
@@ -144,7 +144,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="handlers">The collection of handlers to use in the application.</param>
         /// <param name="implementationFactory">The function that creates the message handler.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="handlers"/> or <paramref name="implementationFactory"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v4.0, please implement " + nameof(IServiceBusMessageHandler<object>) + " instead")]
+        [Obsolete("Will be removed in v4.0, please implement " + nameof(IServiceBusMessageHandler<object>) + " instead", DiagnosticId = "ARCUS")]
         public static ServiceBusMessageHandlerCollection WithServiceBusMessageHandler<TMessageHandler, TMessage>(
             this ServiceBusMessageHandlerCollection handlers,
             Func<IServiceProvider, TMessageHandler> implementationFactory)
@@ -163,7 +163,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="implementationFactory">The function that creates the message handler.</param>
         /// <param name="configureOptions">The additional set of options to configure the registration of the message handler.</param>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="handlers"/> or <paramref name="implementationFactory"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v4.0, please implement " + nameof(IServiceBusMessageHandler<object>) + " instead")]
+        [Obsolete("Will be removed in v4.0, please implement " + nameof(IServiceBusMessageHandler<object>) + " instead", DiagnosticId = "ARCUS")]
         public static ServiceBusMessageHandlerCollection WithServiceBusMessageHandler<TMessageHandler, TMessage>(
             this ServiceBusMessageHandlerCollection handlers,
             Func<IServiceProvider, TMessageHandler> implementationFactory,
@@ -179,8 +179,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 configureOptions);
         }
 
-        [Obsolete("Will be removed in v4.0")]
-        private class DeprecatedServiceBusMessageHandlerAdapter<TMessage> : IServiceBusMessageHandler<TMessage>
+        [Obsolete("Will be removed in v4.0", DiagnosticId = "ARCUS")]
+        private sealed class DeprecatedServiceBusMessageHandlerAdapter<TMessage> : IServiceBusMessageHandler<TMessage>
         {
             private readonly IAzureServiceBusMessageHandler<TMessage> _deprecatedHandler;
 

--- a/src/Arcus.Messaging.ServiceBus/Extensions/ServiceBusMessageHandlerOptions.cs
+++ b/src/Arcus.Messaging.ServiceBus/Extensions/ServiceBusMessageHandlerOptions.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Adds a custom <paramref name="contextFilter"/> to only select a subset of messages, based on its context, that the registered message handler can handle.
         /// </summary>
-        [Obsolete("Will be removed in v4.0, please use " + nameof(ServiceBusMessageContext) + " instead")]
+        [Obsolete("Will be removed in v4.0, please use " + nameof(ServiceBusMessageContext) + " instead", DiagnosticId = "ARCUS")]
         public ServiceBusMessageHandlerOptions<TMessage> AddMessageContextFilter(Func<AzureServiceBusMessageContext, bool> contextFilter)
         {
             ArgumentNullException.ThrowIfNull(contextFilter);
@@ -81,7 +81,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Adds a custom serializer instance that deserializes the incoming <see cref="ServiceBusReceivedMessage.Body"/>.
         /// </summary>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="serializer"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v4.0, please use " + nameof(UseMessageBodyDeserializer) + " which provides the exact same functionality")]
+        [Obsolete("Will be removed in v4.0, please use " + nameof(UseMessageBodyDeserializer) + " which provides the exact same functionality", DiagnosticId = "ARCUS")]
         public ServiceBusMessageHandlerOptions<TMessage> AddMessageBodySerializer(IMessageBodySerializer serializer)
         {
             return AddMessageBodySerializer(_ => serializer);
@@ -91,7 +91,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Adds a custom serializer instance that deserializes the incoming <see cref="ServiceBusReceivedMessage.Body"/>.
         /// </summary>
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="implementationFactory"/> is <c>null</c>.</exception>
-        [Obsolete("Will be removed in v4.0, please use " + nameof(UseMessageBodyDeserializer) + " which provides the exact same functionality")]
+        [Obsolete("Will be removed in v4.0, please use " + nameof(UseMessageBodyDeserializer) + " which provides the exact same functionality", DiagnosticId = "ARCUS")]
         public ServiceBusMessageHandlerOptions<TMessage> AddMessageBodySerializer(Func<IServiceProvider, IMessageBodySerializer> implementationFactory)
         {
             return UseMessageBodyDeserializer(serviceProvider =>
@@ -101,7 +101,7 @@ namespace Microsoft.Extensions.DependencyInjection
             });
         }
 
-        [Obsolete("Will be removed in v3.0")]
+        [Obsolete("Will be removed in v3.0", DiagnosticId = "ARCUS")]
         private sealed class DeprecatedMessageBodyDeserializerAdapter(IMessageBodySerializer deprecated) : IMessageBodyDeserializer
         {
             public async Task<MessageBodyResult> DeserializeMessageAsync(BinaryData messageBody)

--- a/src/Arcus.Messaging.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.ServiceBus/MessageHandling/AzureServiceBusMessageRouter.cs
@@ -9,14 +9,12 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using static Arcus.Messaging.Abstractions.MessageHandling.MessageProcessingError;
 
-#pragma warning disable S1133
-
 namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
 {
     /// <summary>
     /// Represents an <see cref="IAzureServiceBusMessageRouter"/> that can route Azure Service Bus <see cref="ServiceBusReceivedMessage"/>s.
     /// </summary>
-    [Obsolete("Will be removed in v4.0 as the message router is being made internal")]
+    [Obsolete("Will be removed in v4.0 as the message router is being made internal", DiagnosticId = "ARCUS")]
     public class AzureServiceBusMessageRouter : MessageRouter, IAzureServiceBusMessageRouter
     {
         /// <summary>
@@ -77,7 +75,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
         ///     Thrown when the <paramref name="messageReceiver"/>, <paramref name="message"/>, <paramref name="messageContext"/>, or <paramref name="correlationInfo"/> is <c>null</c>.
         /// </exception>
         /// <exception cref="InvalidOperationException">Thrown when no message handlers or none matching message handlers are found to process the message.</exception>
-        [Obsolete("Will be removed in v3.0, please use the Azure service bus operations on the " + nameof(AzureServiceBusMessageContext) + " instead of defining fallback message handlers")]
+        [Obsolete("Will be removed in v3.0, please use the Azure service bus operations on the " + nameof(AzureServiceBusMessageContext) + " instead of defining fallback message handlers", DiagnosticId = "ARCUS")]
         protected async Task<MessageProcessingResult> RouteMessageWithPotentialFallbackAsync(
             ServiceBusReceiver messageReceiver,
             ServiceBusReceivedMessage message,

--- a/src/Arcus.Messaging.ServiceBus/MessageHandling/IAzureServiceBusMessageHandler.cs
+++ b/src/Arcus.Messaging.ServiceBus/MessageHandling/IAzureServiceBusMessageHandler.cs
@@ -20,7 +20,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
     /// Represents a handler for a specific <see cref="ServiceBusReceivedMessage"/> in a <see cref="AzureServiceBusMessageContext"/>
     /// during the processing of the messages in Azure Service Bus.
     /// </summary>
-    [Obsolete("Will be removed in v4.0, please implement " + nameof(IServiceBusMessageHandler<object>) + " instead")]
+    [Obsolete("Will be removed in v4.0, please implement " + nameof(IServiceBusMessageHandler<object>) + " instead", DiagnosticId = "ARCUS")]
     public interface IAzureServiceBusMessageHandler<in TMessage> : IMessageHandler<TMessage, AzureServiceBusMessageContext>
     {
     }

--- a/src/Arcus.Messaging.ServiceBus/MessageHandling/IAzureServiceBusMessageRouter.cs
+++ b/src/Arcus.Messaging.ServiceBus/MessageHandling/IAzureServiceBusMessageRouter.cs
@@ -9,9 +9,7 @@ namespace Arcus.Messaging.Abstractions.ServiceBus.MessageHandling
     /// <summary>
     /// Represents an instance that can route Azure Service Bus <see cref="ServiceBusReceivedMessage"/>s through registered <see cref="IAzureServiceBusMessageHandler{TMessage}"/>s.
     /// </summary>
-#pragma warning disable S1133
-    [Obsolete("Will be removed in v4.0 as the message router is being made internal")]
-#pragma warning restore S1133
+    [Obsolete("Will be removed in v4.0 as the message router is being made internal", DiagnosticId = "ARCUS")]
     public interface IAzureServiceBusMessageRouter
     {
         /// <summary>

--- a/src/Arcus.Messaging.ServiceBus/Resiliency/CircuitBreakerServiceBusMessageHandler.cs
+++ b/src/Arcus.Messaging.ServiceBus/Resiliency/CircuitBreakerServiceBusMessageHandler.cs
@@ -116,7 +116,7 @@ namespace Arcus.Messaging.Pumps.ServiceBus.Resiliency
     /// Represents a template for a message handler that interacts with an unstable dependency system that requires a circuit breaker to prevent overloading the system.
     /// </summary>
     /// <typeparam name="TMessage">The type of the message that this handler can process.</typeparam>
-    [Obsolete("Will be removed in v4.0, please implement the Arcus.Messaging." + nameof(DefaultCircuitBreakerServiceBusMessageHandler<object>) + " one instead")]
+    [Obsolete("Will be removed in v4.0, please implement the Arcus.Messaging." + nameof(DefaultCircuitBreakerServiceBusMessageHandler<object>) + " one instead", DiagnosticId = "ARCUS")]
     public abstract class CircuitBreakerServiceBusMessageHandler<TMessage> : DefaultCircuitBreakerServiceBusMessageHandler<TMessage>, IAzureServiceBusMessageHandler<TMessage>
     {
         /// <summary>

--- a/src/Arcus.Messaging.Tests.Core/Arcus.Messaging.Tests.Core.csproj
+++ b/src/Arcus.Messaging.Tests.Core/Arcus.Messaging.Tests.Core.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <NoWarn>ARCUS</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Messaging.Tests.Core/ServiceBus/MessageHandlers/DeadLetterAzureServiceMessageHandler.cs
+++ b/src/Arcus.Messaging.Tests.Core/ServiceBus/MessageHandlers/DeadLetterAzureServiceMessageHandler.cs
@@ -1,6 +1,5 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
-using Arcus.Messaging.Abstractions;
 using Arcus.Messaging.Abstractions.ServiceBus;
 using Arcus.Messaging.Abstractions.ServiceBus.MessageHandling;
 using Arcus.Messaging.Tests.Core.Messages.v1;

--- a/src/Arcus.Messaging.Tests.Integration/Arcus.Messaging.Tests.Integration.csproj
+++ b/src/Arcus.Messaging.Tests.Integration/Arcus.Messaging.Tests.Integration.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
+    <NoWarn>ARCUS</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Messaging.Tests.Integration/Fixture/WorkerOptions.cs
+++ b/src/Arcus.Messaging.Tests.Integration/Fixture/WorkerOptions.cs
@@ -55,6 +55,7 @@ namespace Arcus.Messaging.Tests.Integration.Fixture
                     LogEventLevel.Information => LogLevel.Information,
                     LogEventLevel.Verbose => LogLevel.Trace,
                     LogEventLevel.Warning => LogLevel.Warning,
+                    _ => throw new ArgumentOutOfRangeException(nameof(logEvent), logEvent.Level, "Unknown log level")
                 };
 
                 logger.Log(level, logEvent.Exception, logEvent.RenderMessage());

--- a/src/Arcus.Messaging.Tests.Unit/Arcus.Messaging.Tests.Unit.csproj
+++ b/src/Arcus.Messaging.Tests.Unit/Arcus.Messaging.Tests.Unit.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
+    <NoWarn>ARCUS</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
By using a specific Diagnostic ID for the deprecation messages, we can possibly add more context/feature documentation in the future / Diagnostic ID (linking to site, for example), and also make sure that we can differentiate between warnings that are coming from external code and Arcus-code in our own code base. 