### PR TITLE
chore(telemetry): provide default operation name

### DIFF
--- a/src/Arcus.Messaging.Core/MessageHandling/MessageTelemetryOptions.cs
+++ b/src/Arcus.Messaging.Core/MessageHandling/MessageTelemetryOptions.cs
@@ -7,7 +7,7 @@ namespace Arcus.Messaging.Abstractions.MessageHandling
     /// </summary>
     public class MessageTelemetryOptions
     {
-        private string _operationName = "Service Bus message processing";
+        private string _operationName = "Azure Service Bus message processing";
 
         /// <summary>
         /// Gets or sets the name of the operation that is used when a request telemetry is tracked - default 'Process' is used as operation name.


### PR DESCRIPTION
Provide a default operation name for the telemetry options.

Relates to #616 