### PR TITLE
fix(deps): correct package ranges for including .NET 10-supported dependencies

### DIFF
--- a/src/Arcus.Messaging.Core/Arcus.Messaging.Core.csproj
+++ b/src/Arcus.Messaging.Core/Arcus.Messaging.Core.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[8.*,10.0.0)" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[8.*,11.0.0)" />
         <PackageReference Include="System.Memory.Data" Version="[8.*,10.0.0)" />
     </ItemGroup>
 

--- a/src/Arcus.Messaging.Health/Arcus.Messaging.Health.csproj
+++ b/src/Arcus.Messaging.Health/Arcus.Messaging.Health.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[8.*,10.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[8.*,11.0.0)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
We should broaden our package range to include .NET 10-supported dependencies, otherwise the upgrade to .NET 10 does not fully work.
Relates to #655 