### PR TITLE
Remove upper-version dependency constraints

### DIFF
--- a/src/Arcus.Messaging.Core/Arcus.Messaging.Core.csproj
+++ b/src/Arcus.Messaging.Core/Arcus.Messaging.Core.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[8.*,11.0.0)" />
-        <PackageReference Include="System.Memory.Data" Version="[8.*,10.0.0)" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[8.*,)" />
+        <PackageReference Include="System.Memory.Data" Version="[8.*,)" />
     </ItemGroup>
 
 </Project>

--- a/src/Arcus.Messaging.Health/Arcus.Messaging.Health.csproj
+++ b/src/Arcus.Messaging.Health/Arcus.Messaging.Health.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[8.*,11.0.0)" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="[8.*,)" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Messaging.ServiceBus.Telemetry.Serilog/Arcus.Messaging.ServiceBus.Telemetry.Serilog.csproj
+++ b/src/Arcus.Messaging.ServiceBus.Telemetry.Serilog/Arcus.Messaging.ServiceBus.Telemetry.Serilog.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="[2.*,3.0.0)" />
-    <PackageReference Include="Serilog" Version="[4.*,5.0.0)" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="[2.*,)" />
+    <PackageReference Include="Serilog" Version="[4.*,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Messaging.ServiceBus/Arcus.Messaging.ServiceBus.csproj
+++ b/src/Arcus.Messaging.ServiceBus/Arcus.Messaging.ServiceBus.csproj
@@ -32,8 +32,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="[1.*,2.0.0)" />
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="[7.*,8.0.0)" />
+    <PackageReference Include="Azure.Identity" Version="[1.*,)" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="[7.*,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Arcus.Messaging.Tests.Unit/Arcus.Messaging.Tests.Unit.csproj
+++ b/src/Arcus.Messaging.Tests.Unit/Arcus.Messaging.Tests.Unit.csproj
@@ -15,7 +15,7 @@
     </PackageReference>
     <PackageReference Include="FsCheck" Version="3.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.*" />
-    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="3.1.0" />
     <PackageReference Include="xunit.v3" Version="3.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.*">


### PR DESCRIPTION
Remove the specified max-version dependency constraints.
Updated the Moq package to the latest version in the unit-test project as well, as the specified version contained vulnerabilities.

Closes #702 