### PR TITLE
chore(deps): use correct dependency constraints for .NET 10 target framework

### DIFF
--- a/src/Arcus.Messaging.Core/Arcus.Messaging.Core.csproj
+++ b/src/Arcus.Messaging.Core/Arcus.Messaging.Core.csproj
@@ -33,7 +33,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[8.*,11.0.0)" />
-        <PackageReference Include="System.Memory.Data" Version="[8.*,10.0.0)" />
+        <PackageReference Include="System.Memory.Data" Version="[8.*,11.0.0)" />
     </ItemGroup>
 
 </Project>

--- a/src/Arcus.Messaging.Tests.Unit/Arcus.Messaging.Tests.Unit.csproj
+++ b/src/Arcus.Messaging.Tests.Unit/Arcus.Messaging.Tests.Unit.csproj
@@ -15,7 +15,7 @@
     </PackageReference>
     <PackageReference Include="FsCheck" Version="3.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.*" />
-    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="3.1.0" />
     <PackageReference Include="xunit.v3" Version="3.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.*">


### PR DESCRIPTION
* Use correct 11 upper threshold boundary for the `System.Data.Memory` package as this will include all the .NET 10-related minor versions.
* Updated Moq library to most recent version.
